### PR TITLE
Replace x, y, z getters with Ptr3D abstraction

### DIFF
--- a/src/energy_tracking/energy_tracking.cpp
+++ b/src/energy_tracking/energy_tracking.cpp
@@ -62,9 +62,10 @@ EnergyTracker::EnergyTracker(double box_length, double num_particles)
 
     data_ = AlignedSoA<double>(num_g_vectors_, NUM_ARRAYS_);
 
-    std::copy_n(tmp_x.data(), num_g_vectors_, G_vector_x_get());
-    std::copy_n(tmp_y.data(), num_g_vectors_, G_vector_y_get());
-    std::copy_n(tmp_z.data(), num_g_vectors_, G_vector_z_get());
+    const auto g_dst{G_vector()};
+    std::copy_n(tmp_x.data(), num_g_vectors_, g_dst.x_);
+    std::copy_n(tmp_y.data(), num_g_vectors_, g_dst.y_);
+    std::copy_n(tmp_z.data(), num_g_vectors_, g_dst.z_);
     std::copy_n(tmp_w.data(), num_g_vectors_, G_vector_weights_get());
 }
 
@@ -105,13 +106,7 @@ void EnergyTracker::initialize_real_energy(const Particles& particles) noexcept 
     const double a4{-1.453152027};
     const double a5{1.061405429};
 
-    const double* RESTRICT p_x{particles.pos_x_get()};
-    const double* RESTRICT p_y{particles.pos_y_get()};
-    const double* RESTRICT p_z{particles.pos_z_get()};
-
-    ASSUME_ALIGNED(p_x, SIMD_BYTES);
-    ASSUME_ALIGNED(p_y, SIMD_BYTES);
-    ASSUME_ALIGNED(p_z, SIMD_BYTES);
+    const auto [p_x, p_y, p_z]{particles.pos().align()};
 
     double sum{};
     for (std::size_t i = 0; i < N; ++i) {
@@ -146,24 +141,11 @@ void EnergyTracker::initialize_structure_factors(const Particles& particles) noe
     const std::size_t N{particles.num_particles_get()};
     const std::size_t num_G{num_g_vectors_get()};
 
-    const double* RESTRICT p_x{particles.pos_x_get()};
-    const double* RESTRICT p_y{particles.pos_y_get()};
-    const double* RESTRICT p_z{particles.pos_z_get()};
-
-    const double* RESTRICT g_x{G_vector_x_get()};
-    const double* RESTRICT g_y{G_vector_y_get()};
-    const double* RESTRICT g_z{G_vector_z_get()};
+    const auto [p_x, p_y, p_z]{particles.pos().align()};
+    const auto [g_x, g_y, g_z]{G_vector().align()};
 
     double* RESTRICT sum_real{sum_real_get()};
     double* RESTRICT sum_imag{sum_imag_get()};
-
-    ASSUME_ALIGNED(p_x, SIMD_BYTES);
-    ASSUME_ALIGNED(p_y, SIMD_BYTES);
-    ASSUME_ALIGNED(p_z, SIMD_BYTES);
-
-    ASSUME_ALIGNED(g_x, SIMD_BYTES);
-    ASSUME_ALIGNED(g_y, SIMD_BYTES);
-    ASSUME_ALIGNED(g_z, SIMD_BYTES);
 
     ASSUME_ALIGNED(sum_real, SIMD_BYTES);
     ASSUME_ALIGNED(sum_imag, SIMD_BYTES);
@@ -197,9 +179,7 @@ void EnergyTracker::update_structure_factors(double old_x, double old_y, double 
     const double prefactor{1.0 / (2.0 * std::numbers::pi * L * L * L)};
 
     const double* RESTRICT g_weights{G_vector_weights_get()};
-    const double* RESTRICT g_x{G_vector_x_get()};
-    const double* RESTRICT g_y{G_vector_y_get()};
-    const double* RESTRICT g_z{G_vector_z_get()};
+    const auto [g_x, g_y, g_z]{G_vector().align()};
 
     double* RESTRICT sum_real{sum_real_get()};
     double* RESTRICT sum_imag{sum_imag_get()};
@@ -207,9 +187,6 @@ void EnergyTracker::update_structure_factors(double old_x, double old_y, double 
     double* RESTRICT d_real_temp{d_real_temp_get()};
 
     ASSUME_ALIGNED(g_weights, SIMD_BYTES);
-    ASSUME_ALIGNED(g_x, SIMD_BYTES);
-    ASSUME_ALIGNED(g_y, SIMD_BYTES);
-    ASSUME_ALIGNED(g_z, SIMD_BYTES);
 
     ASSUME_ALIGNED(sum_real, SIMD_BYTES);
     ASSUME_ALIGNED(sum_imag, SIMD_BYTES);
@@ -250,14 +227,9 @@ void EnergyTracker::update_structure_factors(double old_x, double old_y, double 
 }
 
 double EnergyTracker::kinetic_energy(const Particles& particles) const noexcept {
-    const double* RESTRICT grad_x{particles.grad_log_psi_x_get()};
-    const double* RESTRICT grad_y{particles.grad_log_psi_y_get()};
-    const double* RESTRICT grad_z{particles.grad_log_psi_z_get()};
+    const auto [grad_x, grad_y, grad_z]{particles.grad_log_psi().align()};
     const double* RESTRICT lap{particles.lap_log_psi_get()};
 
-    ASSUME_ALIGNED(grad_x, SIMD_BYTES);
-    ASSUME_ALIGNED(grad_y, SIMD_BYTES);
-    ASSUME_ALIGNED(grad_z, SIMD_BYTES);
     ASSUME_ALIGNED(lap, SIMD_BYTES);
 
     // Kinetic
@@ -294,13 +266,7 @@ void EnergyTracker::update_real_energy(std::size_t moved_idx, double old_x, doub
     const double a4{-1.453152027};
     const double a5{1.061405429};
 
-    const double* RESTRICT p_x{particles.pos_x_get()};
-    const double* RESTRICT p_y{particles.pos_y_get()};
-    const double* RESTRICT p_z{particles.pos_z_get()};
-
-    ASSUME_ALIGNED(p_x, SIMD_BYTES);
-    ASSUME_ALIGNED(p_y, SIMD_BYTES);
-    ASSUME_ALIGNED(p_z, SIMD_BYTES);
+    const auto [p_x, p_y, p_z]{particles.pos().align()};
 
     const double new_x{p_x[moved_idx]};
     const double new_y{p_y[moved_idx]};

--- a/src/energy_tracking/energy_tracking.hpp
+++ b/src/energy_tracking/energy_tracking.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../particles/particles.hpp"
+#include "../utilities/ptr3d.hpp"
 #include "../utilities/aligned_soa.hpp"
 
 #include <cmath>
@@ -57,14 +58,14 @@ private:
     [[nodiscard]] double ewald_correction_get() const noexcept { return ewald_correction_; }
     [[nodiscard]] double ewald_background_get() const noexcept { return ewald_background_; }
 
-    [[nodiscard]] double* G_vector_x_get() noexcept { return data_[G_X_]; }
-    [[nodiscard]] double* G_vector_y_get() noexcept { return data_[G_Y_]; }
-    [[nodiscard]] double* G_vector_z_get() noexcept { return data_[G_Z_]; }
-    [[nodiscard]] double* G_vector_weights_get() noexcept { return data_[G_WEIGHTS_]; }
+    [[nodiscard]] Ptr3D<double> G_vector() noexcept {
+        return {data_[G_X_], data_[G_Y_], data_[G_Z_]};
+    }
+    [[nodiscard]] Ptr3D<const double> G_vector() const noexcept {
+        return {data_[G_X_], data_[G_Y_], data_[G_Z_]};
+    }
 
-    [[nodiscard]] const double* G_vector_x_get() const noexcept { return data_[G_X_]; }
-    [[nodiscard]] const double* G_vector_y_get() const noexcept { return data_[G_Y_]; }
-    [[nodiscard]] const double* G_vector_z_get() const noexcept { return data_[G_Z_]; }
+    [[nodiscard]] double* G_vector_weights_get() noexcept { return data_[G_WEIGHTS_]; }
     [[nodiscard]] const double* G_vector_weights_get() const noexcept { return data_[G_WEIGHTS_]; }
 
     [[nodiscard]] double* sum_real_get() noexcept { return data_[S_REAL_]; }

--- a/src/jastrow_pade/jastrow_pade.cpp
+++ b/src/jastrow_pade/jastrow_pade.cpp
@@ -10,13 +10,7 @@ double JastrowPade::value(const Particles& particles) const noexcept {
     const double half_L{0.5 * L};
     const double neg_half_L{-1.0 * half_L};
 
-    const double* RESTRICT pos_x{particles.pos_x_get()};
-    const double* RESTRICT pos_y{particles.pos_y_get()};
-    const double* RESTRICT pos_z{particles.pos_z_get()};
-
-    ASSUME_ALIGNED(pos_x, SIMD_BYTES);
-    ASSUME_ALIGNED(pos_y, SIMD_BYTES);
-    ASSUME_ALIGNED(pos_z, SIMD_BYTES);
+    const auto [pos_x, pos_y, pos_z]{particles.pos().align()};
 
     const double a_local{a_get()};
     const double b_local{b_get()};
@@ -63,13 +57,7 @@ void JastrowPade::add_derivatives(const Particles& particles, double* RESTRICT g
     const double half_L{0.5 * L};
     const double neg_half_L{-1.0 * half_L};
 
-    const double* RESTRICT pos_x{particles.pos_x_get()};
-    const double* RESTRICT pos_y{particles.pos_y_get()};
-    const double* RESTRICT pos_z{particles.pos_z_get()};
-
-    ASSUME_ALIGNED(pos_x, SIMD_BYTES);
-    ASSUME_ALIGNED(pos_y, SIMD_BYTES);
-    ASSUME_ALIGNED(pos_z, SIMD_BYTES);
+    const auto [pos_x, pos_y, pos_z]{particles.pos().align()};
 
     ASSUME_ALIGNED(grad_x, SIMD_BYTES);
     ASSUME_ALIGNED(grad_y, SIMD_BYTES);
@@ -144,13 +132,7 @@ double JastrowPade::delta_value(const Particles& particles, std::size_t moved, d
     const double half_L{0.5 * L};
     const double neg_half_L{-1.0 * half_L};
 
-    const double* RESTRICT pos_x{particles.pos_x_get()};
-    const double* RESTRICT pos_y{particles.pos_y_get()};
-    const double* RESTRICT pos_z{particles.pos_z_get()};
-    
-    ASSUME_ALIGNED(pos_x, SIMD_BYTES);
-    ASSUME_ALIGNED(pos_y, SIMD_BYTES);
-    ASSUME_ALIGNED(pos_z, SIMD_BYTES);
+    const auto [pos_x, pos_y, pos_z]{particles.pos().align()};
 
     const double a_local{a_get()};
     const double b_local{b_get()};
@@ -216,13 +198,7 @@ void JastrowPade::update_derivatives_for_move(const Particles& particles, std::s
     const double half_L{0.5 * L};
     const double neg_half_L{-1.0 * half_L};
 
-    const double* RESTRICT pos_x{particles.pos_x_get()};
-    const double* RESTRICT pos_y{particles.pos_y_get()};
-    const double* RESTRICT pos_z{particles.pos_z_get()};
-
-    ASSUME_ALIGNED(pos_x, SIMD_BYTES);
-    ASSUME_ALIGNED(pos_y, SIMD_BYTES);
-    ASSUME_ALIGNED(pos_z, SIMD_BYTES);
+    const auto [pos_x, pos_y, pos_z]{particles.pos().align()};
 
     ASSUME_ALIGNED(grad_x, SIMD_BYTES);
     ASSUME_ALIGNED(grad_y, SIMD_BYTES);

--- a/src/particles/particles.hpp
+++ b/src/particles/particles.hpp
@@ -2,6 +2,7 @@
 
 #include "../utilities/aligned_soa.hpp"
 #include "../utilities/macros.hpp"
+#include "../utilities/ptr3d.hpp"
 
 #include <algorithm>
 #include <cstdlib>
@@ -37,35 +38,41 @@ public:
     // Length of the padded stride
     [[nodiscard]] std::size_t padding_stride_get() const { return particle_data_.stride(); }
 
-    // Raw Pointers:
-    // X position of particle
-    [[nodiscard]] double* pos_x_get() noexcept { return particle_data_[POS_X_]; }
-    [[nodiscard]] double const* pos_x_get() const noexcept { return particle_data_[POS_X_]; }
-
-    // Y position of particle
-    [[nodiscard]] double* pos_y_get() noexcept { return particle_data_[POS_Y_]; }
-    [[nodiscard]] double const* pos_y_get() const noexcept { return particle_data_[POS_Y_]; }
-
-    // Z position of particle
-    [[nodiscard]] double* pos_z_get() noexcept { return particle_data_[POS_Z_]; }
-    [[nodiscard]] double const* pos_z_get() const noexcept { return particle_data_[POS_Z_]; }
-
-    // X component of gradient( log|PSI| )
-    [[nodiscard]] double* grad_log_psi_x_get() noexcept { return particle_data_[GRAD_X_]; }
-    [[nodiscard]] double const* grad_log_psi_x_get() const noexcept {
-        return particle_data_[GRAD_X_];
+    [[nodiscard]]
+    Ptr3D<const double> pos() const noexcept {
+        return {
+            particle_data_[POS_X_],
+            particle_data_[POS_Y_],
+            particle_data_[POS_Z_]
+        };
     }
 
-    // Y component of gradient( log|PSI| )
-    [[nodiscard]] double* grad_log_psi_y_get() noexcept { return particle_data_[GRAD_Y_]; }
-    [[nodiscard]] double const* grad_log_psi_y_get() const noexcept {
-        return particle_data_[GRAD_Y_];
+    [[nodiscard]]
+    Ptr3D<double> pos() noexcept {
+        return {
+            particle_data_[POS_X_],
+            particle_data_[POS_Y_],
+            particle_data_[POS_Z_]
+        };
     }
 
-    // Z component of gradient( log|PSI| )
-    [[nodiscard]] double* grad_log_psi_z_get() noexcept { return particle_data_[GRAD_Z_]; }
-    [[nodiscard]] double const* grad_log_psi_z_get() const noexcept {
-        return particle_data_[GRAD_Z_];
+    // Gradient( log|PSI| )
+    [[nodiscard]]
+    Ptr3D<const double> grad_log_psi() const noexcept {
+        return {
+            particle_data_[GRAD_X_],
+            particle_data_[GRAD_Y_],
+            particle_data_[GRAD_Z_]
+        };
+    }
+
+    [[nodiscard]]
+    Ptr3D<double> grad_log_psi() noexcept {
+        return {
+            particle_data_[GRAD_X_],
+            particle_data_[GRAD_Y_],
+            particle_data_[GRAD_Z_]
+        };
     }
 
     // Laplacian of Log|PSI|

--- a/src/simulation/simulation.cpp
+++ b/src/simulation/simulation.cpp
@@ -20,13 +20,7 @@ Simulation::Simulation(Config config, std::unique_ptr<OutputWriter> output_write
 
 std::vector<double> Simulation::positions_snapshot() const {
     const std::size_t N{particles_.num_particles_get()};
-    const double* RESTRICT p_x{particles_.pos_x_get()};
-    const double* RESTRICT p_y{particles_.pos_y_get()};
-    const double* RESTRICT p_z{particles_.pos_z_get()};
-
-    ASSUME_ALIGNED(p_x, SIMD_BYTES);
-    ASSUME_ALIGNED(p_y, SIMD_BYTES);
-    ASSUME_ALIGNED(p_z, SIMD_BYTES);
+    auto [p_x, p_y, p_z]{particles_.pos().align()};
 
     std::vector<double> positions{};
     positions.reserve(N * 3U);
@@ -41,17 +35,9 @@ std::vector<double> Simulation::positions_snapshot() const {
 
 /// @brief Intializes Random Positions for each particle, making sure to not exceed box length
 void Simulation::initialize_positions() {
-    // X, Y, Z Position Blocks of Memory
-    double* RESTRICT p_x{particles_.pos_x_get()};
-    double* RESTRICT p_y{particles_.pos_y_get()};
-    double* RESTRICT p_z{particles_.pos_z_get()};
-
-    ASSUME_ALIGNED(p_x, SIMD_BYTES);
-    ASSUME_ALIGNED(p_y, SIMD_BYTES);
-    ASSUME_ALIGNED(p_z, SIMD_BYTES);
-
     const std::size_t N{particles_.num_particles_get()};
     const double length{config_.box_length};
+    auto [p_x, p_y, p_z]{particles_.pos().align()};
 
     constexpr std::size_t MAX_INIT_ATTEMPTS{100};
 
@@ -79,13 +65,7 @@ void Simulation::initialize_positions() {
 /// was valid then either accepts or rejects it
 Simulation::StepResult Simulation::metropolis_step() {
     // Position pointers:
-    double* RESTRICT p_x{particles_.pos_x_get()};
-    double* RESTRICT p_y{particles_.pos_y_get()};
-    double* RESTRICT p_z{particles_.pos_z_get()};
-
-    ASSUME_ALIGNED(p_x, SIMD_BYTES);
-    ASSUME_ALIGNED(p_y, SIMD_BYTES);
-    ASSUME_ALIGNED(p_z, SIMD_BYTES);
+    auto [p_x, p_y, p_z]{particles_.pos().align()};
 
     // Local random vars:
     const std::size_t rand{rand_particle_get()};

--- a/src/slater_plane_wave/slater_plane_wave.cpp
+++ b/src/slater_plane_wave/slater_plane_wave.cpp
@@ -82,15 +82,7 @@ SlaterPlaneWave::SlaterPlaneWave(const Particles& particles, double box_lengthL)
     // Assign orbitals
     // Orbital 0: k=0 -> cos(0 dot r) = cos(0) = 1
     // For each nonzero canonical k: orbital 2m-1 -> cos(k dot r), orbital 2m -> sin(k dot r)
-
-    int* RESTRICT n_x{n_vector_x_get()};
-    int* RESTRICT n_y{n_vector_y_get()};
-    int* RESTRICT n_z{n_vector_z_get()};
-
-    ASSUME_ALIGNED(n_x, SIMD_BYTES);
-    ASSUME_ALIGNED(n_y, SIMD_BYTES);
-    ASSUME_ALIGNED(n_z, SIMD_BYTES);
-
+    auto [n_x, n_y, n_z]{n_vector().align()};
 
     auto& orb_k_idx{orbital_k_index_get()};
     auto& orb_type{orbital_type_get()};
@@ -124,13 +116,7 @@ SlaterPlaneWave::SlaterPlaneWave(const Particles& particles, double box_lengthL)
     num_unique_k_set() = k_idx;
     trig_row_stride_ = AlignedSoA<double>::round_up(k_idx);
 
-    double* RESTRICT k_x{k_vector_x_get()};
-    double* RESTRICT k_y{k_vector_y_get()};
-    double* RESTRICT k_z{k_vector_z_get()};
-
-    ASSUME_ALIGNED(k_x, SIMD_BYTES);
-    ASSUME_ALIGNED(k_y, SIMD_BYTES);
-    ASSUME_ALIGNED(k_z, SIMD_BYTES);
+    auto [k_x, k_y, k_z]{k_vector().align()};
 
     const double inv_L{1.0 / box_length_get()};
 
@@ -172,27 +158,22 @@ void SlaterPlaneWave::update_trig_cache(std::size_t particle, const Particles& p
     const std::size_t num_k{num_unique_k_get()};
     const std::size_t ROW_STRIDE{trig_row_stride_get()};
 
-    const double px{particles.pos_x_get()[particle]};
-    const double py{particles.pos_y_get()[particle]};
-    const double pz{particles.pos_z_get()[particle]};
-
-    const double* RESTRICT kx{k_vector_x_get()};
-    const double* RESTRICT ky{k_vector_y_get()};
-    const double* RESTRICT kz{k_vector_z_get()};
+    auto [p_x, p_y, p_z]{particles.pos().align()};
+    auto [k_x, k_y, k_z]{k_vector().align()};
 
     double* RESTRICT c_row{cos_cache_get() + particle * ROW_STRIDE};
     double* RESTRICT s_row{sin_cache_get() + particle * ROW_STRIDE};
-
-    ASSUME_ALIGNED(kx, SIMD_BYTES);
-    ASSUME_ALIGNED(ky, SIMD_BYTES);
-    ASSUME_ALIGNED(kz, SIMD_BYTES);
 
     ASSUME_ALIGNED(c_row, SIMD_BYTES);
     ASSUME_ALIGNED(s_row, SIMD_BYTES);
 
     #pragma omp simd
     for (std::size_t k = 0; k < num_k; ++k) {
-        const double dot{kx[k] * px + ky[k] * py + kz[k] * pz};
+        const double dot{
+            k_x[k] * p_x[particle] +
+            k_y[k] * p_y[particle] + 
+            k_z[k] * p_z[particle]
+        };
 
         PORTABLE_SINCOS(dot, &s_row[k], &c_row[k]);
     }
@@ -203,13 +184,8 @@ double SlaterPlaneWave::log_abs_det(const Particles& particles) {
     const std::size_t S{matrix_row_stride_get()};
     const std::size_t padded_N{particles.padding_stride_get()};
 
-    const double* RESTRICT pos_x{particles.pos_x_get()};
-    const double* RESTRICT pos_y{particles.pos_y_get()};
-    const double* RESTRICT pos_z{particles.pos_z_get()};
-
-    const double* RESTRICT k_x_comp{k_vector_x_get()};
-    const double* RESTRICT k_y_comp{k_vector_y_get()};
-    const double* RESTRICT k_z_comp{k_vector_z_get()};
+    auto [p_x, p_y, p_z]{particles.pos().align()};
+    auto [k_x, k_y, k_z]{k_vector().align()};
 
     const auto& k_index{orbital_k_index_get()};
     const auto& orb_type{orbital_type_get()};
@@ -227,14 +203,6 @@ double SlaterPlaneWave::log_abs_det(const Particles& particles) {
     double* RESTRICT cos_cache{cos_cache_get()};
     double* RESTRICT sin_cache{sin_cache_get()};
 
-    ASSUME_ALIGNED(pos_x, SIMD_BYTES);
-    ASSUME_ALIGNED(pos_y, SIMD_BYTES);
-    ASSUME_ALIGNED(pos_z, SIMD_BYTES);
-
-    ASSUME_ALIGNED(k_x_comp, SIMD_BYTES);
-    ASSUME_ALIGNED(k_y_comp, SIMD_BYTES);
-    ASSUME_ALIGNED(k_z_comp, SIMD_BYTES);
-
     ASSUME_ALIGNED(det_matrix, SIMD_BYTES);
     ASSUME_ALIGNED(lower_upper_matrix, SIMD_BYTES);
     ASSUME_ALIGNED(inv_det_matrix, SIMD_BYTES);
@@ -251,15 +219,15 @@ double SlaterPlaneWave::log_abs_det(const Particles& particles) {
     // Build determinant matrix D
     const std::size_t ROW_STRIDE{trig_row_stride_get()};
     for (std::size_t particle = 0; particle < N; ++particle) {
-        const double p_x{pos_x[particle]};
-        const double p_y{pos_y[particle]};
-        const double p_z{pos_z[particle]};
-
         const std::size_t offset{particle * ROW_STRIDE};
         
         #pragma omp simd
         for (std::size_t k = 0; k < num_k; ++k) {
-            const double dot{k_x_comp[k] * p_x + k_y_comp[k] * p_y + k_z_comp[k] * p_z};
+            const double dot{
+                k_x[k] * p_x[particle] +
+                k_y[k] * p_y[particle] +
+                k_z[k] * p_z[particle]
+            };
             const std::size_t i{offset + k};
 
             PORTABLE_SINCOS(dot, &sin_cache[i], &cos_cache[i]);
@@ -432,9 +400,7 @@ void SlaterPlaneWave::add_derivatives(double* RESTRICT grad_x, double* RESTRICT 
     const std::size_t N{num_orbitals_get()};
     const std::size_t S{matrix_row_stride_get()};
 
-    const double* RESTRICT k_x{k_vector_x_get()};
-    const double* RESTRICT k_y{k_vector_y_get()};
-    const double* RESTRICT k_z{k_vector_z_get()};
+    auto [k_x, k_y, k_z]{k_vector().align()};
 
     const auto& k_index{orbital_k_index_get()};
     const auto& o_type{orbital_type_get()};
@@ -442,10 +408,6 @@ void SlaterPlaneWave::add_derivatives(double* RESTRICT grad_x, double* RESTRICT 
     const double* RESTRICT inv_det{inv_determinant_get()};
     const double* RESTRICT cos_cache{cos_cache_get()};
     const double* RESTRICT sin_cache{sin_cache_get()};
-
-    ASSUME_ALIGNED(k_x, SIMD_BYTES);
-    ASSUME_ALIGNED(k_y, SIMD_BYTES);
-    ASSUME_ALIGNED(k_z, SIMD_BYTES);
 
     ASSUME_ALIGNED(inv_det, SIMD_BYTES);
     ASSUME_ALIGNED(cos_cache, SIMD_BYTES);

--- a/src/slater_plane_wave/slater_plane_wave.hpp
+++ b/src/slater_plane_wave/slater_plane_wave.hpp
@@ -3,6 +3,7 @@
 #include "../particles/particles.hpp"
 #include "../utilities/aligned_soa.hpp"
 #include "../utilities/macros.hpp"
+#include "../utilities/ptr3d.hpp"
 
 #include <cstddef>
 #include <cstdlib>
@@ -107,36 +108,46 @@ public:
     [[nodiscard]] int const* pivot_get() const noexcept { return int_vectors_[PIVOT_]; }
 
     // X component of n (length = num_unique_k_)
-    [[nodiscard]] int* n_vector_x_get() noexcept { return int_vectors_[N_X_]; }
-    [[nodiscard]] int const* n_vector_x_get() const noexcept { return int_vectors_[N_X_]; }
+    [[nodiscard]]
+    Ptr3D<int> n_vector() noexcept {
+        return{
+            int_vectors_[N_X_],
+            int_vectors_[N_Y_],
+            int_vectors_[N_Z_],
+        };
+    }
 
-    // Y component of n
-    [[nodiscard]] int* n_vector_y_get() noexcept { return int_vectors_[N_Y_]; }
-    [[nodiscard]] int const* n_vector_y_get() const noexcept { return int_vectors_[N_Y_]; }
+    [[nodiscard]]
+    Ptr3D<const int> n_vector() const noexcept {
+        return{
+            int_vectors_[N_X_],
+            int_vectors_[N_Y_],
+            int_vectors_[N_Z_],
+        };
+    }
 
-    // Z component of n
-    [[nodiscard]] int* n_vector_z_get() noexcept { return int_vectors_[N_Z_]; }
-    [[nodiscard]] int const* n_vector_z_get() const noexcept { return int_vectors_[N_Z_]; }
+    [[nodiscard]]
+    Ptr3D<double> k_vector() noexcept {
+        return {
+            double_vectors_[K_X_],
+            double_vectors_[K_Y_],
+            double_vectors_[K_Z_]
+        };
+    }
 
-    // Solution vector
+    Ptr3D<const double> k_vector() const noexcept {
+        return {
+            double_vectors_[K_X_],
+            double_vectors_[K_Y_],
+            double_vectors_[K_Z_]
+        };
+    }
+
     [[nodiscard]] double* solution_get() noexcept { return double_vectors_[SOLUTION_]; }
     [[nodiscard]] double const* solution_get() const noexcept { return double_vectors_[SOLUTION_]; }
 
-    // RHS vector
     [[nodiscard]] double* rhs_get() noexcept { return double_vectors_[RHS_]; }
     [[nodiscard]] double const* rhs_get() const noexcept { return double_vectors_[RHS_]; }
-
-    // X component of k (length = num_unique_k_)
-    [[nodiscard]] double* k_vector_x_get() noexcept { return double_vectors_[K_X_]; }
-    [[nodiscard]] double const* k_vector_x_get() const noexcept { return double_vectors_[K_X_]; }
-
-    // Y component of k
-    [[nodiscard]] double* k_vector_y_get() noexcept { return double_vectors_[K_Y_]; }
-    [[nodiscard]] double const* k_vector_y_get() const noexcept { return double_vectors_[K_Y_]; }
-
-    // Z component of k
-    [[nodiscard]] double* k_vector_z_get() noexcept { return double_vectors_[K_Z_]; }
-    [[nodiscard]] double const* k_vector_z_get() const noexcept { return double_vectors_[K_Z_]; }
 
     [[nodiscard]] double* sin_cache_get() noexcept { return trig_cache_[SIN_CACHE_]; }
     [[nodiscard]] double const* sin_cache_get() const noexcept { return trig_cache_[SIN_CACHE_]; }
@@ -165,8 +176,12 @@ public:
     void accept_move(std::size_t particle, const double* new_row, double ratio) noexcept;
 
     // Accumulates Slater contributions into grad/lap (length = stride/at least N).
-    void add_derivatives(double* RESTRICT grad_x, double* RESTRICT grad_y, double* RESTRICT grad_z,
-                         double* RESTRICT laplacian) const noexcept;
+    void add_derivatives(
+        double* RESTRICT grad_x,
+        double* RESTRICT grad_y,
+        double* RESTRICT grad_z,
+        double* RESTRICT laplacian
+    ) const noexcept;
 
 private:
     // Scratch buffer: new Slater row for moved particle

--- a/src/utilities/ptr3d.hpp
+++ b/src/utilities/ptr3d.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "macros.hpp"
+#include "aligned_soa.hpp"
+
+template <typename T>
+struct Ptr3D {
+    T* RESTRICT x_;
+    T* RESTRICT y_;
+    T* RESTRICT z_;
+
+    [[nodiscard]]
+    Ptr3D align() const noexcept {
+        Ptr3D p{x_, y_, z_};
+
+        ASSUME_ALIGNED(p.x_, SIMD_BYTES);
+        ASSUME_ALIGNED(p.y_, SIMD_BYTES);
+        ASSUME_ALIGNED(p.z_, SIMD_BYTES);
+
+        return p;
+    }
+};

--- a/src/wavefunction/wavefunction.cpp
+++ b/src/wavefunction/wavefunction.cpp
@@ -12,24 +12,13 @@ double WaveFunction::evaluate_log_psi(const Particles& particles) {
 void WaveFunction::evaluate_derivatives(Particles& particles) noexcept {
     const std::size_t padded_stride{particles.padding_stride_get()};
 
-    double* RESTRICT log_grad_x{particles.grad_log_psi_x_get()};
-    double* RESTRICT log_grad_y{particles.grad_log_psi_y_get()};
-    double* RESTRICT log_grad_z{particles.grad_log_psi_z_get()};
+    auto [log_grad_x, log_grad_y, log_grad_z]{particles.grad_log_psi().align()};
     double* RESTRICT log_lap{particles.lap_log_psi_get()};
 
-    double* RESTRICT jastrow_grad_x{jastrow_grad_x_get()};
-    double* RESTRICT jastrow_grad_y{jastrow_grad_y_get()};
-    double* RESTRICT jastrow_grad_z{jastrow_grad_z_get()};
+    auto [jastrow_grad_x, jastrow_grad_y, jastrow_grad_z]{j_grad().align()};
     double* RESTRICT jastrow_lap{jastrow_lap_get()};
 
-    ASSUME_ALIGNED(log_grad_x, SIMD_BYTES);
-    ASSUME_ALIGNED(log_grad_y, SIMD_BYTES);
-    ASSUME_ALIGNED(log_grad_z, SIMD_BYTES);
     ASSUME_ALIGNED(log_lap, SIMD_BYTES);
-
-    ASSUME_ALIGNED(jastrow_grad_x, SIMD_BYTES);
-    ASSUME_ALIGNED(jastrow_grad_y, SIMD_BYTES);
-    ASSUME_ALIGNED(jastrow_grad_z, SIMD_BYTES);
     ASSUME_ALIGNED(jastrow_lap, SIMD_BYTES);
 
     std::fill_n(log_grad_x, padded_stride, 0.0);
@@ -74,24 +63,13 @@ void WaveFunction::evaluate_derivatives(Particles& particles, bool move_accepted
     }
     const std::size_t padded_stride{particles.padding_stride_get()};
 
-    double* RESTRICT log_grad_x{particles.grad_log_psi_x_get()};
-    double* RESTRICT log_grad_y{particles.grad_log_psi_y_get()};
-    double* RESTRICT log_grad_z{particles.grad_log_psi_z_get()};
+    auto [log_grad_x, log_grad_y, log_grad_z]{particles.grad_log_psi().align()};
     double* RESTRICT log_lap{particles.lap_log_psi_get()};
 
-    double* RESTRICT jastrow_grad_x{jastrow_grad_x_get()};
-    double* RESTRICT jastrow_grad_y{jastrow_grad_y_get()};
-    double* RESTRICT jastrow_grad_z{jastrow_grad_z_get()};
+    auto [jastrow_grad_x, jastrow_grad_y, jastrow_grad_z]{j_grad().align()};
     double* RESTRICT jastrow_lap{jastrow_lap_get()};
 
-    ASSUME_ALIGNED(log_grad_x, SIMD_BYTES);
-    ASSUME_ALIGNED(log_grad_y, SIMD_BYTES);
-    ASSUME_ALIGNED(log_grad_z, SIMD_BYTES);
     ASSUME_ALIGNED(log_lap, SIMD_BYTES);
-
-    ASSUME_ALIGNED(jastrow_grad_x, SIMD_BYTES);
-    ASSUME_ALIGNED(jastrow_grad_y, SIMD_BYTES);
-    ASSUME_ALIGNED(jastrow_grad_z, SIMD_BYTES);
     ASSUME_ALIGNED(jastrow_lap, SIMD_BYTES);
 
     jastrow_pade_.update_derivatives_for_move(particles, moved, old_x, old_y, old_z, jastrow_grad_x,

--- a/src/wavefunction/wavefunction.hpp
+++ b/src/wavefunction/wavefunction.hpp
@@ -35,9 +35,24 @@ public:
         return slater_plane_wave_;
     }
 
-    [[nodiscard]] double* jastrow_grad_x_get() noexcept { return derivatives_[GRAD_X_]; }
-    [[nodiscard]] double* jastrow_grad_y_get() noexcept { return derivatives_[GRAD_Y_]; }
-    [[nodiscard]] double* jastrow_grad_z_get() noexcept { return derivatives_[GRAD_Z_]; }
+    [[nodiscard]]
+    Ptr3D<double> j_grad() noexcept {
+        return {
+            derivatives_[GRAD_X_],
+            derivatives_[GRAD_Y_],
+            derivatives_[GRAD_Z_]
+        };
+    }
+    
+    [[nodiscard]]
+    Ptr3D<const double> j_grad() const noexcept {
+        return {
+            derivatives_[GRAD_X_],
+            derivatives_[GRAD_Y_],
+            derivatives_[GRAD_Z_]
+        };
+    }
+
     [[nodiscard]] double* jastrow_lap_get() noexcept { return derivatives_[LAP_]; }
 
     [[nodiscard]] bool jastrow_cache_valid_get() const noexcept { return jastrow_cache_valid_; }

--- a/tests/test_energy_tracking.cpp
+++ b/tests/test_energy_tracking.cpp
@@ -12,32 +12,32 @@ TEST_CASE("EnergyTracker total energy changes by expected kinetic contribution",
     const EnergyTracker tracker{L, static_cast<double>(n)};
 
     Particles reference{n};
-    reference.pos_x_get()[0] = 0.3;
-    reference.pos_y_get()[0] = 1.5;
-    reference.pos_z_get()[0] = 2.4;
-    reference.pos_x_get()[1] = 3.7;
-    reference.pos_y_get()[1] = 0.2;
-    reference.pos_z_get()[1] = 5.1;
-    reference.pos_x_get()[2] = 6.9;
-    reference.pos_y_get()[2] = 7.2;
-    reference.pos_z_get()[2] = 1.1;
+    reference.pos().x_[0] = 0.3;
+    reference.pos().y_[0] = 1.5;
+    reference.pos().z_[0] = 2.4;
+    reference.pos().x_[1] = 3.7;
+    reference.pos().y_[1] = 0.2;
+    reference.pos().z_[1] = 5.1;
+    reference.pos().x_[2] = 6.9;
+    reference.pos().y_[2] = 7.2;
+    reference.pos().z_[2] = 1.1;
 
     Particles with_derivatives{n};
     copy_positions(reference, with_derivatives);
 
-    with_derivatives.grad_log_psi_x_get()[0] = 0.2;
-    with_derivatives.grad_log_psi_y_get()[0] = -0.1;
-    with_derivatives.grad_log_psi_z_get()[0] = 0.3;
+    with_derivatives.grad_log_psi().x_[0] = 0.2;
+    with_derivatives.grad_log_psi().y_[0] = -0.1;
+    with_derivatives.grad_log_psi().z_[0] = 0.3;
     with_derivatives.lap_log_psi_get()[0] = 0.5;
 
-    with_derivatives.grad_log_psi_x_get()[1] = -0.4;
-    with_derivatives.grad_log_psi_y_get()[1] = 0.0;
-    with_derivatives.grad_log_psi_z_get()[1] = 0.1;
+    with_derivatives.grad_log_psi().x_[1] = -0.4;
+    with_derivatives.grad_log_psi().y_[1] = 0.0;
+    with_derivatives.grad_log_psi().z_[1] = 0.1;
     with_derivatives.lap_log_psi_get()[1] = -0.2;
 
-    with_derivatives.grad_log_psi_x_get()[2] = 0.3;
-    with_derivatives.grad_log_psi_y_get()[2] = -0.2;
-    with_derivatives.grad_log_psi_z_get()[2] = -0.5;
+    with_derivatives.grad_log_psi().x_[2] = 0.3;
+    with_derivatives.grad_log_psi().y_[2] = -0.2;
+    with_derivatives.grad_log_psi().z_[2] = -0.5;
     with_derivatives.lap_log_psi_get()[2] = 0.7;
 
     const double energy_without_derivatives{tracker.eval_total_energy(reference)};
@@ -45,9 +45,9 @@ TEST_CASE("EnergyTracker total energy changes by expected kinetic contribution",
 
     double expected_kinetic{};
     for (std::size_t i = 0; i < n; ++i) {
-        const double gx{with_derivatives.grad_log_psi_x_get()[i]};
-        const double gy{with_derivatives.grad_log_psi_y_get()[i]};
-        const double gz{with_derivatives.grad_log_psi_z_get()[i]};
+        const double gx{with_derivatives.grad_log_psi().x_[i]};
+        const double gy{with_derivatives.grad_log_psi().y_[i]};
+        const double gz{with_derivatives.grad_log_psi().z_[i]};
         const double lap{with_derivatives.lap_log_psi_get()[i]};
         expected_kinetic += -0.5 * (lap + gx * gx + gy * gy + gz * gz);
     }
@@ -61,39 +61,39 @@ TEST_CASE("EnergyTracker is invariant under box-periodic particle translations",
     const EnergyTracker tracker{L, static_cast<double>(n)};
 
     Particles particles{n};
-    particles.pos_x_get()[0] = 1.1;
-    particles.pos_y_get()[0] = 2.3;
-    particles.pos_z_get()[0] = 3.7;
-    particles.pos_x_get()[1] = 6.4;
-    particles.pos_y_get()[1] = 5.6;
-    particles.pos_z_get()[1] = 0.4;
-    particles.pos_x_get()[2] = 2.9;
-    particles.pos_y_get()[2] = 1.2;
-    particles.pos_z_get()[2] = 7.0;
+    particles.pos().x_[0] = 1.1;
+    particles.pos().y_[0] = 2.3;
+    particles.pos().z_[0] = 3.7;
+    particles.pos().x_[1] = 6.4;
+    particles.pos().y_[1] = 5.6;
+    particles.pos().z_[1] = 0.4;
+    particles.pos().x_[2] = 2.9;
+    particles.pos().y_[2] = 1.2;
+    particles.pos().z_[2] = 7.0;
 
-    particles.grad_log_psi_x_get()[0] = 0.12;
-    particles.grad_log_psi_y_get()[0] = -0.08;
-    particles.grad_log_psi_z_get()[0] = 0.05;
+    particles.grad_log_psi().x_[0] = 0.12;
+    particles.grad_log_psi().y_[0] = -0.08;
+    particles.grad_log_psi().z_[0] = 0.05;
     particles.lap_log_psi_get()[0] = 0.2;
 
-    particles.grad_log_psi_x_get()[1] = -0.15;
-    particles.grad_log_psi_y_get()[1] = 0.11;
-    particles.grad_log_psi_z_get()[1] = -0.03;
+    particles.grad_log_psi().x_[1] = -0.15;
+    particles.grad_log_psi().y_[1] = 0.11;
+    particles.grad_log_psi().z_[1] = -0.03;
     particles.lap_log_psi_get()[1] = -0.1;
 
-    particles.grad_log_psi_x_get()[2] = 0.07;
-    particles.grad_log_psi_y_get()[2] = 0.09;
-    particles.grad_log_psi_z_get()[2] = -0.04;
+    particles.grad_log_psi().x_[2] = 0.07;
+    particles.grad_log_psi().y_[2] = 0.09;
+    particles.grad_log_psi().z_[2] = -0.04;
     particles.lap_log_psi_get()[2] = 0.05;
 
     Particles translated{n};
     copy_positions(particles, translated);
     copy_derivatives(particles, translated);
 
-    translated.pos_x_get()[0] += L;
-    translated.pos_y_get()[0] -= 2.0 * L;
-    translated.pos_z_get()[1] += 3.0 * L;
-    translated.pos_x_get()[2] -= L;
+    translated.pos().x_[0] += L;
+    translated.pos().y_[0] -= 2.0 * L;
+    translated.pos().z_[1] += 3.0 * L;
+    translated.pos().x_[2] -= L;
 
     const double baseline{tracker.eval_total_energy(particles)};
     const double shifted{tracker.eval_total_energy(translated)};
@@ -106,40 +106,40 @@ TEST_CASE("EnergyTracker handles degenerate positions and permutation symmetry",
     const EnergyTracker tracker{L, static_cast<double>(n)};
 
     Particles particles{n};
-    particles.pos_x_get()[0] = 2.0;
-    particles.pos_y_get()[0] = 2.0;
-    particles.pos_z_get()[0] = 2.0;
-    particles.pos_x_get()[1] = 2.0;
-    particles.pos_y_get()[1] = 2.0;
-    particles.pos_z_get()[1] = 2.0;
+    particles.pos().x_[0] = 2.0;
+    particles.pos().y_[0] = 2.0;
+    particles.pos().z_[0] = 2.0;
+    particles.pos().x_[1] = 2.0;
+    particles.pos().y_[1] = 2.0;
+    particles.pos().z_[1] = 2.0;
 
-    particles.grad_log_psi_x_get()[0] = 0.1;
-    particles.grad_log_psi_y_get()[0] = 0.2;
-    particles.grad_log_psi_z_get()[0] = 0.3;
+    particles.grad_log_psi().x_[0] = 0.1;
+    particles.grad_log_psi().y_[0] = 0.2;
+    particles.grad_log_psi().z_[0] = 0.3;
     particles.lap_log_psi_get()[0] = 0.4;
-    particles.grad_log_psi_x_get()[1] = -0.3;
-    particles.grad_log_psi_y_get()[1] = -0.1;
-    particles.grad_log_psi_z_get()[1] = 0.2;
+    particles.grad_log_psi().x_[1] = -0.3;
+    particles.grad_log_psi().y_[1] = -0.1;
+    particles.grad_log_psi().z_[1] = 0.2;
     particles.lap_log_psi_get()[1] = -0.5;
 
     const double degenerate_energy{tracker.eval_total_energy(particles)};
     REQUIRE(std::isfinite(degenerate_energy));
 
     Particles permuted{n};
-    permuted.pos_x_get()[0] = particles.pos_x_get()[1];
-    permuted.pos_y_get()[0] = particles.pos_y_get()[1];
-    permuted.pos_z_get()[0] = particles.pos_z_get()[1];
-    permuted.pos_x_get()[1] = particles.pos_x_get()[0];
-    permuted.pos_y_get()[1] = particles.pos_y_get()[0];
-    permuted.pos_z_get()[1] = particles.pos_z_get()[0];
+    permuted.pos().x_[0] = particles.pos().x_[1];
+    permuted.pos().y_[0] = particles.pos().y_[1];
+    permuted.pos().z_[0] = particles.pos().z_[1];
+    permuted.pos().x_[1] = particles.pos().x_[0];
+    permuted.pos().y_[1] = particles.pos().y_[0];
+    permuted.pos().z_[1] = particles.pos().z_[0];
 
-    permuted.grad_log_psi_x_get()[0] = particles.grad_log_psi_x_get()[1];
-    permuted.grad_log_psi_y_get()[0] = particles.grad_log_psi_y_get()[1];
-    permuted.grad_log_psi_z_get()[0] = particles.grad_log_psi_z_get()[1];
+    permuted.grad_log_psi().x_[0] = particles.grad_log_psi().x_[1];
+    permuted.grad_log_psi().y_[0] = particles.grad_log_psi().y_[1];
+    permuted.grad_log_psi().z_[0] = particles.grad_log_psi().z_[1];
     permuted.lap_log_psi_get()[0] = particles.lap_log_psi_get()[1];
-    permuted.grad_log_psi_x_get()[1] = particles.grad_log_psi_x_get()[0];
-    permuted.grad_log_psi_y_get()[1] = particles.grad_log_psi_y_get()[0];
-    permuted.grad_log_psi_z_get()[1] = particles.grad_log_psi_z_get()[0];
+    permuted.grad_log_psi().x_[1] = particles.grad_log_psi().x_[0];
+    permuted.grad_log_psi().y_[1] = particles.grad_log_psi().y_[0];
+    permuted.grad_log_psi().z_[1] = particles.grad_log_psi().z_[0];
     permuted.lap_log_psi_get()[1] = particles.lap_log_psi_get()[0];
 
     const double permuted_energy{tracker.eval_total_energy(permuted)};
@@ -153,15 +153,15 @@ TEST_CASE("EnergyTracker incremental reciprocal and real-energy updates match fu
     constexpr std::size_t moved{1U};
 
     Particles initial{n};
-    initial.pos_x_get()[0] = 0.7;
-    initial.pos_y_get()[0] = 1.1;
-    initial.pos_z_get()[0] = 2.3;
-    initial.pos_x_get()[1] = 3.2;
-    initial.pos_y_get()[1] = 2.7;
-    initial.pos_z_get()[1] = 1.4;
-    initial.pos_x_get()[2] = 5.6;
-    initial.pos_y_get()[2] = 0.9;
-    initial.pos_z_get()[2] = 4.8;
+    initial.pos().x_[0] = 0.7;
+    initial.pos().y_[0] = 1.1;
+    initial.pos().z_[0] = 2.3;
+    initial.pos().x_[1] = 3.2;
+    initial.pos().y_[1] = 2.7;
+    initial.pos().z_[1] = 1.4;
+    initial.pos().x_[2] = 5.6;
+    initial.pos().y_[2] = 0.9;
+    initial.pos().z_[2] = 4.8;
 
     EnergyTracker incremental{L, static_cast<double>(n)};
     incremental.initialize_structure_factors(initial);
@@ -171,17 +171,17 @@ TEST_CASE("EnergyTracker incremental reciprocal and real-energy updates match fu
     Particles moved_particles{n};
     copy_positions(initial, moved_particles);
 
-    const double old_x{moved_particles.pos_x_get()[moved]};
-    const double old_y{moved_particles.pos_y_get()[moved]};
-    const double old_z{moved_particles.pos_z_get()[moved]};
+    const double old_x{moved_particles.pos().x_[moved]};
+    const double old_y{moved_particles.pos().y_[moved]};
+    const double old_z{moved_particles.pos().z_[moved]};
 
-    moved_particles.pos_x_get()[moved] = old_x + 0.21;
-    moved_particles.pos_y_get()[moved] = old_y - 0.17;
-    moved_particles.pos_z_get()[moved] = old_z + 0.33;
+    moved_particles.pos().x_[moved] = old_x + 0.21;
+    moved_particles.pos().y_[moved] = old_y - 0.17;
+    moved_particles.pos().z_[moved] = old_z + 0.33;
 
-    incremental.update_structure_factors(old_x, old_y, old_z, moved_particles.pos_x_get()[moved],
-                                         moved_particles.pos_y_get()[moved],
-                                         moved_particles.pos_z_get()[moved]);
+    incremental.update_structure_factors(old_x, old_y, old_z, moved_particles.pos().x_[moved],
+                                         moved_particles.pos().y_[moved],
+                                         moved_particles.pos().z_[moved]);
     incremental.update_real_energy(moved, old_x, old_y, old_z, moved_particles);
 
     EnergyTracker rebuilt{L, static_cast<double>(n)};

--- a/tests/test_jastrow_pade.cpp
+++ b/tests/test_jastrow_pade.cpp
@@ -10,9 +10,9 @@ namespace {
 double valueAtOffset(const JastrowPade& jastrow, const Particles& reference, std::size_t particle,
                      double dx, double dy, double dz) {
     Particles shifted{copy_particle_positions(reference)};
-    shifted.pos_x_get()[particle] += dx;
-    shifted.pos_y_get()[particle] += dy;
-    shifted.pos_z_get()[particle] += dz;
+    shifted.pos().x_[particle] += dx;
+    shifted.pos().y_[particle] += dy;
+    shifted.pos().z_[particle] += dz;
     return jastrow.value(shifted);
 }
 
@@ -22,13 +22,13 @@ TEST_CASE("Jastrow value uses minimum-image pair distances", "[jastrow]") {
     const JastrowPade jastrow{10.0, 0.25, 1.0};
     Particles particles{2U};
 
-    particles.pos_x_get()[0] = 0.1;
-    particles.pos_y_get()[0] = 0.0;
-    particles.pos_z_get()[0] = 0.0;
+    particles.pos().x_[0] = 0.1;
+    particles.pos().y_[0] = 0.0;
+    particles.pos().z_[0] = 0.0;
 
-    particles.pos_x_get()[1] = 9.9;
-    particles.pos_y_get()[1] = 0.0;
-    particles.pos_z_get()[1] = 0.0;
+    particles.pos().x_[1] = 9.9;
+    particles.pos().y_[1] = 0.0;
+    particles.pos().z_[1] = 0.0;
 
     const double r{0.2};
     const double expected{(0.25 * r) / (1.0 + r)};
@@ -39,13 +39,13 @@ TEST_CASE("Jastrow value skips degenerate pairs", "[jastrow]") {
     const JastrowPade jastrow{10.0, 0.25, 1.0};
     Particles particles{2U};
 
-    particles.pos_x_get()[0] = 1.0;
-    particles.pos_y_get()[0] = 2.0;
-    particles.pos_z_get()[0] = 3.0;
+    particles.pos().x_[0] = 1.0;
+    particles.pos().y_[0] = 2.0;
+    particles.pos().z_[0] = 3.0;
 
-    particles.pos_x_get()[1] = 1.0;
-    particles.pos_y_get()[1] = 2.0;
-    particles.pos_z_get()[1] = 3.0;
+    particles.pos().x_[1] = 1.0;
+    particles.pos().y_[1] = 2.0;
+    particles.pos().z_[1] = 3.0;
 
     require_near(jastrow.value(particles), 0.0);
 }
@@ -54,13 +54,13 @@ TEST_CASE("Jastrow derivatives match the analytic two-particle result", "[jastro
     const JastrowPade jastrow{100.0, 0.25, 1.0};
     Particles particles{2U};
 
-    particles.pos_x_get()[0] = 0.0;
-    particles.pos_y_get()[0] = 0.0;
-    particles.pos_z_get()[0] = 0.0;
+    particles.pos().x_[0] = 0.0;
+    particles.pos().y_[0] = 0.0;
+    particles.pos().z_[0] = 0.0;
 
-    particles.pos_x_get()[1] = 1.0;
-    particles.pos_y_get()[1] = 0.0;
-    particles.pos_z_get()[1] = 0.0;
+    particles.pos().x_[1] = 1.0;
+    particles.pos().y_[1] = 0.0;
+    particles.pos().z_[1] = 0.0;
 
     const std::size_t stride{particles.padding_stride_get()};
     std::vector<double> gradX(stride, 0.0);
@@ -95,13 +95,13 @@ TEST_CASE("Jastrow derivatives are unchanged for degenerate pairs", "[jastrow]")
     const JastrowPade jastrow{10.0, 0.25, 1.0};
     Particles particles{2U};
 
-    particles.pos_x_get()[0] = 4.0;
-    particles.pos_y_get()[0] = 5.0;
-    particles.pos_z_get()[0] = 6.0;
+    particles.pos().x_[0] = 4.0;
+    particles.pos().y_[0] = 5.0;
+    particles.pos().z_[0] = 6.0;
 
-    particles.pos_x_get()[1] = 4.0;
-    particles.pos_y_get()[1] = 5.0;
-    particles.pos_z_get()[1] = 6.0;
+    particles.pos().x_[1] = 4.0;
+    particles.pos().y_[1] = 5.0;
+    particles.pos().z_[1] = 6.0;
 
     const std::size_t stride{particles.padding_stride_get()};
     std::vector<double> gradX(stride, 3.0);
@@ -123,17 +123,17 @@ TEST_CASE("Jastrow derivatives match finite-difference gradients and Laplacians"
     const JastrowPade jastrow{20.0, 0.6, 0.9};
     Particles particles{3U};
 
-    particles.pos_x_get()[0] = 1.1;
-    particles.pos_y_get()[0] = 2.2;
-    particles.pos_z_get()[0] = 0.7;
+    particles.pos().x_[0] = 1.1;
+    particles.pos().y_[0] = 2.2;
+    particles.pos().z_[0] = 0.7;
 
-    particles.pos_x_get()[1] = 3.8;
-    particles.pos_y_get()[1] = 1.4;
-    particles.pos_z_get()[1] = 2.5;
+    particles.pos().x_[1] = 3.8;
+    particles.pos().y_[1] = 1.4;
+    particles.pos().z_[1] = 2.5;
 
-    particles.pos_x_get()[2] = 0.2;
-    particles.pos_y_get()[2] = 4.1;
-    particles.pos_z_get()[2] = 3.3;
+    particles.pos().x_[2] = 0.2;
+    particles.pos().y_[2] = 4.1;
+    particles.pos().z_[2] = 3.3;
 
     const std::size_t stride{particles.padding_stride_get()};
     std::vector<double> gradX(stride, 0.0);

--- a/tests/test_particles.cpp
+++ b/tests/test_particles.cpp
@@ -16,16 +16,16 @@ TEST_CASE("Particles allocates aligned padded blocks and zero-initializes them",
     REQUIRE(stride >= numParticles);
     REQUIRE(stride % doublesPerAlignment == 0U);
 
-    const auto baseAddress{reinterpret_cast<std::uintptr_t>(particles.pos_x_get())};
+    const auto baseAddress{reinterpret_cast<std::uintptr_t>(particles.pos().x_)};
     REQUIRE(baseAddress % SIMD_BYTES == 0U);
 
     for (std::size_t i = 0; i < stride; ++i) {
-        REQUIRE(particles.pos_x_get()[i] == 0.0);
-        REQUIRE(particles.pos_y_get()[i] == 0.0);
-        REQUIRE(particles.pos_z_get()[i] == 0.0);
-        REQUIRE(particles.grad_log_psi_x_get()[i] == 0.0);
-        REQUIRE(particles.grad_log_psi_y_get()[i] == 0.0);
-        REQUIRE(particles.grad_log_psi_z_get()[i] == 0.0);
+        REQUIRE(particles.pos().x_[i] == 0.0);
+        REQUIRE(particles.pos().y_[i] == 0.0);
+        REQUIRE(particles.pos().z_[i] == 0.0);
+        REQUIRE(particles.grad_log_psi().x_[i] == 0.0);
+        REQUIRE(particles.grad_log_psi().y_[i] == 0.0);
+        REQUIRE(particles.grad_log_psi().z_[i] == 0.0);
         REQUIRE(particles.lap_log_psi_get()[i] == 0.0);
     }
 }
@@ -34,19 +34,19 @@ TEST_CASE("Particles exposes non-overlapping slices for each component", "[parti
     Particles particles{2U};
 
     const std::ptrdiff_t stride{static_cast<std::ptrdiff_t>(particles.padding_stride_get())};
-    REQUIRE(particles.pos_y_get() - particles.pos_x_get() == stride);
-    REQUIRE(particles.pos_z_get() - particles.pos_y_get() == stride);
-    REQUIRE(particles.grad_log_psi_x_get() - particles.pos_z_get() == stride);
-    REQUIRE(particles.grad_log_psi_y_get() - particles.grad_log_psi_x_get() == stride);
-    REQUIRE(particles.grad_log_psi_z_get() - particles.grad_log_psi_y_get() == stride);
-    REQUIRE(particles.lap_log_psi_get() - particles.grad_log_psi_z_get() == stride);
+    REQUIRE(particles.pos().y_ - particles.pos().x_ == stride);
+    REQUIRE(particles.pos().z_ - particles.pos().y_ == stride);
+    REQUIRE(particles.grad_log_psi().x_ - particles.pos().z_ == stride);
+    REQUIRE(particles.grad_log_psi().y_ - particles.grad_log_psi().x_ == stride);
+    REQUIRE(particles.grad_log_psi().z_ - particles.grad_log_psi().y_ == stride);
+    REQUIRE(particles.lap_log_psi_get() - particles.grad_log_psi().z_ == stride);
 
-    particles.pos_x_get()[0] = 1.0;
-    particles.pos_y_get()[0] = 2.0;
-    particles.pos_z_get()[0] = 3.0;
+    particles.pos().x_[0] = 1.0;
+    particles.pos().y_[0] = 2.0;
+    particles.pos().z_[0] = 3.0;
 
-    REQUIRE(particles.pos_x_get()[0] == 1.0);
-    REQUIRE(particles.pos_y_get()[0] == 2.0);
-    REQUIRE(particles.pos_z_get()[0] == 3.0);
-    REQUIRE(particles.grad_log_psi_x_get()[0] == 0.0);
+    REQUIRE(particles.pos().x_[0] == 1.0);
+    REQUIRE(particles.pos().y_[0] == 2.0);
+    REQUIRE(particles.pos().z_[0] == 3.0);
+    REQUIRE(particles.grad_log_psi().x_[0] == 0.0);
 }

--- a/tests/test_rigorous_physics.cpp
+++ b/tests/test_rigorous_physics.cpp
@@ -33,9 +33,9 @@ void phy_copy_positions(const Particles& source, Particles& dest) {
     const std::size_t n{source.num_particles_get()};
 
     for (std::size_t i = 0; i < n; ++i) {
-        dest.pos_x_get()[i] = source.pos_x_get()[i];
-        dest.pos_y_get()[i] = source.pos_y_get()[i];
-        dest.pos_z_get()[i] = source.pos_z_get()[i];
+        dest.pos().x_[i] = source.pos().x_[i];
+        dest.pos().y_[i] = source.pos().y_[i];
+        dest.pos().z_[i] = source.pos().z_[i];
     }
 }
 
@@ -48,11 +48,11 @@ double exact_real_potential(const Particles& particles, double box_length) {
     for (std::size_t i = 0; i < n; ++i) {
         for (std::size_t j = i + 1; j < n; ++j) {
             const double dx{
-                minimum_image(particles.pos_x_get()[i] - particles.pos_x_get()[j], box_length)};
+                minimum_image(particles.pos().x_[i] - particles.pos().x_[j], box_length)};
             const double dy{
-                minimum_image(particles.pos_y_get()[i] - particles.pos_y_get()[j], box_length)};
+                minimum_image(particles.pos().y_[i] - particles.pos().y_[j], box_length)};
             const double dz{
-                minimum_image(particles.pos_z_get()[i] - particles.pos_z_get()[j], box_length)};
+                minimum_image(particles.pos().z_[i] - particles.pos().z_[j], box_length)};
 
             const double r{std::sqrt(dx * dx + dy * dy + dz * dz)};
             total += std::erfc(alpha * r) / r;
@@ -104,9 +104,9 @@ double exact_reciprocal_potential(const Particles& particles, double box_length)
                 double s_imag{};
 
                 for (std::size_t i = 0; i < n; ++i) {
-                    const double phase{gx * particles.pos_x_get()[i] +
-                                       gy * particles.pos_y_get()[i] +
-                                       gz * particles.pos_z_get()[i]};
+                    const double phase{gx * particles.pos().x_[i] +
+                                       gy * particles.pos().y_[i] +
+                                       gz * particles.pos().z_[i]};
                     s_real += std::cos(phase);
                     s_imag += std::sin(phase);
                 }
@@ -140,14 +140,14 @@ TEST_CASE("Fully polarized Jastrow cusp matches the same-spin analytical form ne
     const JastrowPade jastrow{box_length, 0.25, 1.0};
     Particles particles{2U};
 
-    particles.pos_x_get()[0] = 0.0;
-    particles.pos_y_get()[0] = 0.0;
-    particles.pos_z_get()[0] = 0.0;
+    particles.pos().x_[0] = 0.0;
+    particles.pos().y_[0] = 0.0;
+    particles.pos().z_[0] = 0.0;
 
     for (const double r : {1.0e-5, 2.0e-5, 5.0e-5, 1.0e-4}) {
-        particles.pos_x_get()[1] = r;
-        particles.pos_y_get()[1] = 0.0;
-        particles.pos_z_get()[1] = 0.0;
+        particles.pos().x_[1] = r;
+        particles.pos().y_[1] = 0.0;
+        particles.pos().z_[1] = 0.0;
 
         const double expected_value{0.25 * r / (1.0 + r)};
         const double actual_value{jastrow.value(particles)};
@@ -189,17 +189,17 @@ TEST_CASE("Slater determinant changes sign under particle exchange while log_abs
     constexpr double box_length{9.0};
 
     Particles original{n};
-    original.pos_x_get()[0] = 0.7;
-    original.pos_y_get()[0] = 1.4;
-    original.pos_z_get()[0] = 2.1;
+    original.pos().x_[0] = 0.7;
+    original.pos().y_[0] = 1.4;
+    original.pos().z_[0] = 2.1;
 
-    original.pos_x_get()[1] = 2.8;
-    original.pos_y_get()[1] = 0.9;
-    original.pos_z_get()[1] = 1.6;
+    original.pos().x_[1] = 2.8;
+    original.pos().y_[1] = 0.9;
+    original.pos().z_[1] = 1.6;
 
-    original.pos_x_get()[2] = 4.3;
-    original.pos_y_get()[2] = 3.2;
-    original.pos_z_get()[2] = 0.5;
+    original.pos().x_[2] = 4.3;
+    original.pos().y_[2] = 3.2;
+    original.pos().z_[2] = 0.5;
 
     SlaterPlaneWave slater_original{original, box_length};
     const double log_original{slater_original.log_abs_det(original)};
@@ -209,9 +209,9 @@ TEST_CASE("Slater determinant changes sign under particle exchange while log_abs
 
     Particles swapped{n};
     phy_copy_positions(original, swapped);
-    std::swap(swapped.pos_x_get()[0], swapped.pos_x_get()[1]);
-    std::swap(swapped.pos_y_get()[0], swapped.pos_y_get()[1]);
-    std::swap(swapped.pos_z_get()[0], swapped.pos_z_get()[1]);
+    std::swap(swapped.pos().x_[0], swapped.pos().x_[1]);
+    std::swap(swapped.pos().y_[0], swapped.pos().y_[1]);
+    std::swap(swapped.pos().z_[0], swapped.pos().z_[1]);
 
     SlaterPlaneWave slater_swapped{swapped, box_length};
     const double log_swapped{slater_swapped.log_abs_det(swapped)};
@@ -231,17 +231,17 @@ TEST_CASE("SlaterPlaneWave is periodic under box translations of a single partic
     constexpr double box_length{10.0};
 
     Particles particles{n};
-    particles.pos_x_get()[0] = 1.1;
-    particles.pos_y_get()[0] = 2.2;
-    particles.pos_z_get()[0] = 3.3;
+    particles.pos().x_[0] = 1.1;
+    particles.pos().y_[0] = 2.2;
+    particles.pos().z_[0] = 3.3;
 
-    particles.pos_x_get()[1] = 4.4;
-    particles.pos_y_get()[1] = 5.5;
-    particles.pos_z_get()[1] = 6.6;
+    particles.pos().x_[1] = 4.4;
+    particles.pos().y_[1] = 5.5;
+    particles.pos().z_[1] = 6.6;
 
-    particles.pos_x_get()[2] = 7.7;
-    particles.pos_y_get()[2] = 1.8;
-    particles.pos_z_get()[2] = 2.9;
+    particles.pos().x_[2] = 7.7;
+    particles.pos().y_[2] = 1.8;
+    particles.pos().z_[2] = 2.9;
 
     SlaterPlaneWave baseline{particles, box_length};
     const double baseline_log_det{baseline.log_abs_det(particles)};
@@ -249,9 +249,9 @@ TEST_CASE("SlaterPlaneWave is periodic under box translations of a single partic
 
     Particles shifted{n};
     phy_copy_positions(particles, shifted);
-    shifted.pos_x_get()[1] += box_length;
-    shifted.pos_y_get()[1] -= box_length;
-    shifted.pos_z_get()[1] += 2.0 * box_length;
+    shifted.pos().x_[1] += box_length;
+    shifted.pos().y_[1] -= box_length;
+    shifted.pos().z_[1] += 2.0 * box_length;
 
     SlaterPlaneWave translated{shifted, box_length};
     const double translated_log_det{translated.log_abs_det(shifted)};
@@ -286,9 +286,9 @@ TEST_CASE("Randomized determinant_ratio matches exact determinant ratio over man
         Particles particles{n};
 
         for (std::size_t i = 0; i < n; ++i) {
-            particles.pos_x_get()[i] = position_dist(rng);
-            particles.pos_y_get()[i] = position_dist(rng);
-            particles.pos_z_get()[i] = position_dist(rng);
+            particles.pos().x_[i] = position_dist(rng);
+            particles.pos().y_[i] = position_dist(rng);
+            particles.pos().z_[i] = position_dist(rng);
         }
 
         SlaterPlaneWave slater{particles, box_length};
@@ -302,12 +302,12 @@ TEST_CASE("Randomized determinant_ratio matches exact determinant ratio over man
         REQUIRE(std::abs(det_old) > 1e-12);
 
         const std::size_t moved{sample % n};
-        particles.pos_x_get()[moved] =
-            wrap_coordinate(particles.pos_x_get()[moved] + move_dist(rng), box_length);
-        particles.pos_y_get()[moved] =
-            wrap_coordinate(particles.pos_y_get()[moved] + move_dist(rng), box_length);
-        particles.pos_z_get()[moved] =
-            wrap_coordinate(particles.pos_z_get()[moved] + move_dist(rng), box_length);
+        particles.pos().x_[moved] =
+            wrap_coordinate(particles.pos().x_[moved] + move_dist(rng), box_length);
+        particles.pos().y_[moved] =
+            wrap_coordinate(particles.pos().y_[moved] + move_dist(rng), box_length);
+        particles.pos().z_[moved] =
+            wrap_coordinate(particles.pos().z_[moved] + move_dist(rng), box_length);
 
         slater.update_trig_cache(moved, particles);
         const double* const new_row{slater.build_row(moved)};
@@ -335,17 +335,17 @@ TEST_CASE("SlaterPlaneWave reports a singular determinant for duplicate particle
     constexpr double box_length{10.0};
 
     Particles particles{n};
-    particles.pos_x_get()[0] = 1.25;
-    particles.pos_y_get()[0] = 2.50;
-    particles.pos_z_get()[0] = 3.75;
+    particles.pos().x_[0] = 1.25;
+    particles.pos().y_[0] = 2.50;
+    particles.pos().z_[0] = 3.75;
 
-    particles.pos_x_get()[1] = particles.pos_x_get()[0];
-    particles.pos_y_get()[1] = particles.pos_y_get()[0];
-    particles.pos_z_get()[1] = particles.pos_z_get()[0];
+    particles.pos().x_[1] = particles.pos().x_[0];
+    particles.pos().y_[1] = particles.pos().y_[0];
+    particles.pos().z_[1] = particles.pos().z_[0];
 
-    particles.pos_x_get()[2] = 4.10;
-    particles.pos_y_get()[2] = 0.90;
-    particles.pos_z_get()[2] = 1.70;
+    particles.pos().x_[2] = 4.10;
+    particles.pos().y_[2] = 0.90;
+    particles.pos().z_[2] = 1.70;
 
     SlaterPlaneWave slater{particles, box_length};
     const double log_abs_det{slater.log_abs_det(particles)};
@@ -380,12 +380,12 @@ TEST_CASE("Repeated accepted Slater updates preserve predictive determinant rati
         const double dy{-0.0025 * static_cast<double>((step % 7U) + 1U)};
         const double dz{0.002 * static_cast<double>((step % 3U) + 1U)};
 
-        particles.pos_x_get()[moved] =
-            wrap_coordinate(particles.pos_x_get()[moved] + dx, box_length);
-        particles.pos_y_get()[moved] =
-            wrap_coordinate(particles.pos_y_get()[moved] + dy, box_length);
-        particles.pos_z_get()[moved] =
-            wrap_coordinate(particles.pos_z_get()[moved] + dz, box_length);
+        particles.pos().x_[moved] =
+            wrap_coordinate(particles.pos().x_[moved] + dx, box_length);
+        particles.pos().y_[moved] =
+            wrap_coordinate(particles.pos().y_[moved] + dy, box_length);
+        particles.pos().z_[moved] =
+            wrap_coordinate(particles.pos().z_[moved] + dz, box_length);
 
         maintained.update_trig_cache(moved, particles);
         const double* const accepted_row{maintained.build_row(moved)};
@@ -436,12 +436,12 @@ TEST_CASE("Repeated accepted Slater updates preserve predictive determinant rati
         const double probe_dy{-0.0011 * static_cast<double>((step % 6U) + 1U)};
         const double probe_dz{0.0013 * static_cast<double>((step % 5U) + 1U)};
 
-        probe_particles.pos_x_get()[probe] =
-            wrap_coordinate(probe_particles.pos_x_get()[probe] + probe_dx, box_length);
-        probe_particles.pos_y_get()[probe] =
-            wrap_coordinate(probe_particles.pos_y_get()[probe] + probe_dy, box_length);
-        probe_particles.pos_z_get()[probe] =
-            wrap_coordinate(probe_particles.pos_z_get()[probe] + probe_dz, box_length);
+        probe_particles.pos().x_[probe] =
+            wrap_coordinate(probe_particles.pos().x_[probe] + probe_dx, box_length);
+        probe_particles.pos().y_[probe] =
+            wrap_coordinate(probe_particles.pos().y_[probe] + probe_dy, box_length);
+        probe_particles.pos().z_[probe] =
+            wrap_coordinate(probe_particles.pos().z_[probe] + probe_dz, box_length);
 
         maintained.save_trig_row(probe);
         rebuilt.save_trig_row(probe);
@@ -486,24 +486,24 @@ TEST_CASE("WaveFunction log_psi and derivatives are invariant under integer box 
     std::vector<double> baseline_lap(n);
 
     for (std::size_t i = 0; i < n; ++i) {
-        baseline_grad_x[i] = particles.grad_log_psi_x_get()[i];
-        baseline_grad_y[i] = particles.grad_log_psi_y_get()[i];
-        baseline_grad_z[i] = particles.grad_log_psi_z_get()[i];
+        baseline_grad_x[i] = particles.grad_log_psi().x_[i];
+        baseline_grad_y[i] = particles.grad_log_psi().y_[i];
+        baseline_grad_z[i] = particles.grad_log_psi().z_[i];
         baseline_lap[i] = particles.lap_log_psi_get()[i];
     }
 
     Particles shifted{n};
     phy_copy_positions(particles, shifted);
 
-    shifted.pos_x_get()[3] += box_length;
-    shifted.pos_y_get()[3] -= 2.0 * box_length;
-    shifted.pos_z_get()[3] += 3.0 * box_length;
+    shifted.pos().x_[3] += box_length;
+    shifted.pos().y_[3] -= 2.0 * box_length;
+    shifted.pos().z_[3] += 3.0 * box_length;
 
     // After shifting:
     for (std::size_t i = 0; i < n; ++i) {
-        shifted.pos_x_get()[i] -= box_length * std::floor(shifted.pos_x_get()[i] / box_length);
-        shifted.pos_y_get()[i] -= box_length * std::floor(shifted.pos_y_get()[i] / box_length);
-        shifted.pos_z_get()[i] -= box_length * std::floor(shifted.pos_z_get()[i] / box_length);
+        shifted.pos().x_[i] -= box_length * std::floor(shifted.pos().x_[i] / box_length);
+        shifted.pos().y_[i] -= box_length * std::floor(shifted.pos().y_[i] / box_length);
+        shifted.pos().z_[i] -= box_length * std::floor(shifted.pos().z_[i] / box_length);
     }
 
     WaveFunction translated{shifted, box_length};
@@ -516,9 +516,9 @@ TEST_CASE("WaveFunction log_psi and derivatives are invariant under integer box 
 
     for (std::size_t i = 0; i < n; ++i) {
         CAPTURE(i);
-        REQUIRE(std::abs(baseline_grad_x[i] - shifted.grad_log_psi_x_get()[i]) <= 1e-10);
-        REQUIRE(std::abs(baseline_grad_y[i] - shifted.grad_log_psi_y_get()[i]) <= 1e-10);
-        REQUIRE(std::abs(baseline_grad_z[i] - shifted.grad_log_psi_z_get()[i]) <= 1e-10);
+        REQUIRE(std::abs(baseline_grad_x[i] - shifted.grad_log_psi().x_[i]) <= 1e-10);
+        REQUIRE(std::abs(baseline_grad_y[i] - shifted.grad_log_psi().y_[i]) <= 1e-10);
+        REQUIRE(std::abs(baseline_grad_z[i] - shifted.grad_log_psi().z_[i]) <= 1e-10);
         REQUIRE(std::abs(baseline_lap[i] - shifted.lap_log_psi_get()[i]) <= 1e-7);
     }
 }
@@ -536,9 +536,9 @@ TEST_CASE("EnergyTracker matches an exact Ewald reference on many random small c
         Particles particles{n};
 
         for (std::size_t i = 0; i < n; ++i) {
-            particles.pos_x_get()[i] = dist(rng);
-            particles.pos_y_get()[i] = dist(rng);
-            particles.pos_z_get()[i] = dist(rng);
+            particles.pos().x_[i] = dist(rng);
+            particles.pos().y_[i] = dist(rng);
+            particles.pos().z_[i] = dist(rng);
         }
 
         EnergyTracker tracker{box_length, static_cast<double>(n)};
@@ -562,17 +562,17 @@ TEST_CASE("EnergyTracker remains close to the exact Ewald reference across many 
     constexpr std::size_t steps{48U};
 
     Particles particles{n};
-    particles.pos_x_get()[0] = 0.55;
-    particles.pos_y_get()[0] = 1.20;
-    particles.pos_z_get()[0] = 2.10;
+    particles.pos().x_[0] = 0.55;
+    particles.pos().y_[0] = 1.20;
+    particles.pos().z_[0] = 2.10;
 
-    particles.pos_x_get()[1] = 3.15;
-    particles.pos_y_get()[1] = 2.45;
-    particles.pos_z_get()[1] = 1.05;
+    particles.pos().x_[1] = 3.15;
+    particles.pos().y_[1] = 2.45;
+    particles.pos().z_[1] = 1.05;
 
-    particles.pos_x_get()[2] = 5.60;
-    particles.pos_y_get()[2] = 0.85;
-    particles.pos_z_get()[2] = 4.45;
+    particles.pos().x_[2] = 5.60;
+    particles.pos().y_[2] = 0.85;
+    particles.pos().z_[2] = 4.45;
 
     EnergyTracker tracker{box_length, static_cast<double>(n)};
     tracker.initialize_structure_factors(particles);
@@ -582,21 +582,21 @@ TEST_CASE("EnergyTracker remains close to the exact Ewald reference across many 
     for (std::size_t step = 0; step < steps; ++step) {
         const std::size_t moved{step % n};
 
-        const double old_x{particles.pos_x_get()[moved]};
-        const double old_y{particles.pos_y_get()[moved]};
-        const double old_z{particles.pos_z_get()[moved]};
+        const double old_x{particles.pos().x_[moved]};
+        const double old_y{particles.pos().y_[moved]};
+        const double old_z{particles.pos().z_[moved]};
 
         const double dx{0.017 * static_cast<double>((step % 4U) + 1U)};
         const double dy{-0.012 * static_cast<double>((step % 5U) + 1U)};
         const double dz{0.010 * static_cast<double>((step % 3U) + 1U)};
 
-        particles.pos_x_get()[moved] = wrap_coordinate(old_x + dx, box_length);
-        particles.pos_y_get()[moved] = wrap_coordinate(old_y + dy, box_length);
-        particles.pos_z_get()[moved] = wrap_coordinate(old_z + dz, box_length);
+        particles.pos().x_[moved] = wrap_coordinate(old_x + dx, box_length);
+        particles.pos().y_[moved] = wrap_coordinate(old_y + dy, box_length);
+        particles.pos().z_[moved] = wrap_coordinate(old_z + dz, box_length);
 
-        tracker.update_structure_factors(old_x, old_y, old_z, particles.pos_x_get()[moved],
-                                         particles.pos_y_get()[moved],
-                                         particles.pos_z_get()[moved]);
+        tracker.update_structure_factors(old_x, old_y, old_z, particles.pos().x_[moved],
+                                         particles.pos().y_[moved],
+                                         particles.pos().z_[moved]);
         tracker.update_real_energy(moved, old_x, old_y, old_z, particles);
 
         const double tracker_total{tracker.eval_total_energy(particles)};

--- a/tests/test_slater_plane_wave.cpp
+++ b/tests/test_slater_plane_wave.cpp
@@ -25,9 +25,9 @@ TEST_CASE("log_abs_det handles the N=1 constant orbital case", "[slater]") {
     Particles particles{1U};
     SlaterPlaneWave slater{particles, 10.0};
 
-    particles.pos_x_get()[0] = 3.25;
-    particles.pos_y_get()[0] = 1.50;
-    particles.pos_z_get()[0] = 7.75;
+    particles.pos().x_[0] = 3.25;
+    particles.pos().y_[0] = 1.50;
+    particles.pos().z_[0] = 7.75;
 
     const double logDet{slater.log_abs_det(particles)};
 
@@ -42,17 +42,17 @@ TEST_CASE("log_abs_det computes an inverse satisfying D*invD = I", "[slater]") {
     Particles particles{N};
     SlaterPlaneWave slater{particles, 11.0};
 
-    particles.pos_x_get()[0] = 0.3;
-    particles.pos_y_get()[0] = 0.4;
-    particles.pos_z_get()[0] = 0.5;
+    particles.pos().x_[0] = 0.3;
+    particles.pos().y_[0] = 0.4;
+    particles.pos().z_[0] = 0.5;
 
-    particles.pos_x_get()[1] = 1.7;
-    particles.pos_y_get()[1] = 0.2;
-    particles.pos_z_get()[1] = 2.1;
+    particles.pos().x_[1] = 1.7;
+    particles.pos().y_[1] = 0.2;
+    particles.pos().z_[1] = 2.1;
 
-    particles.pos_x_get()[2] = 2.2;
-    particles.pos_y_get()[2] = 1.8;
-    particles.pos_z_get()[2] = 0.9;
+    particles.pos().x_[2] = 2.2;
+    particles.pos().y_[2] = 1.8;
+    particles.pos().z_[2] = 0.9;
 
     const double logDet{slater.log_abs_det(particles)};
     REQUIRE(std::isfinite(logDet));
@@ -96,17 +96,17 @@ TEST_CASE("determinant_ratio matches exact determinant ratio for a moved row", "
     constexpr double L{12.0};
     Particles particles{N};
 
-    particles.pos_x_get()[0] = 0.8;
-    particles.pos_y_get()[0] = 1.1;
-    particles.pos_z_get()[0] = 0.3;
+    particles.pos().x_[0] = 0.8;
+    particles.pos().y_[0] = 1.1;
+    particles.pos().z_[0] = 0.3;
 
-    particles.pos_x_get()[1] = 2.7;
-    particles.pos_y_get()[1] = 0.4;
-    particles.pos_z_get()[1] = 1.9;
+    particles.pos().x_[1] = 2.7;
+    particles.pos().y_[1] = 0.4;
+    particles.pos().z_[1] = 1.9;
 
-    particles.pos_x_get()[2] = 4.2;
-    particles.pos_y_get()[2] = 3.5;
-    particles.pos_z_get()[2] = 2.6;
+    particles.pos().x_[2] = 4.2;
+    particles.pos().y_[2] = 3.5;
+    particles.pos().z_[2] = 2.6;
 
     SlaterPlaneWave slater{particles, L};
     const double logDetOld{slater.log_abs_det(particles)};
@@ -116,9 +116,9 @@ TEST_CASE("determinant_ratio matches exact determinant ratio for a moved row", "
     REQUIRE(std::abs(detOld) > 1e-12);
 
     constexpr std::size_t moved{1U};
-    particles.pos_x_get()[moved] += 0.35;
-    particles.pos_y_get()[moved] -= 0.20;
-    particles.pos_z_get()[moved] += 0.15;
+    particles.pos().x_[moved] += 0.35;
+    particles.pos().y_[moved] -= 0.20;
+    particles.pos().z_[moved] += 0.15;
 
     slater.update_trig_cache(moved, particles);
     const double* const newRow{slater.build_row(moved)};
@@ -141,26 +141,26 @@ TEST_CASE("accept_move matches a fresh full rebuild after an accepted row update
     constexpr double L{10.5};
     Particles particles{N};
 
-    particles.pos_x_get()[0] = 0.4;
-    particles.pos_y_get()[0] = 1.5;
-    particles.pos_z_get()[0] = 2.7;
+    particles.pos().x_[0] = 0.4;
+    particles.pos().y_[0] = 1.5;
+    particles.pos().z_[0] = 2.7;
 
-    particles.pos_x_get()[1] = 3.1;
-    particles.pos_y_get()[1] = 2.2;
-    particles.pos_z_get()[1] = 0.9;
+    particles.pos().x_[1] = 3.1;
+    particles.pos().y_[1] = 2.2;
+    particles.pos().z_[1] = 0.9;
 
-    particles.pos_x_get()[2] = 4.8;
-    particles.pos_y_get()[2] = 0.7;
-    particles.pos_z_get()[2] = 3.3;
+    particles.pos().x_[2] = 4.8;
+    particles.pos().y_[2] = 0.7;
+    particles.pos().z_[2] = 3.3;
 
     SlaterPlaneWave updated{particles, L};
     const double logDetInitial{updated.log_abs_det(particles)};
     REQUIRE(std::isfinite(logDetInitial));
 
     constexpr std::size_t moved{2U};
-    particles.pos_x_get()[moved] -= 0.28;
-    particles.pos_y_get()[moved] += 0.19;
-    particles.pos_z_get()[moved] += 0.41;
+    particles.pos().x_[moved] -= 0.28;
+    particles.pos().y_[moved] += 0.19;
+    particles.pos().z_[moved] += 0.41;
 
     updated.update_trig_cache(moved, particles);
     const double* const newRow{updated.build_row(moved)};
@@ -197,17 +197,17 @@ TEST_CASE("N=3 determinant matrix uses cos/sin basis correctly", "[slater]") {
     Particles particles{N};
     SlaterPlaneWave slater{particles, L};
 
-    particles.pos_x_get()[0] = 1.0;
-    particles.pos_y_get()[0] = 2.0;
-    particles.pos_z_get()[0] = 3.0;
+    particles.pos().x_[0] = 1.0;
+    particles.pos().y_[0] = 2.0;
+    particles.pos().z_[0] = 3.0;
 
-    particles.pos_x_get()[1] = 4.0;
-    particles.pos_y_get()[1] = 5.0;
-    particles.pos_z_get()[1] = 6.0;
+    particles.pos().x_[1] = 4.0;
+    particles.pos().y_[1] = 5.0;
+    particles.pos().z_[1] = 6.0;
 
-    particles.pos_x_get()[2] = 7.0;
-    particles.pos_y_get()[2] = 8.0;
-    particles.pos_z_get()[2] = 9.0;
+    particles.pos().x_[2] = 7.0;
+    particles.pos().y_[2] = 8.0;
+    particles.pos().z_[2] = 9.0;
 
     slater.log_abs_det(particles);
 
@@ -216,9 +216,9 @@ TEST_CASE("N=3 determinant matrix uses cos/sin basis correctly", "[slater]") {
 
     // Orbital 0 should be cos type with k=0
     REQUIRE(o_type[0] == 0);
-    require_near(slater.k_vector_x_get()[k_index[0]], 0.0);
-    require_near(slater.k_vector_y_get()[k_index[0]], 0.0);
-    require_near(slater.k_vector_z_get()[k_index[0]], 0.0);
+    require_near(slater.k_vector().x_[k_index[0]], 0.0);
+    require_near(slater.k_vector().y_[k_index[0]], 0.0);
+    require_near(slater.k_vector().z_[k_index[0]], 0.0);
 
     // First column should all be 1.0 (cos(0))
     for (std::size_t i = 0; i < N; ++i) {
@@ -232,13 +232,13 @@ TEST_CASE("N=3 determinant matrix uses cos/sin basis correctly", "[slater]") {
 
     // Verify D entries for orbitals 1 and 2
     const std::size_t ki{k_index[1]};
-    const double kx{slater.k_vector_x_get()[ki]};
-    const double ky{slater.k_vector_y_get()[ki]};
-    const double kz{slater.k_vector_z_get()[ki]};
+    const double kx{slater.k_vector().x_[ki]};
+    const double ky{slater.k_vector().y_[ki]};
+    const double kz{slater.k_vector().z_[ki]};
 
     for (std::size_t i = 0; i < N; ++i) {
-        const double k_dot_r{kx * particles.pos_x_get()[i] + ky * particles.pos_y_get()[i] +
-                             kz * particles.pos_z_get()[i]};
+        const double k_dot_r{kx * particles.pos().x_[i] + ky * particles.pos().y_[i] +
+                             kz * particles.pos().z_[i]};
         require_near(slater.determinant_get()[matrix_index(i, 1, slater.matrix_row_stride_get())], std::cos(k_dot_r));
         require_near(slater.determinant_get()[matrix_index(i, 2, slater.matrix_row_stride_get())], std::sin(k_dot_r));
     }
@@ -252,9 +252,9 @@ TEST_CASE("N=7 determinant is nonzero with cos/sin basis", "[slater]") {
 
     // Spread particles around the box
     for (std::size_t i = 0; i < N; ++i) {
-        particles.pos_x_get()[i] = 1.0 + static_cast<double>(i) * 1.1;
-        particles.pos_y_get()[i] = 0.5 + static_cast<double>(i) * 0.7;
-        particles.pos_z_get()[i] = 0.3 + static_cast<double>(i) * 1.3;
+        particles.pos().x_[i] = 1.0 + static_cast<double>(i) * 1.1;
+        particles.pos().y_[i] = 0.5 + static_cast<double>(i) * 0.7;
+        particles.pos().z_[i] = 0.3 + static_cast<double>(i) * 1.3;
     }
 
     const double logDet{slater.log_abs_det(particles)};
@@ -280,17 +280,17 @@ TEST_CASE("Slater derivatives match finite-difference for N=3 cos/sin basis", "[
     Particles particles{N};
     SlaterPlaneWave slater{particles, L};
 
-    particles.pos_x_get()[0] = 1.1;
-    particles.pos_y_get()[0] = 2.3;
-    particles.pos_z_get()[0] = 0.7;
+    particles.pos().x_[0] = 1.1;
+    particles.pos().y_[0] = 2.3;
+    particles.pos().z_[0] = 0.7;
 
-    particles.pos_x_get()[1] = 4.2;
-    particles.pos_y_get()[1] = 1.8;
-    particles.pos_z_get()[1] = 3.5;
+    particles.pos().x_[1] = 4.2;
+    particles.pos().y_[1] = 1.8;
+    particles.pos().z_[1] = 3.5;
 
-    particles.pos_x_get()[2] = 7.6;
-    particles.pos_y_get()[2] = 5.1;
-    particles.pos_z_get()[2] = 8.9;
+    particles.pos().x_[2] = 7.6;
+    particles.pos().y_[2] = 5.1;
+    particles.pos().z_[2] = 8.9;
 
     // Compute analytic derivatives
     slater.log_abs_det(particles);
@@ -308,13 +308,13 @@ TEST_CASE("Slater derivatives match finite-difference for N=3 cos/sin basis", "[
     auto shift_and_eval = [&](std::size_t p, double dx, double dy, double dz) {
         Particles shifted{N};
         for (std::size_t i = 0; i < N; ++i) {
-            shifted.pos_x_get()[i] = particles.pos_x_get()[i];
-            shifted.pos_y_get()[i] = particles.pos_y_get()[i];
-            shifted.pos_z_get()[i] = particles.pos_z_get()[i];
+            shifted.pos().x_[i] = particles.pos().x_[i];
+            shifted.pos().y_[i] = particles.pos().y_[i];
+            shifted.pos().z_[i] = particles.pos().z_[i];
         }
-        shifted.pos_x_get()[p] += dx;
-        shifted.pos_y_get()[p] += dy;
-        shifted.pos_z_get()[p] += dz;
+        shifted.pos().x_[p] += dx;
+        shifted.pos().y_[p] += dy;
+        shifted.pos().z_[p] += dz;
         return slater.log_abs_det(shifted);
     };
 
@@ -338,9 +338,9 @@ TEST_CASE("Shell filling produces (0,0,0) as the first n-vector", "[slater]") {
     Particles p{1U};
     SlaterPlaneWave slater{p, 5.0};
 
-    REQUIRE(slater.n_vector_x_get()[0] == 0);
-    REQUIRE(slater.n_vector_y_get()[0] == 0);
-    REQUIRE(slater.n_vector_z_get()[0] == 0);
+    REQUIRE(slater.n_vector().x_[0] == 0);
+    REQUIRE(slater.n_vector().y_[0] == 0);
+    REQUIRE(slater.n_vector().z_[0] == 0);
 }
 
 TEST_CASE("Shell filling for N=7 uses canonical n-vectors with 4 unique k-vectors", "[slater]") {
@@ -350,9 +350,9 @@ TEST_CASE("Shell filling for N=7 uses canonical n-vectors with 4 unique k-vector
 
     REQUIRE(slater.num_unique_k_get() == 4U);
 
-    const int* n_x{slater.n_vector_x_get()};
-    const int* n_y{slater.n_vector_y_get()};
-    const int* n_z{slater.n_vector_z_get()};
+    const int* n_x{slater.n_vector().x_};
+    const int* n_y{slater.n_vector().y_};
+    const int* n_z{slater.n_vector().z_};
 
     // k-index 0 should be (0,0,0)
     REQUIRE(n_x[0] == 0);
@@ -398,9 +398,9 @@ TEST_CASE("Shell filling n-vectors are sorted by magnitude then lexicographicall
     SlaterPlaneWave slater{p, 10.0};
 
     const std::size_t num_k{slater.num_unique_k_get()};
-    const int* n_x{slater.n_vector_x_get()};
-    const int* n_y{slater.n_vector_y_get()};
-    const int* n_z{slater.n_vector_z_get()};
+    const int* n_x{slater.n_vector().x_};
+    const int* n_y{slater.n_vector().y_};
+    const int* n_z{slater.n_vector().z_};
 
     for (std::size_t i = 0; i + 1 < num_k; ++i) {
         const int mag_sq_a{n_x[i] * n_x[i] + n_y[i] * n_y[i] + n_z[i] * n_z[i]};
@@ -426,8 +426,8 @@ TEST_CASE("Shell filling k-vectors match 2pi/L times n-vectors", "[slater]") {
     const std::size_t num_k{slater.num_unique_k_get()};
 
     for (std::size_t i = 0; i < num_k; ++i) {
-        require_near(slater.k_vector_x_get()[i], TWO_PI_OVER_L * static_cast<double>(slater.n_vector_x_get()[i]));
-        require_near(slater.k_vector_y_get()[i], TWO_PI_OVER_L * static_cast<double>(slater.n_vector_y_get()[i]));
-        require_near(slater.k_vector_z_get()[i], TWO_PI_OVER_L * static_cast<double>(slater.n_vector_z_get()[i]));
+        require_near(slater.k_vector().x_[i], TWO_PI_OVER_L * static_cast<double>(slater.n_vector().x_[i]));
+        require_near(slater.k_vector().y_[i], TWO_PI_OVER_L * static_cast<double>(slater.n_vector().y_[i]));
+        require_near(slater.k_vector().z_[i], TWO_PI_OVER_L * static_cast<double>(slater.n_vector().z_[i]));
     }
 }

--- a/tests/test_utilities.hpp
+++ b/tests/test_utilities.hpp
@@ -25,16 +25,16 @@ inline void require_near(double actual, double expected, double tolerance = 1e-1
 
 inline void copy_positions(const Particles& source, Particles& dest) {
     const std::size_t N{source.num_particles_get()};
-    std::copy_n(source.pos_x_get(), N, dest.pos_x_get());
-    std::copy_n(source.pos_y_get(), N, dest.pos_y_get());
-    std::copy_n(source.pos_z_get(), N, dest.pos_z_get());
+    std::copy_n(source.pos().x_, N, dest.pos().x_);
+    std::copy_n(source.pos().y_, N, dest.pos().y_);
+    std::copy_n(source.pos().z_, N, dest.pos().z_);
 }
 
 inline void copy_derivatives(const Particles& source, Particles& dest) {
     const std::size_t N{source.num_particles_get()};
-    std::copy_n(source.grad_log_psi_x_get(), N, dest.grad_log_psi_x_get());
-    std::copy_n(source.grad_log_psi_y_get(), N, dest.grad_log_psi_y_get());
-    std::copy_n(source.grad_log_psi_z_get(), N, dest.grad_log_psi_z_get());
+    std::copy_n(source.grad_log_psi().x_, N, dest.grad_log_psi().x_);
+    std::copy_n(source.grad_log_psi().y_, N, dest.grad_log_psi().y_);
+    std::copy_n(source.grad_log_psi().z_, N, dest.grad_log_psi().z_);
     std::copy_n(source.lap_log_psi_get(), N, dest.lap_log_psi_get());
 }
 
@@ -98,9 +98,9 @@ inline double minimum_image(double dx, double box_length) {
 
 inline double exact_kinetic_energy(const SlaterPlaneWave& slater) {
     const std::size_t N{slater.num_orbitals_get()};
-    const double* k_x{slater.k_vector_x_get()};
-    const double* k_y{slater.k_vector_y_get()};
-    const double* k_z{slater.k_vector_z_get()};
+    const double* k_x{slater.k_vector().x_};
+    const double* k_y{slater.k_vector().y_};
+    const double* k_z{slater.k_vector().z_};
     const auto& K_INDEX{slater.orbital_k_index_get()};
 
     double T_exact{};
@@ -115,9 +115,9 @@ inline double local_kinetic_energy(const Particles& particles) {
     const std::size_t N{particles.num_particles_get()};
     double T_local{};
     for (std::size_t i = 0; i < N; ++i) {
-        const double GX{particles.grad_log_psi_x_get()[i]};
-        const double GY{particles.grad_log_psi_y_get()[i]};
-        const double GZ{particles.grad_log_psi_z_get()[i]};
+        const double GX{particles.grad_log_psi().x_[i]};
+        const double GY{particles.grad_log_psi().y_[i]};
+        const double GZ{particles.grad_log_psi().z_[i]};
         const double LAP{particles.lap_log_psi_get()[i]};
         T_local += -0.5 * (LAP + GX * GX + GY * GY + GZ * GZ);
     }
@@ -132,9 +132,9 @@ inline void set_stable_closed_shell_positions(Particles& particles) {
     const std::size_t N{particles.num_particles_get()};
 
     for (std::size_t i = 0; i < N; ++i) {
-        particles.pos_x_get()[i] = 1.0 + static_cast<double>(i) * 1.1;
-        particles.pos_y_get()[i] = 0.5 + static_cast<double>(i) * 0.7;
-        particles.pos_z_get()[i] = 0.3 + static_cast<double>(i) * 1.3;
+        particles.pos().x_[i] = 1.0 + static_cast<double>(i) * 1.1;
+        particles.pos().y_[i] = 0.5 + static_cast<double>(i) * 0.7;
+        particles.pos().z_[i] = 0.3 + static_cast<double>(i) * 1.3;
     }
 }
 

--- a/tests/test_validation_free_gas.cpp
+++ b/tests/test_validation_free_gas.cpp
@@ -23,9 +23,9 @@ TEST_CASE("Free gas N=1: kinetic energy is exactly zero", "[validation]") {
     std::uniform_real_distribution<double> uniform{0.0, L};
 
     for (int sample = 0; sample < 5; ++sample) {
-        particles.pos_x_get()[0] = uniform(rng);
-        particles.pos_y_get()[0] = uniform(rng);
-        particles.pos_z_get()[0] = uniform(rng);
+        particles.pos().x_[0] = uniform(rng);
+        particles.pos().y_[0] = uniform(rng);
+        particles.pos().z_[0] = uniform(rng);
 
         wf.evaluate_log_psi(particles);
         wf.evaluate_derivatives(particles);
@@ -56,9 +56,9 @@ TEST_CASE("Free gas N=7: local kinetic energy matches exact value at every sampl
 
     for (int sample = 0; sample < 10; ++sample) {
         for (std::size_t i = 0; i < N; ++i) {
-            particles.pos_x_get()[i] = uniform(rng);
-            particles.pos_y_get()[i] = uniform(rng);
-            particles.pos_z_get()[i] = uniform(rng);
+            particles.pos().x_[i] = uniform(rng);
+            particles.pos().y_[i] = uniform(rng);
+            particles.pos().z_[i] = uniform(rng);
         }
 
         wf.evaluate_log_psi(particles);
@@ -90,9 +90,9 @@ TEST_CASE("Free gas N=19: local kinetic energy matches exact value at every samp
 
     for (int sample = 0; sample < 10; ++sample) {
         for (std::size_t i = 0; i < N; ++i) {
-            particles.pos_x_get()[i] = uniform(rng);
-            particles.pos_y_get()[i] = uniform(rng);
-            particles.pos_z_get()[i] = uniform(rng);
+            particles.pos().x_[i] = uniform(rng);
+            particles.pos().y_[i] = uniform(rng);
+            particles.pos().z_[i] = uniform(rng);
         }
 
         wf.evaluate_log_psi(particles);
@@ -120,9 +120,9 @@ TEST_CASE("Free gas zero-variance: local kinetic energy is configuration-indepen
 
     for (int sample = 0; sample < NUM_SAMPLES; ++sample) {
         for (std::size_t i = 0; i < N; ++i) {
-            particles.pos_x_get()[i] = uniform(rng);
-            particles.pos_y_get()[i] = uniform(rng);
-            particles.pos_z_get()[i] = uniform(rng);
+            particles.pos().x_[i] = uniform(rng);
+            particles.pos().y_[i] = uniform(rng);
+            particles.pos().z_[i] = uniform(rng);
         }
 
         wf.evaluate_log_psi(particles);
@@ -151,9 +151,9 @@ TEST_CASE("Free gas: EnergyTracker kinetic term matches manual computation", "[v
     std::uniform_real_distribution<double> uniform{0.0, L};
 
     for (std::size_t i = 0; i < N; ++i) {
-        particles.pos_x_get()[i] = uniform(rng);
-        particles.pos_y_get()[i] = uniform(rng);
-        particles.pos_z_get()[i] = uniform(rng);
+        particles.pos().x_[i] = uniform(rng);
+        particles.pos().y_[i] = uniform(rng);
+        particles.pos().z_[i] = uniform(rng);
     }
 
     wf.evaluate_log_psi(particles);
@@ -218,9 +218,9 @@ TEST_CASE("Free gas partial shell N=16: zero-variance property still holds", "[v
 
     for (int sample = 0; sample < NUM_SAMPLES; ++sample) {
         for (std::size_t i = 0; i < N; ++i) {
-            particles.pos_x_get()[i] = uniform(rng);
-            particles.pos_y_get()[i] = uniform(rng);
-            particles.pos_z_get()[i] = uniform(rng);
+            particles.pos().x_[i] = uniform(rng);
+            particles.pos().y_[i] = uniform(rng);
+            particles.pos().z_[i] = uniform(rng);
         }
 
         wf.evaluate_log_psi(particles);

--- a/tests/test_wavefunction.cpp
+++ b/tests/test_wavefunction.cpp
@@ -9,19 +9,19 @@
 TEST_CASE("WaveFunction evaluateDerivatives clears buffers and delegates to Jastrow", "[wavefunction]") {
     Particles particles{2U};
 
-    particles.pos_x_get()[0] = 0.0;
-    particles.pos_y_get()[0] = 0.0;
-    particles.pos_z_get()[0] = 0.0;
+    particles.pos().x_[0] = 0.0;
+    particles.pos().y_[0] = 0.0;
+    particles.pos().z_[0] = 0.0;
 
-    particles.pos_x_get()[1] = 1.0;
-    particles.pos_y_get()[1] = 0.0;
-    particles.pos_z_get()[1] = 0.0;
+    particles.pos().x_[1] = 1.0;
+    particles.pos().y_[1] = 0.0;
+    particles.pos().z_[1] = 0.0;
 
     const std::size_t stride{particles.padding_stride_get()};
     for (std::size_t i = 0; i < stride; ++i) {
-        particles.grad_log_psi_x_get()[i] = 999.0;
-        particles.grad_log_psi_y_get()[i] = 999.0;
-        particles.grad_log_psi_z_get()[i] = 999.0;
+        particles.grad_log_psi().x_[i] = 999.0;
+        particles.grad_log_psi().y_[i] = 999.0;
+        particles.grad_log_psi().z_[i] = 999.0;
         particles.lap_log_psi_get()[i] = 999.0;
     }
 
@@ -43,9 +43,9 @@ TEST_CASE("WaveFunction evaluateDerivatives clears buffers and delegates to Jast
     waveFunction.evaluate_derivatives(particles);
 
     for (std::size_t i = 0; i < stride; ++i) {
-        require_near(particles.grad_log_psi_x_get()[i], expectedX[i]);
-        require_near(particles.grad_log_psi_y_get()[i], expectedY[i]);
-        require_near(particles.grad_log_psi_z_get()[i], expectedZ[i]);
+        require_near(particles.grad_log_psi().x_[i], expectedX[i]);
+        require_near(particles.grad_log_psi().y_[i], expectedY[i]);
+        require_near(particles.grad_log_psi().z_[i], expectedZ[i]);
         require_near(particles.lap_log_psi_get()[i], expectedLap[i]);
     }
 }
@@ -56,9 +56,9 @@ TEST_CASE("WaveFunction evaluate_log_psi returns finite for N=1", "[wavefunction
     // Total log_psi = 0
     Particles particles{1U};
 
-    particles.pos_x_get()[0] = 0.4;
-    particles.pos_y_get()[0] = 0.7;
-    particles.pos_z_get()[0] = 0.9;
+    particles.pos().x_[0] = 0.4;
+    particles.pos().y_[0] = 0.7;
+    particles.pos().z_[0] = 0.9;
 
     WaveFunction waveFunction{particles, 10.0, 0.5, 1.0};
 


### PR DESCRIPTION
## Summary

Replaces the per-axis `*_x_get()` / `*_y_get()` / `*_z_get()` pointer getters with a single zero-overhead `Ptr3D<T>` abstraction.

A `Ptr3D<T>` bundles the x/y/z pointers and exposes `.align()` to apply SIMD alignment hints to all three at once. It compiles to the same code as the old three-getter pattern after inlining.

## Changes

- **New** `src/utilities/ptr3d.hpp`: `Ptr3D<T>` struct with `.align()`.
- **Getters** now return `Ptr3D` (const + non-const):
  - `Particles`: `pos()`, `grad_log_psi()`
  - `SlaterPlaneWave`: `n_vector()`, `k_vector()`
  - `EnergyTracker`: `G_vector()`
  - `WaveFunction`: `j_grad()`
- **Call sites** use the `auto [x, y, z]{obj.foo().align()}` idiom, collapsing each 3-pointer + 3-`ASSUME_ALIGNED` block into one line.
- Removed all old per-axis getters.

## Testing

- `vmc` and full test suite build clean (`-Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion`).
- All **1635 assertions / 95 test cases** pass.
