### PR TITLE
Use named Ptr3D temps in omp simd loops for Clang

### DIFF
--- a/src/energy_tracking/energy_tracking.cpp
+++ b/src/energy_tracking/energy_tracking.cpp
@@ -106,7 +106,7 @@ void EnergyTracker::initialize_real_energy(const Particles& particles) noexcept 
     const double a4{-1.453152027};
     const double a5{1.061405429};
 
-    const auto [p_x, p_y, p_z]{particles.pos().align()};
+    const auto pos{particles.pos().align()};
 
     double sum{};
     for (std::size_t i = 0; i < N; ++i) {
@@ -114,9 +114,9 @@ void EnergyTracker::initialize_real_energy(const Particles& particles) noexcept 
 
         #pragma omp simd reduction(+ : local_sum)
         for (std::size_t j = i + 1; j < N; ++j) {
-            double dx{p_x[i] - p_x[j]};
-            double dy{p_y[i] - p_y[j]};
-            double dz{p_z[i] - p_z[j]};
+            double dx{pos.x_[i] - pos.x_[j]};
+            double dy{pos.y_[i] - pos.y_[j]};
+            double dz{pos.z_[i] - pos.z_[j]};
 
             dx += L * (dx <= neg_half_L) + neg_L * (dx > half_L);
             dy += L * (dy <= neg_half_L) + neg_L * (dy > half_L);
@@ -141,8 +141,8 @@ void EnergyTracker::initialize_structure_factors(const Particles& particles) noe
     const std::size_t N{particles.num_particles_get()};
     const std::size_t num_G{num_g_vectors_get()};
 
-    const auto [p_x, p_y, p_z]{particles.pos().align()};
-    const auto [g_x, g_y, g_z]{G_vector().align()};
+    const auto pos{particles.pos().align()};
+    const auto gv{G_vector().align()};
 
     double* RESTRICT sum_real{sum_real_get()};
     double* RESTRICT sum_imag{sum_imag_get()};
@@ -156,7 +156,7 @@ void EnergyTracker::initialize_structure_factors(const Particles& particles) noe
 
         #pragma omp simd reduction(+ : cos_sum, sin_sum)
         for (std::size_t j = 0; j < N; ++j) {
-            const double G_dot_r{g_x[g] * p_x[j] + g_y[g] * p_y[j] + g_z[g] * p_z[j]};
+            const double G_dot_r{gv.x_[g] * pos.x_[j] + gv.y_[g] * pos.y_[j] + gv.z_[g] * pos.z_[j]};
             double cos_temp{};
             double sin_temp{};
 
@@ -179,7 +179,7 @@ void EnergyTracker::update_structure_factors(double old_x, double old_y, double 
     const double prefactor{1.0 / (2.0 * std::numbers::pi * L * L * L)};
 
     const double* RESTRICT g_weights{G_vector_weights_get()};
-    const auto [g_x, g_y, g_z]{G_vector().align()};
+    const auto gv{G_vector().align()};
 
     double* RESTRICT sum_real{sum_real_get()};
     double* RESTRICT sum_imag{sum_imag_get()};
@@ -197,8 +197,8 @@ void EnergyTracker::update_structure_factors(double old_x, double old_y, double 
     
     #pragma omp simd
     for (std::size_t g = 0; g < num_G; ++g) {
-        const double old_dot{g_x[g] * old_x + g_y[g] * old_y + g_z[g] * old_z};
-        const double new_dot{g_x[g] * new_x + g_y[g] * new_y + g_z[g] * new_z};
+        const double old_dot{gv.x_[g] * old_x + gv.y_[g] * old_y + gv.z_[g] * old_z};
+        const double new_dot{gv.x_[g] * new_x + gv.y_[g] * new_y + gv.z_[g] * new_z};
 
         double new_sin{}, new_cos{};
         double old_sin{}, old_cos{};
@@ -227,7 +227,7 @@ void EnergyTracker::update_structure_factors(double old_x, double old_y, double 
 }
 
 double EnergyTracker::kinetic_energy(const Particles& particles) const noexcept {
-    const auto [grad_x, grad_y, grad_z]{particles.grad_log_psi().align()};
+    const auto grad{particles.grad_log_psi().align()};
     const double* RESTRICT lap{particles.lap_log_psi_get()};
 
     ASSUME_ALIGNED(lap, SIMD_BYTES);
@@ -239,7 +239,7 @@ double EnergyTracker::kinetic_energy(const Particles& particles) const noexcept 
     #pragma omp simd reduction(+ : T_sum)
     for (std::size_t i = 0; i < N; ++i) {
         // Computes ||Grad(logPsi)||^2
-        const double grad_sq{grad_x[i] * grad_x[i] + grad_y[i] * grad_y[i] + grad_z[i] * grad_z[i]};
+        const double grad_sq{grad.x_[i] * grad.x_[i] + grad.y_[i] * grad.y_[i] + grad.z_[i] * grad.z_[i]};
 
         // Accumulate Lapl(LogPsi) + ||Grad(LogPsi)||^2
         T_sum += (lap[i] + grad_sq);
@@ -266,11 +266,11 @@ void EnergyTracker::update_real_energy(std::size_t moved_idx, double old_x, doub
     const double a4{-1.453152027};
     const double a5{1.061405429};
 
-    const auto [p_x, p_y, p_z]{particles.pos().align()};
+    const auto pos{particles.pos().align()};
 
-    const double new_x{p_x[moved_idx]};
-    const double new_y{p_y[moved_idx]};
-    const double new_z{p_z[moved_idx]};
+    const double new_x{pos.x_[moved_idx]};
+    const double new_y{pos.y_[moved_idx]};
+    const double new_z{pos.z_[moved_idx]};
 
     double delta{};
 
@@ -280,9 +280,9 @@ void EnergyTracker::update_real_energy(std::size_t moved_idx, double old_x, doub
         const double valid_mask{(j == moved_idx) ? 0.0 : 1.0};
 
         // Old pair
-        double dx_old{old_x - p_x[j]};
-        double dy_old{old_y - p_y[j]};
-        double dz_old{old_z - p_z[j]};
+        double dx_old{old_x - pos.x_[j]};
+        double dy_old{old_y - pos.y_[j]};
+        double dz_old{old_z - pos.z_[j]};
 
         dx_old += L * (dx_old <= neg_half_L) + neg_L * (dx_old > half_L);
         dy_old += L * (dy_old <= neg_half_L) + neg_L * (dy_old > half_L);
@@ -301,9 +301,9 @@ void EnergyTracker::update_real_energy(std::size_t moved_idx, double old_x, doub
         double const erfc_old{tau_old * std::exp(-erfc_arg_old * erfc_arg_old) * inv_r_old};
 
         // New pair
-        double dx_new{new_x - p_x[j]};
-        double dy_new{new_y - p_y[j]};
-        double dz_new{new_z - p_z[j]};
+        double dx_new{new_x - pos.x_[j]};
+        double dy_new{new_y - pos.y_[j]};
+        double dz_new{new_z - pos.z_[j]};
 
         dx_new += L * (dx_new <= neg_half_L) + neg_L * (dx_new > half_L);
         dy_new += L * (dy_new <= neg_half_L) + neg_L * (dy_new > half_L);

--- a/src/jastrow_pade/jastrow_pade.cpp
+++ b/src/jastrow_pade/jastrow_pade.cpp
@@ -10,7 +10,7 @@ double JastrowPade::value(const Particles& particles) const noexcept {
     const double half_L{0.5 * L};
     const double neg_half_L{-1.0 * half_L};
 
-    const auto [pos_x, pos_y, pos_z]{particles.pos().align()};
+    const auto p{particles.pos().align()};
 
     const double a_local{a_get()};
     const double b_local{b_get()};
@@ -23,9 +23,9 @@ double JastrowPade::value(const Particles& particles) const noexcept {
         for (std::size_t j = 0; j < num_particles; ++j) {
             const double mask{i == j ? 0.0 : 1.0};
 
-            double displ_x{pos_x[i] - pos_x[j]};
-            double displ_y{pos_y[i] - pos_y[j]};
-            double displ_z{pos_z[i] - pos_z[j]};
+            double displ_x{p.x_[i] - p.x_[j]};
+            double displ_y{p.y_[i] - p.y_[j]};
+            double displ_z{p.z_[i] - p.z_[j]};
 
             // Boolean masks - reduce to 0 if false, and 1 if true.
             displ_x += L * (displ_x <= neg_half_L) + neg_L * (displ_x > half_L);
@@ -57,7 +57,7 @@ void JastrowPade::add_derivatives(const Particles& particles, double* RESTRICT g
     const double half_L{0.5 * L};
     const double neg_half_L{-1.0 * half_L};
 
-    const auto [pos_x, pos_y, pos_z]{particles.pos().align()};
+    const auto p{particles.pos().align()};
 
     ASSUME_ALIGNED(grad_x, SIMD_BYTES);
     ASSUME_ALIGNED(grad_y, SIMD_BYTES);
@@ -76,9 +76,9 @@ void JastrowPade::add_derivatives(const Particles& particles, double* RESTRICT g
         for (std::size_t j = 0; j < num_particles; ++j) {
             const double valid_idx{i == j ? 0.0 : 1.0};
 
-            double displ_x{pos_x[i] - pos_x[j]};
-            double displ_y{pos_y[i] - pos_y[j]};
-            double displ_z{pos_z[i] - pos_z[j]};
+            double displ_x{p.x_[i] - p.x_[j]};
+            double displ_y{p.y_[i] - p.y_[j]};
+            double displ_z{p.z_[i] - p.z_[j]};
 
             // Boolean masks - reduce to 0 if false, and 1 if true.
             displ_x += L * (displ_x <= neg_half_L) + neg_L * (displ_x > half_L);
@@ -132,14 +132,14 @@ double JastrowPade::delta_value(const Particles& particles, std::size_t moved, d
     const double half_L{0.5 * L};
     const double neg_half_L{-1.0 * half_L};
 
-    const auto [pos_x, pos_y, pos_z]{particles.pos().align()};
+    const auto p{particles.pos().align()};
 
     const double a_local{a_get()};
     const double b_local{b_get()};
 
-    const double new_x{pos_x[moved]};
-    const double new_y{pos_y[moved]};
-    const double new_z{pos_z[moved]};
+    const double new_x{p.x_[moved]};
+    const double new_y{p.y_[moved]};
+    const double new_z{p.z_[moved]};
 
     double delta{};
 
@@ -149,9 +149,9 @@ double JastrowPade::delta_value(const Particles& particles, std::size_t moved, d
         const double valid_mask{(j == moved) ? 0.0 : 1.0};
 
         // Old pair:
-        double displ_old_x{old_x - pos_x[j]};
-        double displ_old_y{old_y - pos_y[j]};
-        double displ_old_z{old_z - pos_z[j]};
+        double displ_old_x{old_x - p.x_[j]};
+        double displ_old_y{old_y - p.y_[j]};
+        double displ_old_z{old_z - p.z_[j]};
 
         displ_old_x += L * (displ_old_x <= neg_half_L) + neg_L * (displ_old_x > half_L);
         displ_old_y += L * (displ_old_y <= neg_half_L) + neg_L * (displ_old_y > half_L);
@@ -162,9 +162,9 @@ double JastrowPade::delta_value(const Particles& particles, std::size_t moved, d
         const double denom_old{1.0 / (1.0 + b_local * dist_old)};
 
         // New pair:
-        double displ_new_x{new_x - pos_x[j]};
-        double displ_new_y{new_y - pos_y[j]};
-        double displ_new_z{new_z - pos_z[j]};
+        double displ_new_x{new_x - p.x_[j]};
+        double displ_new_y{new_y - p.y_[j]};
+        double displ_new_z{new_z - p.z_[j]};
 
         displ_new_x += L * (displ_new_x <= neg_half_L) + neg_L * (displ_new_x > half_L);
         displ_new_y += L * (displ_new_y <= neg_half_L) + neg_L * (displ_new_y > half_L);
@@ -198,7 +198,7 @@ void JastrowPade::update_derivatives_for_move(const Particles& particles, std::s
     const double half_L{0.5 * L};
     const double neg_half_L{-1.0 * half_L};
 
-    const auto [pos_x, pos_y, pos_z]{particles.pos().align()};
+    const auto p{particles.pos().align()};
 
     ASSUME_ALIGNED(grad_x, SIMD_BYTES);
     ASSUME_ALIGNED(grad_y, SIMD_BYTES);
@@ -209,9 +209,9 @@ void JastrowPade::update_derivatives_for_move(const Particles& particles, std::s
     const double b_local{b_get()};
     const double m2ab{-2.0 * a_local * b_local};
 
-    const double new_x{pos_x[moved]};
-    const double new_y{pos_y[moved]};
-    const double new_z{pos_z[moved]};
+    const double new_x{p.x_[moved]};
+    const double new_y{p.y_[moved]};
+    const double new_z{p.z_[moved]};
 
     // Moved variables out of the loop
     double m_grad_x{}, m_grad_y{}, m_grad_z{}, m_lap{};
@@ -222,9 +222,9 @@ void JastrowPade::update_derivatives_for_move(const Particles& particles, std::s
         const bool is_moved{j == moved};
 
         // Old pair:
-        double displ_old_x{old_x - pos_x[j]};
-        double displ_old_y{old_y - pos_y[j]};
-        double displ_old_z{old_z - pos_z[j]};
+        double displ_old_x{old_x - p.x_[j]};
+        double displ_old_y{old_y - p.y_[j]};
+        double displ_old_z{old_z - p.z_[j]};
 
         displ_old_x += L * (displ_old_x <= neg_half_L) + neg_L * (displ_old_x > half_L);
         displ_old_y += L * (displ_old_y <= neg_half_L) + neg_L * (displ_old_y > half_L);
@@ -247,9 +247,9 @@ void JastrowPade::update_derivatives_for_move(const Particles& particles, std::s
                                   (second_deriv_old + 2.0 * first_deriv_old * inv_dist_old)};
 
         // New pair:
-        double displ_new_x{new_x - pos_x[j]};
-        double displ_new_y{new_y - pos_y[j]};
-        double displ_new_z{new_z - pos_z[j]};
+        double displ_new_x{new_x - p.x_[j]};
+        double displ_new_y{new_y - p.y_[j]};
+        double displ_new_z{new_z - p.z_[j]};
 
         displ_new_x += L * (displ_new_x <= neg_half_L) + neg_L * (displ_new_x > half_L);
         displ_new_y += L * (displ_new_y <= neg_half_L) + neg_L * (displ_new_y > half_L);

--- a/src/slater_plane_wave/slater_plane_wave.cpp
+++ b/src/slater_plane_wave/slater_plane_wave.cpp
@@ -82,7 +82,7 @@ SlaterPlaneWave::SlaterPlaneWave(const Particles& particles, double box_lengthL)
     // Assign orbitals
     // Orbital 0: k=0 -> cos(0 dot r) = cos(0) = 1
     // For each nonzero canonical k: orbital 2m-1 -> cos(k dot r), orbital 2m -> sin(k dot r)
-    auto [n_x, n_y, n_z]{n_vector().align()};
+    const auto nv{n_vector().align()};
 
     auto& orb_k_idx{orbital_k_index_get()};
     auto& orb_type{orbital_type_get()};
@@ -94,9 +94,9 @@ SlaterPlaneWave::SlaterPlaneWave(const Particles& particles, double box_lengthL)
         const auto& cand{n_candidates[c]};
         const bool mag_not_zero{cand.n_mag_sq != 0};
 
-        n_x[k_idx] = cand.n_cand_x;
-        n_y[k_idx] = cand.n_cand_y;
-        n_z[k_idx] = cand.n_cand_z;
+        nv.x_[k_idx] = cand.n_cand_x;
+        nv.y_[k_idx] = cand.n_cand_y;
+        nv.z_[k_idx] = cand.n_cand_z;
 
         // Cos orbital (every k-vector gets one)
         orb_k_idx[orb_idx] = k_idx;
@@ -116,16 +116,16 @@ SlaterPlaneWave::SlaterPlaneWave(const Particles& particles, double box_lengthL)
     num_unique_k_set() = k_idx;
     trig_row_stride_ = AlignedSoA<double>::round_up(k_idx);
 
-    auto [k_x, k_y, k_z]{k_vector().align()};
+    const auto kv{k_vector().align()};
 
     const double inv_L{1.0 / box_length_get()};
 
     // Follows the calculation: K = (2pi/L) * n;
     #pragma omp simd
     for (std::size_t i = 0; i < k_idx; ++i) {
-        k_x[i] = 2 * std::numbers::pi * inv_L * static_cast<double>(n_x[i]);
-        k_y[i] = 2 * std::numbers::pi * inv_L * static_cast<double>(n_y[i]);
-        k_z[i] = 2 * std::numbers::pi * inv_L * static_cast<double>(n_z[i]);
+        kv.x_[i] = 2 * std::numbers::pi * inv_L * static_cast<double>(nv.x_[i]);
+        kv.y_[i] = 2 * std::numbers::pi * inv_L * static_cast<double>(nv.y_[i]);
+        kv.z_[i] = 2 * std::numbers::pi * inv_L * static_cast<double>(nv.z_[i]);
     }
 
     trig_cache_ = AlignedSoA<double>(num_particles * trig_row_stride_get(), NUM_TRIG_ARRAYS_);
@@ -158,8 +158,8 @@ void SlaterPlaneWave::update_trig_cache(std::size_t particle, const Particles& p
     const std::size_t num_k{num_unique_k_get()};
     const std::size_t ROW_STRIDE{trig_row_stride_get()};
 
-    auto [p_x, p_y, p_z]{particles.pos().align()};
-    auto [k_x, k_y, k_z]{k_vector().align()};
+    const auto pos{particles.pos().align()};
+    const auto kv{k_vector().align()};
 
     double* RESTRICT c_row{cos_cache_get() + particle * ROW_STRIDE};
     double* RESTRICT s_row{sin_cache_get() + particle * ROW_STRIDE};
@@ -170,9 +170,9 @@ void SlaterPlaneWave::update_trig_cache(std::size_t particle, const Particles& p
     #pragma omp simd
     for (std::size_t k = 0; k < num_k; ++k) {
         const double dot{
-            k_x[k] * p_x[particle] +
-            k_y[k] * p_y[particle] + 
-            k_z[k] * p_z[particle]
+            kv.x_[k] * pos.x_[particle] +
+            kv.y_[k] * pos.y_[particle] + 
+            kv.z_[k] * pos.z_[particle]
         };
 
         PORTABLE_SINCOS(dot, &s_row[k], &c_row[k]);
@@ -184,8 +184,8 @@ double SlaterPlaneWave::log_abs_det(const Particles& particles) {
     const std::size_t S{matrix_row_stride_get()};
     const std::size_t padded_N{particles.padding_stride_get()};
 
-    auto [p_x, p_y, p_z]{particles.pos().align()};
-    auto [k_x, k_y, k_z]{k_vector().align()};
+    const auto pos{particles.pos().align()};
+    const auto kv{k_vector().align()};
 
     const auto& k_index{orbital_k_index_get()};
     const auto& orb_type{orbital_type_get()};
@@ -224,9 +224,9 @@ double SlaterPlaneWave::log_abs_det(const Particles& particles) {
         #pragma omp simd
         for (std::size_t k = 0; k < num_k; ++k) {
             const double dot{
-                k_x[k] * p_x[particle] +
-                k_y[k] * p_y[particle] +
-                k_z[k] * p_z[particle]
+                kv.x_[k] * pos.x_[particle] +
+                kv.y_[k] * pos.y_[particle] +
+                kv.z_[k] * pos.z_[particle]
             };
             const std::size_t i{offset + k};
 
@@ -400,7 +400,7 @@ void SlaterPlaneWave::add_derivatives(double* RESTRICT grad_x, double* RESTRICT 
     const std::size_t N{num_orbitals_get()};
     const std::size_t S{matrix_row_stride_get()};
 
-    auto [k_x, k_y, k_z]{k_vector().align()};
+    const auto kv{k_vector().align()};
 
     const auto& k_index{orbital_k_index_get()};
     const auto& o_type{orbital_type_get()};
@@ -430,9 +430,9 @@ void SlaterPlaneWave::add_derivatives(double* RESTRICT grad_x, double* RESTRICT 
         for (std::size_t orbital = 0; orbital < N; ++orbital) {
             const std::size_t k_idx{k_index[orbital]};
 
-            const double k_x_orbital{k_x[k_idx]};
-            const double k_y_orbital{k_y[k_idx]};
-            const double k_z_orbital{k_z[k_idx]};
+            const double k_x_orbital{kv.x_[k_idx]};
+            const double k_y_orbital{kv.y_[k_idx]};
+            const double k_z_orbital{kv.z_[k_idx]};
 
             const double k_sq{k_x_orbital * k_x_orbital + k_y_orbital * k_y_orbital +
                               k_z_orbital * k_z_orbital};

--- a/src/wavefunction/wavefunction.cpp
+++ b/src/wavefunction/wavefunction.cpp
@@ -12,34 +12,34 @@ double WaveFunction::evaluate_log_psi(const Particles& particles) {
 void WaveFunction::evaluate_derivatives(Particles& particles) noexcept {
     const std::size_t padded_stride{particles.padding_stride_get()};
 
-    auto [log_grad_x, log_grad_y, log_grad_z]{particles.grad_log_psi().align()};
+    const auto log_grad{particles.grad_log_psi().align()};
     double* RESTRICT log_lap{particles.lap_log_psi_get()};
 
-    auto [jastrow_grad_x, jastrow_grad_y, jastrow_grad_z]{j_grad().align()};
+    const auto jg{j_grad().align()};
     double* RESTRICT jastrow_lap{jastrow_lap_get()};
 
     ASSUME_ALIGNED(log_lap, SIMD_BYTES);
     ASSUME_ALIGNED(jastrow_lap, SIMD_BYTES);
 
-    std::fill_n(log_grad_x, padded_stride, 0.0);
-    std::fill_n(log_grad_y, padded_stride, 0.0);
-    std::fill_n(log_grad_z, padded_stride, 0.0);
+    std::fill_n(log_grad.x_, padded_stride, 0.0);
+    std::fill_n(log_grad.y_, padded_stride, 0.0);
+    std::fill_n(log_grad.z_, padded_stride, 0.0);
     std::fill_n(log_lap, padded_stride, 0.0);
 
-    std::fill_n(jastrow_grad_x, padded_stride, 0.0);
-    std::fill_n(jastrow_grad_y, padded_stride, 0.0);
-    std::fill_n(jastrow_grad_z, padded_stride, 0.0);
+    std::fill_n(jg.x_, padded_stride, 0.0);
+    std::fill_n(jg.y_, padded_stride, 0.0);
+    std::fill_n(jg.z_, padded_stride, 0.0);
     std::fill_n(jastrow_lap, padded_stride, 0.0);
 
-    slater_plane_wave_.add_derivatives(log_grad_x, log_grad_y, log_grad_z, log_lap);
-    jastrow_pade_.add_derivatives(particles, jastrow_grad_x, jastrow_grad_y, jastrow_grad_z,
+    slater_plane_wave_.add_derivatives(log_grad.x_, log_grad.y_, log_grad.z_, log_lap);
+    jastrow_pade_.add_derivatives(particles, jg.x_, jg.y_, jg.z_,
                                   jastrow_lap);
 
     #pragma omp simd
     for (std::size_t i = 0; i < padded_stride; ++i) {
-        log_grad_x[i] += jastrow_grad_x[i];
-        log_grad_y[i] += jastrow_grad_y[i];
-        log_grad_z[i] += jastrow_grad_z[i];
+        log_grad.x_[i] += jg.x_[i];
+        log_grad.y_[i] += jg.y_[i];
+        log_grad.z_[i] += jg.z_[i];
         log_lap[i] += jastrow_lap[i];
     }
     jastrow_cache_valid_set(true);
@@ -63,30 +63,30 @@ void WaveFunction::evaluate_derivatives(Particles& particles, bool move_accepted
     }
     const std::size_t padded_stride{particles.padding_stride_get()};
 
-    auto [log_grad_x, log_grad_y, log_grad_z]{particles.grad_log_psi().align()};
+    const auto log_grad{particles.grad_log_psi().align()};
     double* RESTRICT log_lap{particles.lap_log_psi_get()};
 
-    auto [jastrow_grad_x, jastrow_grad_y, jastrow_grad_z]{j_grad().align()};
+    const auto jg{j_grad().align()};
     double* RESTRICT jastrow_lap{jastrow_lap_get()};
 
     ASSUME_ALIGNED(log_lap, SIMD_BYTES);
     ASSUME_ALIGNED(jastrow_lap, SIMD_BYTES);
 
-    jastrow_pade_.update_derivatives_for_move(particles, moved, old_x, old_y, old_z, jastrow_grad_x,
-                                              jastrow_grad_y, jastrow_grad_z, jastrow_lap);
+    jastrow_pade_.update_derivatives_for_move(particles, moved, old_x, old_y, old_z, jg.x_,
+                                              jg.y_, jg.z_, jastrow_lap);
 
-    std::fill_n(log_grad_x, padded_stride, 0.0);
-    std::fill_n(log_grad_y, padded_stride, 0.0);
-    std::fill_n(log_grad_z, padded_stride, 0.0);
+    std::fill_n(log_grad.x_, padded_stride, 0.0);
+    std::fill_n(log_grad.y_, padded_stride, 0.0);
+    std::fill_n(log_grad.z_, padded_stride, 0.0);
     std::fill_n(log_lap, padded_stride, 0.0);
 
-    slater_plane_wave_.add_derivatives(log_grad_x, log_grad_y, log_grad_z, log_lap);
+    slater_plane_wave_.add_derivatives(log_grad.x_, log_grad.y_, log_grad.z_, log_lap);
 
     #pragma omp simd
     for (std::size_t i = 0; i < padded_stride; ++i) {
-        log_grad_x[i] += jastrow_grad_x[i];
-        log_grad_y[i] += jastrow_grad_y[i];
-        log_grad_z[i] += jastrow_grad_z[i];
+        log_grad.x_[i] += jg.x_[i];
+        log_grad.y_[i] += jg.y_[i];
+        log_grad.z_[i] += jg.z_[i];
         log_lap[i] += jastrow_lap[i];
     }
 }


### PR DESCRIPTION
## Summary

Replaces structured bindings (`auto [x, y, z] = …`) that feed `#pragma omp simd` loops with named `Ptr3D` temporaries (`const auto p = …align();` + `p.x_[i]`).

Clang rejects referencing a structured binding inside an OpenMP region (*"capturing a structured binding is not yet supported in OpenMP"*), so the previous idiom broke the Clang `-fopenmp-simd` build path. GCC accepts it, which is why our `ubuntu-latest` CI stayed green; this makes the code portable to Clang/macOS with no behavior or performance change.

## Changes

- `jastrow_pade.cpp`: all 4 functions
- `energy_tracking.cpp`: `initialize_real_energy`, `initialize_structure_factors`, `update_structure_factors`, `kinetic_energy`, `update_real_energy`
- `slater_plane_wave.cpp`: constructor, `update_trig_cache`, `log_abs_det`, `add_derivatives`
- `wavefunction.cpp`: both `evaluate_derivatives` overloads

Temp names (`pos`, `gv`, `kv`, `nv`, `grad`, `log_grad`, `jg`) chosen to avoid clashing with loop indices and existing locals. Structured bindings in `simulation.cpp` are left as-is; none sit inside an `omp simd` loop.

## Testing

- `vmc` and full test suite build clean under GCC.
- All **1635 assertions / 95 test cases** pass.

> Note: only verifiable under GCC locally; the fix removes the exact construct Clang rejected.