### PR TITLE
Implement real_t and complex_t for portable floating point arithemtic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ project(Variational-Monte-Carlo LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# --- Floating point precision ---
+option(FP_64 "Use double precision (real_t = double) instead of single precision (real_t = float)" ON)
+
 # --- Dependencies ---
 find_package(OpenMP QUIET COMPONENTS CXX)
 
@@ -70,6 +73,10 @@ add_library(vmc_lib STATIC
 )
 
 target_include_directories(vmc_lib PUBLIC src)
+
+if(FP_64)
+    target_compile_definitions(vmc_lib PUBLIC FP_64)
+endif()
 
 if(OpenMP_CXX_FOUND)
     target_link_libraries(vmc_lib PUBLIC OpenMP::OpenMP_CXX)

--- a/src/blocking_analysis/blocking_analysis.cpp
+++ b/src/blocking_analysis/blocking_analysis.cpp
@@ -12,30 +12,30 @@ BlockingAnalysis::BlockingAnalysis(std::size_t block_size)
 , block_sum_{}
 { }
 
-std::pair<double, double> BlockingAnalysis::mean_and_standard_error() const {
+std::pair<real_t, real_t> BlockingAnalysis::mean_and_standard_error() const {
   if (num_blocks_ < 2) {
     throw std::runtime_error("Not enough blocks");
   }
-  const double variance{running_m2_ / static_cast<double>(num_blocks_ - 1)};
-  const double standard_error{std::sqrt(variance / static_cast<double>(num_blocks_))};
+  const real_t variance{running_m2_ / static_cast<real_t>(num_blocks_ - 1)};
+  const real_t standard_error{std::sqrt(variance / static_cast<real_t>(num_blocks_))};
 
   return {running_mean_, standard_error};
 }
 
-void BlockingAnalysis::add(double local_energy) {
+void BlockingAnalysis::add(real_t local_energy) {
   block_sum_ += local_energy;
   ++in_block_;
 
   if (in_block_ == block_size_) {
-    const double block_mean{block_sum_ / static_cast<double>(block_size_)};
+    const real_t block_mean{block_sum_ / static_cast<real_t>(block_size_)};
 
     ++num_blocks_;
 
-    const double delta{block_mean - running_mean_};
-    running_mean_ += delta / static_cast<double>(num_blocks_);
+    const real_t delta{block_mean - running_mean_};
+    running_mean_ += delta / static_cast<real_t>(num_blocks_);
     running_m2_ += delta * (block_mean - running_mean_);
 
-    block_sum_ = 0.0;
+    block_sum_ = 0.0_r;
     in_block_ = 0U;
   }
 }

--- a/src/blocking_analysis/blocking_analysis.hpp
+++ b/src/blocking_analysis/blocking_analysis.hpp
@@ -1,22 +1,24 @@
 #pragma once
 
+#include "../utilities/macros.hpp"
+
 #include <cstddef>
 #include <utility>
 
 class BlockingAnalysis {
 private:
   std::size_t num_blocks_;
-  double running_mean_;
-  double running_m2_;
+  real_t running_mean_;
+  real_t running_m2_;
 
   std::size_t block_size_;
   std::size_t in_block_;
-  double block_sum_;
+  real_t block_sum_;
 
 public:
   explicit BlockingAnalysis(std::size_t block_size);
 
-  [[nodiscard]] std::pair<double, double> mean_and_standard_error() const;
-  void add(double local_energy);
+  [[nodiscard]] std::pair<real_t, real_t> mean_and_standard_error() const;
+  void add(real_t local_energy);
   [[nodiscard]] bool ready() const noexcept;
 };

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "../utilities/macros.hpp"
+
 #include <cctype>
 #include <cmath>
 #include <cstddef>
@@ -18,16 +20,16 @@ public:
   std::size_t num_particles{7U};
   std::size_t warmup_sweeps{100U};
   std::size_t measure_sweeps{100U};
-  double box_length{10.0};
+  real_t box_length{10.0_r};
   std::size_t block_size{100U};
   uint64_t master_seed{42U};
   bool is_master_thread{};
-  double jastrow_a{0.25};
-  double jastrow_b{1.0};
+  real_t jastrow_a{0.25_r};
+  real_t jastrow_b{1.0_r};
 
   std::size_t warmup_steps;
   std::size_t measure_steps;
-  double step_size;
+  real_t step_size;
 
   Config() { compute_derived(); }
 
@@ -68,7 +70,7 @@ private:
     if (block_size < 1U) {
       throw std::invalid_argument("[Config] Block_Size must be >= 1");
     }
-    if (box_length <= 0.0 || !std::isfinite(box_length)) {
+    if (box_length <= 0.0_r || !std::isfinite(box_length)) {
       throw std::invalid_argument("[Config] Box_Length must be finite and > 0");
     }
     if (measure_sweeps < 1U) {
@@ -76,7 +78,7 @@ private:
     }
     warmup_steps = num_particles * warmup_sweeps;
     measure_steps = num_particles * measure_sweeps;
-    step_size = box_length / 10.0;
+    step_size = box_length / 10.0_r;
   }
 
   using Map = std::unordered_map<std::string, std::string>;
@@ -113,9 +115,9 @@ private:
     return s.substr(start, end - start + 1);
   }
 
-  static void read(Map& map, std::string const& key, double& out) {
+  static void read(Map& map, std::string const& key, real_t& out) {
     if (auto it{map.find(key)}; it != map.end()) {
-      out = std::stod(it->second);
+      out = static_cast<real_t>(std::stod(it->second));
       map.erase(it);
     }
   }

--- a/src/energy_tracking/energy_tracking.cpp
+++ b/src/energy_tracking/energy_tracking.cpp
@@ -2,24 +2,23 @@
 
 #include <numbers>
 
-EnergyTracker::EnergyTracker(double box_length, double num_particles)
+EnergyTracker::EnergyTracker(real_t box_length, real_t num_particles)
 : box_length_{box_length}
-, ewald_alpha_{6.0 / box_length}
-, ewald_correction_{-6.0 * num_particles / (std::sqrt(std::numbers::pi) * box_length)}
-, ewald_background_{-std::numbers::pi * num_particles * num_particles / (72.0 * box_length)}
+, ewald_alpha_{6.0_r / box_length}
+, ewald_correction_{-6.0_r * num_particles / (std::sqrt(std::numbers::pi_v<real_t>) * box_length)}
+, ewald_background_{-std::numbers::pi_v<real_t> * num_particles * num_particles / (72.0_r * box_length)}
 , V_recip_{}
 , V_real_{}
 , num_g_vectors_{}
-, data_{}
-{
-  const double two_pi_over_L{2.0 * std::numbers::pi / box_length};
-  const double four_alpha_sq{4.0 * ewald_alpha_ * ewald_alpha_};
-  const double cutoff_factor{-std::log(EWALD_RECIPROCAL_TOLERANCE)};
+, data_{} {
+  const real_t two_pi_over_L{2.0_r * std::numbers::pi_v<real_t> / box_length};
+  const real_t four_alpha_sq{4.0_r * ewald_alpha_ * ewald_alpha_};
+  const real_t cutoff_factor{-std::log(EWALD_RECIPROCAL_TOLERANCE)};
 
-  const double g_max_mag_sq{four_alpha_sq * cutoff_factor};
+  const real_t g_max_mag_sq{four_alpha_sq * cutoff_factor};
   const int m_max{static_cast<int>(std::ceil(std::sqrt(g_max_mag_sq) / two_pi_over_L)) + 1};
 
-  std::vector<double> tmp_x, tmp_y, tmp_z, tmp_w;
+  std::vector<real_t> tmp_x, tmp_y, tmp_z, tmp_w;
 
   auto& g_x{tmp_x};
   auto& g_y{tmp_y};
@@ -39,10 +38,10 @@ EnergyTracker::EnergyTracker(double box_length, double num_particles)
         if (m_x == 0 && m_y == 0 && m_z <= 0)
           continue;
 
-        const double g_cand_x{two_pi_over_L * static_cast<double>(m_x)};
-        const double g_cand_y{two_pi_over_L * static_cast<double>(m_y)};
-        const double g_cand_z{two_pi_over_L * static_cast<double>(m_z)};
-        const double g_cand_mag_sq{
+        const real_t g_cand_x{two_pi_over_L * static_cast<real_t>(m_x)};
+        const real_t g_cand_y{two_pi_over_L * static_cast<real_t>(m_y)};
+        const real_t g_cand_z{two_pi_over_L * static_cast<real_t>(m_z)};
+        const real_t g_cand_mag_sq{
           g_cand_x * g_cand_x +
           g_cand_y * g_cand_y +
           g_cand_z * g_cand_z
@@ -55,7 +54,7 @@ EnergyTracker::EnergyTracker(double box_length, double num_particles)
         g_y.emplace_back(g_cand_y);
         g_z.emplace_back(g_cand_z);
         weights.emplace_back(
-          8.0 * std::numbers::pi * std::numbers::pi / g_cand_mag_sq *
+          8.0_r * std::numbers::pi_v<real_t> * std::numbers::pi_v<real_t> / g_cand_mag_sq *
           std::exp(-g_cand_mag_sq / four_alpha_sq)
         );
       }
@@ -64,7 +63,7 @@ EnergyTracker::EnergyTracker(double box_length, double num_particles)
 
   num_g_vectors_ = g_x.size();
 
-  data_ = AlignedSoA<double>(num_g_vectors_, NUM_ARRAYS);
+  data_ = AlignedSoA<real_t>(num_g_vectors_, NUM_ARRAYS);
 
   const auto g_dst{g_vector()};
   std::copy_n(tmp_x.data(), num_g_vectors_, g_dst.x_);
@@ -74,19 +73,19 @@ EnergyTracker::EnergyTracker(double box_length, double num_particles)
 }
 
 void EnergyTracker::initialize_reciprocal_energy() noexcept {
-  const double L{box_length_};
-  const double prefactor{1.0 / (2.0 * std::numbers::pi * L * L * L)};
+  const real_t L{box_length_};
+  const real_t prefactor{1.0_r / (2.0_r * std::numbers::pi_v<real_t> * L * L * L)};
 
   const std::size_t num_G{num_g_vectors_};
-  const double* RESTRICT g_weights{this->g_weights()};
-  const double* RESTRICT sum_real{this->sum_real()};
-  const double* RESTRICT sum_imag{this->sum_imag()};
+  const real_t* RESTRICT g_weights{this->g_weights()};
+  const real_t* RESTRICT sum_real{this->sum_real()};
+  const real_t* RESTRICT sum_imag{this->sum_imag()};
 
   ASSUME_ALIGNED(g_weights, SIMD_BYTES);
   ASSUME_ALIGNED(sum_real, SIMD_BYTES);
   ASSUME_ALIGNED(sum_imag, SIMD_BYTES);
 
-  double sum{};
+  real_t sum{};
   #pragma omp simd reduction(+ : sum)
   for (std::size_t g = 0; g < num_G; ++g) {
     sum += g_weights[g] * (sum_real[g] * sum_real[g] + sum_imag[g] * sum_imag[g]);
@@ -96,49 +95,49 @@ void EnergyTracker::initialize_reciprocal_energy() noexcept {
 
 void EnergyTracker::initialize_real_energy(const Particles& particles) noexcept {
   const std::size_t N{particles.size()};
-  const double L{box_length_};
-  const double neg_L{-1.0 * L};
-  const double half_L{0.5 * L};
-  const double neg_half_L{-1.0 * half_L};
-  const double alpha{ewald_alpha_};
+  const real_t L{box_length_};
+  const real_t neg_L{-1.0_r * L};
+  const real_t half_L{0.5_r * L};
+  const real_t neg_half_L{-1.0_r * half_L};
+  const real_t alpha{ewald_alpha_};
 
   // Fast erfc constants
-  const double p{0.3275911};
-  const double a1{0.254829592};
-  const double a2{-0.284496736};
-  const double a3{1.421413741};
-  const double a4{-1.453152027};
-  const double a5{1.061405429};
+  const real_t p{0.3275911_r};
+  const real_t a1{0.254829592_r};
+  const real_t a2{-0.284496736_r};
+  const real_t a3{1.421413741_r};
+  const real_t a4{-1.453152027_r};
+  const real_t a5{1.061405429_r};
 
   const auto pos{particles.pos().align()};
 
-  double sum{};
+  real_t sum{};
   for (std::size_t i = 0; i < N; ++i) {
-    double local_sum{};
+    real_t local_sum{};
 
     #pragma omp simd reduction(+ : local_sum)
     for (std::size_t j = i + 1; j < N; ++j) {
-      double dx{pos.x_[i] - pos.x_[j]};
-      double dy{pos.y_[i] - pos.y_[j]};
-      double dz{pos.z_[i] - pos.z_[j]};
+      real_t dx{pos.x_[i] - pos.x_[j]};
+      real_t dy{pos.y_[i] - pos.y_[j]};
+      real_t dz{pos.z_[i] - pos.z_[j]};
 
       dx += L * (dx <= neg_half_L) + neg_L * (dx > half_L);
       dy += L * (dy <= neg_half_L) + neg_L * (dy > half_L);
       dz += L * (dz <= neg_half_L) + neg_L * (dz > half_L);
 
-      const double r{
+      const real_t r{
         std::sqrt(
           dx * dx +
           dy * dy +
           dz * dz
         )
       };
-      const double inv_r{(r < 1e-12) ? 1.0 : 1.0 / r};
+      const real_t inv_r{(r < 1e-12_r) ? 1.0_r : 1.0_r / r};
 
       // Abramowitz & Stegun formula for fast std::erfc approx.
-      const double erfc_arg{alpha * r};
-      const double t{1.0 / (1.0 + p * erfc_arg)};
-      const double tau{
+      const real_t erfc_arg{alpha * r};
+      const real_t t{1.0_r / (1.0_r + p * erfc_arg)};
+      const real_t tau{
         t * (
           a1 + t * (
             a2 + t * (
@@ -164,25 +163,25 @@ void EnergyTracker::initialize_structure_factors(const Particles& particles) noe
   const auto pos{particles.pos().align()};
   const auto gv{g_vector().align()};
 
-  double* RESTRICT sum_real{this->sum_real()};
-  double* RESTRICT sum_imag{this->sum_imag()};
+  real_t* RESTRICT sum_real{this->sum_real()};
+  real_t* RESTRICT sum_imag{this->sum_imag()};
 
   ASSUME_ALIGNED(sum_real, SIMD_BYTES);
   ASSUME_ALIGNED(sum_imag, SIMD_BYTES);
 
   for (std::size_t g = 0; g < num_G; ++g) {
-    double cos_sum{};
-    double sin_sum{};
+    real_t cos_sum{};
+    real_t sin_sum{};
 
     #pragma omp simd reduction(+ : cos_sum, sin_sum)
     for (std::size_t j = 0; j < N; ++j) {
-      const double G_dot_r{
+      const real_t G_dot_r{
         gv.x_[g] * pos.x_[j] +
         gv.y_[g] * pos.y_[j] +
         gv.z_[g] * pos.z_[j]
       };
-      double cos_temp{};
-      double sin_temp{};
+      real_t cos_temp{};
+      real_t sin_temp{};
 
       PORTABLE_SINCOS(G_dot_r, &sin_temp, &cos_temp);
 
@@ -196,25 +195,25 @@ void EnergyTracker::initialize_structure_factors(const Particles& particles) noe
 }
 
 void EnergyTracker::update_structure_factors(
-  double old_x,
-  double old_y,
-  double old_z,
-  double new_x,
-  double new_y,
-  double new_z
+  real_t old_x,
+  real_t old_y,
+  real_t old_z,
+  real_t new_x,
+  real_t new_y,
+  real_t new_z
 ) noexcept {
-  const double L{box_length_};
+  const real_t L{box_length_};
 
   const std::size_t num_G{num_g_vectors_};
-  const double prefactor{1.0 / (2.0 * std::numbers::pi * L * L * L)};
+  const real_t prefactor{1.0_r / (2.0_r * std::numbers::pi_v<real_t> * L * L * L)};
 
-  const double* RESTRICT g_weights{this->g_weights()};
+  const real_t* RESTRICT g_weights{this->g_weights()};
   const auto gv{g_vector().align()};
 
-  double* RESTRICT sum_real{this->sum_real()};
-  double* RESTRICT sum_imag{this->sum_imag()};
-  double* RESTRICT d_imag_temp{this->d_imag_temp()};
-  double* RESTRICT d_real_temp{this->d_real_temp()};
+  real_t* RESTRICT sum_real{this->sum_real()};
+  real_t* RESTRICT sum_imag{this->sum_imag()};
+  real_t* RESTRICT d_imag_temp{this->d_imag_temp()};
+  real_t* RESTRICT d_real_temp{this->d_real_temp()};
 
   ASSUME_ALIGNED(g_weights, SIMD_BYTES);
 
@@ -223,23 +222,23 @@ void EnergyTracker::update_structure_factors(
   ASSUME_ALIGNED(d_imag_temp, SIMD_BYTES);
   ASSUME_ALIGNED(d_real_temp, SIMD_BYTES);
 
-  double delta{};
+  real_t delta{};
 
   #pragma omp simd
   for (std::size_t g = 0; g < num_G; ++g) {
-    const double old_dot{
+    const real_t old_dot{
       gv.x_[g] * old_x +
       gv.y_[g] * old_y +
       gv.z_[g] * old_z
     };
-    const double new_dot{
+    const real_t new_dot{
       gv.x_[g] * new_x +
       gv.y_[g] * new_y +
       gv.z_[g] * new_z
     };
 
-    double new_sin{}, new_cos{};
-    double old_sin{}, old_cos{};
+    real_t new_sin{}, new_cos{};
+    real_t old_sin{}, old_cos{};
 
     PORTABLE_SINCOS(new_dot, &new_sin, &new_cos);
     PORTABLE_SINCOS(old_dot, &old_sin, &old_cos);
@@ -251,10 +250,10 @@ void EnergyTracker::update_structure_factors(
   // Accumulate delta and update sum_real / sum_imag
   #pragma omp simd reduction(+ : delta)
   for (std::size_t g = 0; g < num_G; ++g) {
-    const double dr{d_real_temp[g]};
-    const double di{d_imag_temp[g]};
+    const real_t dr{d_real_temp[g]};
+    const real_t di{d_imag_temp[g]};
 
-    delta += g_weights[g] * (2.0 * (sum_real[g] * dr + sum_imag[g] * di) + dr * dr + di * di);
+    delta += g_weights[g] * (2.0_r * (sum_real[g] * dr + sum_imag[g] * di) + dr * dr + di * di);
 
     sum_real[g] += dr;
     sum_imag[g] += di;
@@ -263,20 +262,20 @@ void EnergyTracker::update_structure_factors(
   V_recip_ += prefactor * delta;
 }
 
-double EnergyTracker::kinetic_energy(const Particles& particles) const noexcept {
+real_t EnergyTracker::kinetic_energy(const Particles& particles) const noexcept {
   const auto grad{particles.grad_log_psi().align()};
-  const double* RESTRICT lap{particles.lap_log_psi()};
+  const real_t* RESTRICT lap{particles.lap_log_psi()};
 
   ASSUME_ALIGNED(lap, SIMD_BYTES);
 
   // Kinetic
-  double T_sum{};
+  real_t T_sum{};
   const std::size_t N{particles.size()};
 
   #pragma omp simd reduction(+ : T_sum)
   for (std::size_t i = 0; i < N; ++i) {
     // Computes ||Grad(logPsi)||^2
-    const double grad_sq{
+    const real_t grad_sq{
       grad.x_[i] * grad.x_[i] +
       grad.y_[i] * grad.y_[i] +
       grad.z_[i] * grad.z_[i]
@@ -286,55 +285,55 @@ double EnergyTracker::kinetic_energy(const Particles& particles) const noexcept 
     T_sum += (lap[i] + grad_sq);
   }
 
-  return -0.5 * T_sum;
+  return -0.5_r * T_sum;
 }
 
 void EnergyTracker::update_real_energy(
   std::size_t moved_idx,
-  double old_x,
-  double old_y,
-  double old_z,
+  real_t old_x,
+  real_t old_y,
+  real_t old_z,
   const Particles& particles
 ) noexcept {
   const std::size_t N{particles.size()};
-  const double L{box_length_};
-  const double neg_L{-1.0 * L};
-  const double half_L{0.5 * L};
-  const double neg_half_L{-1.0 * half_L};
+  const real_t L{box_length_};
+  const real_t neg_L{-1.0_r * L};
+  const real_t half_L{0.5_r * L};
+  const real_t neg_half_L{-1.0_r * half_L};
 
-  const double alpha{ewald_alpha_};
+  const real_t alpha{ewald_alpha_};
 
   // Fast erfc constants
-  const double p{0.3275911};
-  const double a1{0.254829592};
-  const double a2{-0.284496736};
-  const double a3{1.421413741};
-  const double a4{-1.453152027};
-  const double a5{1.061405429};
+  const real_t p{0.3275911_r};
+  const real_t a1{0.254829592_r};
+  const real_t a2{-0.284496736_r};
+  const real_t a3{1.421413741_r};
+  const real_t a4{-1.453152027_r};
+  const real_t a5{1.061405429_r};
 
   const auto pos{particles.pos().align()};
 
-  const double new_x{pos.x_[moved_idx]};
-  const double new_y{pos.y_[moved_idx]};
-  const double new_z{pos.z_[moved_idx]};
+  const real_t new_x{pos.x_[moved_idx]};
+  const real_t new_y{pos.y_[moved_idx]};
+  const real_t new_z{pos.z_[moved_idx]};
 
-  double delta{};
+  real_t delta{};
 
   #pragma omp simd reduction(+ : delta)
   for (std::size_t j = 0; j < N; ++j) {
     // Branchless mask to safely skip the moved particle
-    const double valid_mask{(j == moved_idx) ? 0.0 : 1.0};
+    const real_t valid_mask{(j == moved_idx) ? 0.0_r : 1.0_r};
 
     // Old pair
-    double dx_old{old_x - pos.x_[j]};
-    double dy_old{old_y - pos.y_[j]};
-    double dz_old{old_z - pos.z_[j]};
+    real_t dx_old{old_x - pos.x_[j]};
+    real_t dy_old{old_y - pos.y_[j]};
+    real_t dz_old{old_z - pos.z_[j]};
 
     dx_old += L * (dx_old <= neg_half_L) + neg_L * (dx_old > half_L);
     dy_old += L * (dy_old <= neg_half_L) + neg_L * (dy_old > half_L);
     dz_old += L * (dz_old <= neg_half_L) + neg_L * (dz_old > half_L);
 
-    const double r_old{
+    const real_t r_old{
       std::sqrt(
         dx_old * dx_old +
         dy_old * dy_old +
@@ -343,12 +342,12 @@ void EnergyTracker::update_real_energy(
     };
 
     // Protect against 1.0 / 0.0 generating NaN
-    const double inv_r_old{(r_old < 1e-12) ? 1.0 : 1.0 / r_old};
+    const real_t inv_r_old{(r_old < 1e-12_r) ? 1.0_r : 1.0_r / r_old};
 
     // Abramowitz & Stegun formula for fast std::erfc approx.
-    const double erfc_arg_old{alpha * r_old};
-    const double t_old{1.0 / (1.0 + p * erfc_arg_old)};
-    const double tau_old{
+    const real_t erfc_arg_old{alpha * r_old};
+    const real_t t_old{1.0_r / (1.0_r + p * erfc_arg_old)};
+    const real_t tau_old{
       t_old * (
         a1 + t_old * (
           a2 + t_old * (
@@ -360,18 +359,18 @@ void EnergyTracker::update_real_energy(
       )
     };
 
-    double const erfc_old{tau_old * std::exp(-erfc_arg_old * erfc_arg_old) * inv_r_old};
+    real_t const erfc_old{tau_old * std::exp(-erfc_arg_old * erfc_arg_old) * inv_r_old};
 
     // New pair
-    double dx_new{new_x - pos.x_[j]};
-    double dy_new{new_y - pos.y_[j]};
-    double dz_new{new_z - pos.z_[j]};
+    real_t dx_new{new_x - pos.x_[j]};
+    real_t dy_new{new_y - pos.y_[j]};
+    real_t dz_new{new_z - pos.z_[j]};
 
     dx_new += L * (dx_new <= neg_half_L) + neg_L * (dx_new > half_L);
     dy_new += L * (dy_new <= neg_half_L) + neg_L * (dy_new > half_L);
     dz_new += L * (dz_new <= neg_half_L) + neg_L * (dz_new > half_L);
 
-    const double r_new{
+    const real_t r_new{
       std::sqrt(
         dx_new * dx_new +
         dy_new * dy_new +
@@ -380,14 +379,14 @@ void EnergyTracker::update_real_energy(
     };
 
     // Protect against 1.0 / 0.0 generating NaN
-    const double inv_r_new{(r_new < 1e-12) ? 1.0 : 1.0 / r_new};
+    const real_t inv_r_new{(r_new < 1e-12_r) ? 1.0_r : 1.0_r / r_new};
 
     // Combine operations and apply the mask
 
     // Abramowitz & Stegun formula for fast std::erfc approx.
-    const double erfc_arg_new{alpha * r_new};
-    const double t_new{1.0 / (1.0 + p * erfc_arg_new)};
-    const double tau_new{
+    const real_t erfc_arg_new{alpha * r_new};
+    const real_t t_new{1.0_r / (1.0_r + p * erfc_arg_new)};
+    const real_t tau_new{
       t_new * (
         a1 + t_new * (
           a2 + t_new * (
@@ -399,7 +398,7 @@ void EnergyTracker::update_real_energy(
       )
     };
 
-    double const erfc_new{tau_new * std::exp(-erfc_arg_new * erfc_arg_new) * inv_r_new};
+    real_t const erfc_new{tau_new * std::exp(-erfc_arg_new * erfc_arg_new) * inv_r_new};
 
     delta += valid_mask * (erfc_new - erfc_old);
   }
@@ -407,19 +406,19 @@ void EnergyTracker::update_real_energy(
   V_real_ += delta;
 }
 
-double EnergyTracker::potential_energy() const noexcept {
+real_t EnergyTracker::potential_energy() const noexcept {
   // Ewald constants:
-  const double ewald_self_correction_term{ewald_correction_};
-  const double ewald_background{ewald_background_};
+  const real_t ewald_self_correction_term{ewald_correction_};
+  const real_t ewald_background{ewald_background_};
 
   // Potentials calcualted in cache:
-  const double V_recip{V_recip_};
-  const double V_real{V_real_};
+  const real_t V_recip{V_recip_};
+  const real_t V_real{V_real_};
 
   // Self + background:
   return V_real + V_recip + ewald_self_correction_term + ewald_background;
 }
 
-double EnergyTracker::eval_total_energy(const Particles& particles) const noexcept {
+real_t EnergyTracker::eval_total_energy(const Particles& particles) const noexcept {
   return kinetic_energy(particles) + potential_energy();
 }

--- a/src/energy_tracking/energy_tracking.hpp
+++ b/src/energy_tracking/energy_tracking.hpp
@@ -10,15 +10,15 @@
 
 class EnergyTracker {
 private:
-  double box_length_;
+  real_t box_length_;
 
-  static constexpr double EWALD_RECIPROCAL_TOLERANCE{1.0e-6};
-  double ewald_alpha_;
-  double ewald_correction_;
-  double ewald_background_;
+  static constexpr real_t EWALD_RECIPROCAL_TOLERANCE{1.0e-6_r};
+  real_t ewald_alpha_;
+  real_t ewald_correction_;
+  real_t ewald_background_;
 
-  double V_recip_;
-  double V_real_;
+  real_t V_recip_;
+  real_t V_real_;
 
   std::size_t num_g_vectors_;
 
@@ -33,10 +33,10 @@ private:
     D_IMAG_TEMP_,
     NUM_ARRAYS
   };
-  AlignedSoA<double> data_;
+  AlignedSoA<real_t> data_;
 
 public:
-  explicit EnergyTracker(double box_length, double num_particles);
+  explicit EnergyTracker(real_t box_length, real_t num_particles);
 
   void initialize_reciprocal_energy() noexcept;
   void initialize_real_energy(const Particles& particles) noexcept;
@@ -44,43 +44,43 @@ public:
   void initialize_structure_factors(const Particles& particles) noexcept;
 
   void update_structure_factors(
-    double old_x,
-    double old_y,
-    double old_z,
-    double new_x,
-    double new_y,
-    double new_z
+    real_t old_x,
+    real_t old_y,
+    real_t old_z,
+    real_t new_x,
+    real_t new_y,
+    real_t new_z
   ) noexcept;
 
   void update_real_energy(
     std::size_t moved_idx,
-    double old_x,
-    double old_y,
-    double old_z,
+    real_t old_x,
+    real_t old_y,
+    real_t old_z,
     const Particles& particles
   ) noexcept;
 
-  double eval_total_energy(const Particles& particles) const noexcept;
+  real_t eval_total_energy(const Particles& particles) const noexcept;
 
 private:
-  Ptr3D<      double> g_vector()       noexcept { return {data_[G_X_], data_[G_Y_], data_[G_Z_]}; }
-  Ptr3D<const double> g_vector() const noexcept { return {data_[G_X_], data_[G_Y_], data_[G_Z_]}; }
+  Ptr3D<      real_t> g_vector()       noexcept { return {data_[G_X_], data_[G_Y_], data_[G_Z_]}; }
+  Ptr3D<const real_t> g_vector() const noexcept { return {data_[G_X_], data_[G_Y_], data_[G_Z_]}; }
 
-  [[nodiscard]] double*       g_weights()       noexcept { return data_[G_WEIGHTS_]; }
-  [[nodiscard]] double const* g_weights() const noexcept { return data_[G_WEIGHTS_]; }
+  [[nodiscard]] real_t*       g_weights()       noexcept { return data_[G_WEIGHTS_]; }
+  [[nodiscard]] real_t const* g_weights() const noexcept { return data_[G_WEIGHTS_]; }
 
-  [[nodiscard]] double*       sum_real()       noexcept { return data_[S_REAL_]; }
-  [[nodiscard]] double const* sum_real() const noexcept { return data_[S_REAL_]; }
+  [[nodiscard]] real_t*       sum_real()       noexcept { return data_[S_REAL_]; }
+  [[nodiscard]] real_t const* sum_real() const noexcept { return data_[S_REAL_]; }
 
-  [[nodiscard]] double*       sum_imag()       noexcept { return data_[S_IMAG_]; }
-  [[nodiscard]] double const* sum_imag() const noexcept { return data_[S_IMAG_]; }
+  [[nodiscard]] real_t*       sum_imag()       noexcept { return data_[S_IMAG_]; }
+  [[nodiscard]] real_t const* sum_imag() const noexcept { return data_[S_IMAG_]; }
 
-  [[nodiscard]] double*       d_real_temp()       noexcept { return data_[D_REAL_TEMP_]; }
-  [[nodiscard]] double const* d_real_temp() const noexcept { return data_[D_REAL_TEMP_]; }
+  [[nodiscard]] real_t*       d_real_temp()       noexcept { return data_[D_REAL_TEMP_]; }
+  [[nodiscard]] real_t const* d_real_temp() const noexcept { return data_[D_REAL_TEMP_]; }
 
-  [[nodiscard]] double*       d_imag_temp()       noexcept { return data_[D_IMAG_TEMP_]; }
-  [[nodiscard]] double const* d_imag_temp() const noexcept { return data_[D_IMAG_TEMP_]; }
+  [[nodiscard]] real_t*       d_imag_temp()       noexcept { return data_[D_IMAG_TEMP_]; }
+  [[nodiscard]] real_t const* d_imag_temp() const noexcept { return data_[D_IMAG_TEMP_]; }
 
-  double kinetic_energy(const Particles& particles) const noexcept;
-  double potential_energy() const noexcept;
+  real_t kinetic_energy(const Particles& particles) const noexcept;
+  real_t potential_energy() const noexcept;
 };

--- a/src/jastrow_pade/jastrow_pade.cpp
+++ b/src/jastrow_pade/jastrow_pade.cpp
@@ -3,63 +3,63 @@
 #include <cmath>
 #include <cstddef>
 
-double JastrowPade::value(const Particles& particles) const noexcept {
+real_t JastrowPade::value(const Particles& particles) const noexcept {
   const std::size_t num_particles{particles.size()};
-  const double L{box_length_};
-  const double neg_L{-1.0 * L};
-  const double half_L{0.5 * L};
-  const double neg_half_L{-1.0 * half_L};
+  const real_t L{box_length_};
+  const real_t neg_L{-1.0_r * L};
+  const real_t half_L{0.5_r * L};
+  const real_t neg_half_L{-1.0_r * half_L};
 
   const auto p{particles.pos().align()};
 
-  const double a_local{a()};
-  const double b_local{b()};
+  const real_t a_local{a()};
+  const real_t b_local{b()};
 
-  double jastrow_pade{};
+  real_t jastrow_pade{};
   for (std::size_t i = 0; i < num_particles; ++i) {
-    double local_jastrow{};
+    real_t local_jastrow{};
 
     #pragma omp simd reduction(+ : local_jastrow)
     for (std::size_t j = 0; j < num_particles; ++j) {
-      const double mask{i == j ? 0.0 : 1.0};
+      const real_t mask{i == j ? 0.0_r : 1.0_r};
 
-      double displ_x{p.x_[i] - p.x_[j]};
-      double displ_y{p.y_[i] - p.y_[j]};
-      double displ_z{p.z_[i] - p.z_[j]};
+      real_t displ_x{p.x_[i] - p.x_[j]};
+      real_t displ_y{p.y_[i] - p.y_[j]};
+      real_t displ_z{p.z_[i] - p.z_[j]};
 
       displ_x += L * (displ_x <= neg_half_L) + neg_L * (displ_x > half_L);
       displ_y += L * (displ_y <= neg_half_L) + neg_L * (displ_y > half_L);
       displ_z += L * (displ_z <= neg_half_L) + neg_L * (displ_z > half_L);
 
-      const double dist_sq{
+      const real_t dist_sq{
         displ_x * displ_x +
         displ_y * displ_y +
         displ_z * displ_z
       };
-      const double dist{std::sqrt(dist_sq)};
+      const real_t dist{std::sqrt(dist_sq)};
 
-      const double denom{1.0 + b_local * dist};
-      const double inv_denom{1.0 / denom};
+      const real_t denom{1.0_r + b_local * dist};
+      const real_t inv_denom{1.0_r / denom};
 
       local_jastrow += mask * a_local * dist * inv_denom;
     }
     jastrow_pade += local_jastrow;
   }
-  return 0.5 * jastrow_pade;
+  return 0.5_r * jastrow_pade;
 }
 
 void JastrowPade::add_derivatives(
   const Particles& particles,
-  double* RESTRICT grad_x,
-  double* RESTRICT grad_y,
-  double* RESTRICT grad_z,
-  double* RESTRICT laplacian
+  real_t* RESTRICT grad_x,
+  real_t* RESTRICT grad_y,
+  real_t* RESTRICT grad_z,
+  real_t* RESTRICT laplacian
 ) const noexcept {
   const std::size_t num_particles{particles.size()};
-  const double L{box_length_};
-  const double neg_L{-1.0 * L};
-  const double half_L{0.5 * L};
-  const double neg_half_L{-1.0 * half_L};
+  const real_t L{box_length_};
+  const real_t neg_L{-1.0_r * L};
+  const real_t half_L{0.5_r * L};
+  const real_t neg_half_L{-1.0_r * half_L};
 
   const auto p{particles.pos().align()};
 
@@ -68,45 +68,45 @@ void JastrowPade::add_derivatives(
   ASSUME_ALIGNED(grad_z, SIMD_BYTES);
   ASSUME_ALIGNED(laplacian, SIMD_BYTES);
 
-  const double a_local{a()};
-  const double b_local{b()};
-  const double neg_two_a_b{-2.0 * a_local * b_local};
+  const real_t a_local{a()};
+  const real_t b_local{b()};
+  const real_t neg_two_a_b{-2.0_r * a_local * b_local};
 
   for (std::size_t i = 0; i < num_particles; ++i) {
-    double d_grad_x{}, d_grad_y{}, d_grad_z{}, d_lap{};
+    real_t d_grad_x{}, d_grad_y{}, d_grad_z{}, d_lap{};
 
     #pragma omp simd reduction(+ : d_grad_x, d_grad_y, d_grad_z, d_lap)
     for (std::size_t j = 0; j < num_particles; ++j) {
-      const double valid_idx{i == j ? 0.0 : 1.0};
+      const real_t valid_idx{i == j ? 0.0_r : 1.0_r};
 
-      double displ_x{p.x_[i] - p.x_[j]};
-      double displ_y{p.y_[i] - p.y_[j]};
-      double displ_z{p.z_[i] - p.z_[j]};
+      real_t displ_x{p.x_[i] - p.x_[j]};
+      real_t displ_y{p.y_[i] - p.y_[j]};
+      real_t displ_z{p.z_[i] - p.z_[j]};
 
       displ_x += L * (displ_x <= neg_half_L) + neg_L * (displ_x > half_L);
       displ_y += L * (displ_y <= neg_half_L) + neg_L * (displ_y > half_L);
       displ_z += L * (displ_z <= neg_half_L) + neg_L * (displ_z > half_L);
 
-      const double dist_sq{
+      const real_t dist_sq{
         displ_x * displ_x +
         displ_y * displ_y +
         displ_z * displ_z
       };
-      const double dist{std::sqrt(dist_sq)};
+      const real_t dist{std::sqrt(dist_sq)};
 
-      const bool degenerate{dist < 1e-12};
-      const double inv_dist{degenerate ? 1.0 : 1.0 / dist};
-      const double mask{degenerate ? 0.0 : valid_idx};
+      const bool degenerate{dist < 1e-12_r};
+      const real_t inv_dist{degenerate ? 1.0_r : 1.0_r / dist};
+      const real_t mask{degenerate ? 0.0_r : valid_idx};
 
-      const double denom{1.0 / (1.0 + b_local * dist)};
-      const double denom_sq{denom * denom};
-      const double denom_cb{denom_sq * denom};
+      const real_t denom{1.0_r / (1.0_r + b_local * dist)};
+      const real_t denom_sq{denom * denom};
+      const real_t denom_cb{denom_sq * denom};
 
-      const double first_deriv{a_local * denom_sq};
-      const double second_deriv{neg_two_a_b * denom_cb};
+      const real_t first_deriv{a_local * denom_sq};
+      const real_t second_deriv{neg_two_a_b * denom_cb};
 
-      const double grad_factor{mask * first_deriv * inv_dist};
-      const double laplacian_pair{mask * (second_deriv + 2.0 * first_deriv * inv_dist)};
+      const real_t grad_factor{mask * first_deriv * inv_dist};
+      const real_t laplacian_pair{mask * (second_deriv + 2.0_r * first_deriv * inv_dist)};
 
       d_grad_x += grad_factor * displ_x;
       d_grad_y += grad_factor * displ_y;
@@ -122,67 +122,67 @@ void JastrowPade::add_derivatives(
   }
 }
 
-double JastrowPade::delta_value(
+real_t JastrowPade::delta_value(
   const Particles& particles,
   std::size_t moved,
-  double old_x,
-  double old_y,
-  double old_z
+  real_t old_x,
+  real_t old_y,
+  real_t old_z
 ) const noexcept {
   const std::size_t num_particles{particles.size()};
-  const double L{box_length_};
-  const double neg_L{-1.0 * L};
-  const double half_L{0.5 * L};
-  const double neg_half_L{-1.0 * half_L};
+  const real_t L{box_length_};
+  const real_t neg_L{-1.0_r * L};
+  const real_t half_L{0.5_r * L};
+  const real_t neg_half_L{-1.0_r * half_L};
 
   const auto p{particles.pos().align()};
 
-  const double a_local{a()};
-  const double b_local{b()};
+  const real_t a_local{a()};
+  const real_t b_local{b()};
 
-  const double new_x{p.x_[moved]};
-  const double new_y{p.y_[moved]};
-  const double new_z{p.z_[moved]};
+  const real_t new_x{p.x_[moved]};
+  const real_t new_y{p.y_[moved]};
+  const real_t new_z{p.z_[moved]};
 
-  double delta{};
+  real_t delta{};
 
   #pragma omp simd reduction(+ : delta)
   for (std::size_t j = 0; j < num_particles; ++j) {
-    const double valid_mask{(j == moved) ? 0.0 : 1.0};
+    const real_t valid_mask{(j == moved) ? 0.0_r : 1.0_r};
 
-    double displ_old_x{old_x - p.x_[j]};
-    double displ_old_y{old_y - p.y_[j]};
-    double displ_old_z{old_z - p.z_[j]};
+    real_t displ_old_x{old_x - p.x_[j]};
+    real_t displ_old_y{old_y - p.y_[j]};
+    real_t displ_old_z{old_z - p.z_[j]};
 
     displ_old_x += L * (displ_old_x <= neg_half_L) + neg_L * (displ_old_x > half_L);
     displ_old_y += L * (displ_old_y <= neg_half_L) + neg_L * (displ_old_y > half_L);
     displ_old_z += L * (displ_old_z <= neg_half_L) + neg_L * (displ_old_z > half_L);
 
-    const double dist_old{
+    const real_t dist_old{
       std::sqrt(
         displ_old_x * displ_old_x +
         displ_old_y * displ_old_y +
         displ_old_z * displ_old_z
       )
     };
-    const double denom_old{1.0 / (1.0 + b_local * dist_old)};
+    const real_t denom_old{1.0_r / (1.0_r + b_local * dist_old)};
 
-    double displ_new_x{new_x - p.x_[j]};
-    double displ_new_y{new_y - p.y_[j]};
-    double displ_new_z{new_z - p.z_[j]};
+    real_t displ_new_x{new_x - p.x_[j]};
+    real_t displ_new_y{new_y - p.y_[j]};
+    real_t displ_new_z{new_z - p.z_[j]};
 
     displ_new_x += L * (displ_new_x <= neg_half_L) + neg_L * (displ_new_x > half_L);
     displ_new_y += L * (displ_new_y <= neg_half_L) + neg_L * (displ_new_y > half_L);
     displ_new_z += L * (displ_new_z <= neg_half_L) + neg_L * (displ_new_z > half_L);
 
-    const double dist_new{
+    const real_t dist_new{
       std::sqrt(
         displ_new_x * displ_new_x +
         displ_new_y * displ_new_y +
         displ_new_z * displ_new_z
       )
     };
-    const double denom_new{1.0 / (1.0 + b_local * dist_new)};
+    const real_t denom_new{1.0_r / (1.0_r + b_local * dist_new)};
 
     delta += valid_mask * a_local * (dist_new * denom_new - dist_old * denom_old);
   }
@@ -193,25 +193,25 @@ double JastrowPade::delta_value(
 void JastrowPade::update_derivatives_for_move(
   const Particles& particles,
   std::size_t moved,
-  double old_x,
-  double old_y,
-  double old_z,
-  double* RESTRICT grad_x,
-  double* RESTRICT grad_y,
-  double* RESTRICT grad_z,
-  double* RESTRICT laplacian
+  real_t old_x,
+  real_t old_y,
+  real_t old_z,
+  real_t* RESTRICT grad_x,
+  real_t* RESTRICT grad_y,
+  real_t* RESTRICT grad_z,
+  real_t* RESTRICT laplacian
 ) const noexcept {
-  grad_x[moved] = 0.0;
-  grad_y[moved] = 0.0;
-  grad_z[moved] = 0.0;
-  laplacian[moved] = 0.0;
+  grad_x[moved] = 0.0_r;
+  grad_y[moved] = 0.0_r;
+  grad_z[moved] = 0.0_r;
+  laplacian[moved] = 0.0_r;
 
   const std::size_t num_particles{particles.size()};
-  const double L{box_length_};
-  const double neg_L{-1.0 * L};
+  const real_t L{box_length_};
+  const real_t neg_L{-1.0_r * L};
 
-  const double half_L{0.5 * L};
-  const double neg_half_L{-1.0 * half_L};
+  const real_t half_L{0.5_r * L};
+  const real_t neg_half_L{-1.0_r * half_L};
 
   const auto p{particles.pos().align()};
 
@@ -220,29 +220,29 @@ void JastrowPade::update_derivatives_for_move(
   ASSUME_ALIGNED(grad_z, SIMD_BYTES);
   ASSUME_ALIGNED(laplacian, SIMD_BYTES);
 
-  const double a_local{a()};
-  const double b_local{b()};
-  const double m2ab{-2.0 * a_local * b_local};
+  const real_t a_local{a()};
+  const real_t b_local{b()};
+  const real_t m2ab{-2.0_r * a_local * b_local};
 
-  const double new_x{p.x_[moved]};
-  const double new_y{p.y_[moved]};
-  const double new_z{p.z_[moved]};
+  const real_t new_x{p.x_[moved]};
+  const real_t new_y{p.y_[moved]};
+  const real_t new_z{p.z_[moved]};
 
-  double m_grad_x{}, m_grad_y{}, m_grad_z{}, m_lap{};
+  real_t m_grad_x{}, m_grad_y{}, m_grad_z{}, m_lap{};
 
   #pragma omp simd reduction(+ : m_grad_x, m_grad_y, m_grad_z, m_lap)
   for (std::size_t j = 0; j < num_particles; ++j) {
     const bool is_moved{j == moved};
 
-    double displ_old_x{old_x - p.x_[j]};
-    double displ_old_y{old_y - p.y_[j]};
-    double displ_old_z{old_z - p.z_[j]};
+    real_t displ_old_x{old_x - p.x_[j]};
+    real_t displ_old_y{old_y - p.y_[j]};
+    real_t displ_old_z{old_z - p.z_[j]};
 
     displ_old_x += L * (displ_old_x <= neg_half_L) + neg_L * (displ_old_x > half_L);
     displ_old_y += L * (displ_old_y <= neg_half_L) + neg_L * (displ_old_y > half_L);
     displ_old_z += L * (displ_old_z <= neg_half_L) + neg_L * (displ_old_z > half_L);
 
-    const double dist_old{
+    const real_t dist_old{
       std::sqrt(
         displ_old_x * displ_old_x +
         displ_old_y * displ_old_y +
@@ -250,27 +250,27 @@ void JastrowPade::update_derivatives_for_move(
       )
     };
 
-    const double inv_dist_old{(dist_old < 1e-12) ? 1.0 : 1.0 / dist_old};
-    const double mask_old{(is_moved || dist_old < 1e-12) ? 0.0 : 1.0};
+    const real_t inv_dist_old{(dist_old < 1e-12_r) ? 1.0_r : 1.0_r / dist_old};
+    const real_t mask_old{(is_moved || dist_old < 1e-12_r) ? 0.0_r : 1.0_r};
 
-    const double inv_denom_old{1.0 / (1.0 + b_local * dist_old)};
-    const double inv_denom_sq_old{inv_denom_old * inv_denom_old};
+    const real_t inv_denom_old{1.0_r / (1.0_r + b_local * dist_old)};
+    const real_t inv_denom_sq_old{inv_denom_old * inv_denom_old};
 
-    const double first_deriv_old{a_local * inv_denom_sq_old};
-    const double second_deriv_old{m2ab * inv_denom_sq_old * inv_denom_old};
+    const real_t first_deriv_old{a_local * inv_denom_sq_old};
+    const real_t second_deriv_old{m2ab * inv_denom_sq_old * inv_denom_old};
 
-    const double grad_factor_old{mask_old * first_deriv_old * inv_dist_old};
-    const double lap_pair_old{mask_old * (second_deriv_old + 2.0 * first_deriv_old * inv_dist_old)};
+    const real_t grad_factor_old{mask_old * first_deriv_old * inv_dist_old};
+    const real_t lap_pair_old{mask_old * (second_deriv_old + 2.0_r * first_deriv_old * inv_dist_old)};
 
-    double displ_new_x{new_x - p.x_[j]};
-    double displ_new_y{new_y - p.y_[j]};
-    double displ_new_z{new_z - p.z_[j]};
+    real_t displ_new_x{new_x - p.x_[j]};
+    real_t displ_new_y{new_y - p.y_[j]};
+    real_t displ_new_z{new_z - p.z_[j]};
 
     displ_new_x += L * (displ_new_x <= neg_half_L) + neg_L * (displ_new_x > half_L);
     displ_new_y += L * (displ_new_y <= neg_half_L) + neg_L * (displ_new_y > half_L);
     displ_new_z += L * (displ_new_z <= neg_half_L) + neg_L * (displ_new_z > half_L);
 
-    const double dist_new{
+    const real_t dist_new{
       std::sqrt(
         displ_new_x * displ_new_x +
         displ_new_y * displ_new_y +
@@ -278,17 +278,17 @@ void JastrowPade::update_derivatives_for_move(
       )
     };
 
-    const double inv_dist_new{(dist_new < 1e-12) ? 1.0 : 1.0 / dist_new};
-    const double mask_new{(is_moved || dist_new < 1e-12) ? 0.0 : 1.0};
+    const real_t inv_dist_new{(dist_new < 1e-12_r) ? 1.0_r : 1.0_r / dist_new};
+    const real_t mask_new{(is_moved || dist_new < 1e-12_r) ? 0.0_r : 1.0_r};
 
-    const double inv_denom_new{1.0 / (1.0 + b_local * dist_new)};
-    const double inv_denom_sq_new{inv_denom_new * inv_denom_new};
+    const real_t inv_denom_new{1.0_r / (1.0_r + b_local * dist_new)};
+    const real_t inv_denom_sq_new{inv_denom_new * inv_denom_new};
 
-    const double first_deriv_new{a_local * inv_denom_sq_new};
-    const double second_deriv_new{m2ab * inv_denom_sq_new * inv_denom_new};
+    const real_t first_deriv_new{a_local * inv_denom_sq_new};
+    const real_t second_deriv_new{m2ab * inv_denom_sq_new * inv_denom_new};
 
-    const double grad_factor_new{mask_new * first_deriv_new * inv_dist_new};
-    const double lap_pair_new{mask_new * (second_deriv_new + 2.0 * first_deriv_new * inv_dist_new)};
+    const real_t grad_factor_new{mask_new * first_deriv_new * inv_dist_new};
+    const real_t lap_pair_new{mask_new * (second_deriv_new + 2.0_r * first_deriv_new * inv_dist_new)};
 
     m_grad_x += grad_factor_new * displ_new_x;
     m_grad_y += grad_factor_new * displ_new_y;

--- a/src/jastrow_pade/jastrow_pade.hpp
+++ b/src/jastrow_pade/jastrow_pade.hpp
@@ -4,48 +4,48 @@
 
 class JastrowPade {
 private:
-  double box_length_;
-  double a_;
-  double b_;
+  real_t box_length_;
+  real_t a_;
+  real_t b_;
 
 public:
-  explicit JastrowPade(double box_length, double a = 0.25, double b = 1) noexcept
+  explicit JastrowPade(real_t box_length, real_t a = 0.25_r, real_t b = 1.0_r) noexcept
   : box_length_{box_length}
   , a_{a}
   , b_{b}
   { }
 
-  [[nodiscard]] double box_length() const noexcept { return box_length_; }
-  [[nodiscard]] double a() const noexcept { return a_; }
-  [[nodiscard]] double b() const noexcept { return b_; }
+  [[nodiscard]] real_t box_length() const noexcept { return box_length_; }
+  [[nodiscard]] real_t a() const noexcept { return a_; }
+  [[nodiscard]] real_t b() const noexcept { return b_; }
 
-  [[nodiscard]] double value(const Particles& particles) const noexcept;
+  [[nodiscard]] real_t value(const Particles& particles) const noexcept;
 
   void add_derivatives(
     const Particles& particles,
-    double* RESTRICT grad_x,
-    double* RESTRICT grad_y,
-    double* RESTRICT grad_z,
-    double* RESTRICT laplacian
+    real_t* RESTRICT grad_x,
+    real_t* RESTRICT grad_y,
+    real_t* RESTRICT grad_z,
+    real_t* RESTRICT laplacian
   ) const noexcept;
 
-  [[nodiscard]] double delta_value(
+  [[nodiscard]] real_t delta_value(
     const Particles& particles,
     std::size_t moved,
-    double old_x,
-    double old_y,
-    double old_z
+    real_t old_x,
+    real_t old_y,
+    real_t old_z
   ) const noexcept;
 
   void update_derivatives_for_move(
     const Particles& particles,
     std::size_t moved,
-    double old_x,
-    double old_y,
-    double old_z,
-    double* RESTRICT grad_x,
-    double* RESTRICT grad_y,
-    double* RESTRICT grad_z,
-    double* RESTRICT laplacian
+    real_t old_x,
+    real_t old_y,
+    real_t old_z,
+    real_t* RESTRICT grad_x,
+    real_t* RESTRICT grad_y,
+    real_t* RESTRICT grad_z,
+    real_t* RESTRICT laplacian
   ) const noexcept;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,9 +65,9 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
       }
     }
 
-    double global_energy_sum{};
-    double global_variance_sum{};
-    double global_acceptance_sum{};
+    real_t global_energy_sum{};
+    real_t global_variance_sum{};
+    real_t global_acceptance_sum{};
     std::size_t threads_with_se{};
 
     for (auto& f : futures) {
@@ -83,15 +83,15 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
     auto end{std::chrono::steady_clock::now()};
     std::chrono::duration<double> elapsed{end - start};
 
-    const double inv_num_threads{1.0 / static_cast<double>(num_threads)};
-    const double final_mean{global_energy_sum * inv_num_threads};
-    const double final_acceptance_rate{global_acceptance_sum * inv_num_threads * 100.0};
+    const real_t inv_num_threads{1.0_r / static_cast<real_t>(num_threads)};
+    const real_t final_mean{global_energy_sum * inv_num_threads};
+    const real_t final_acceptance_rate{global_acceptance_sum * inv_num_threads * 100.0_r};
 
     std::cout << "<--- Final Measurements --->" << std::endl
               << "Final Aggregated Energy: " << std::setprecision(6) << final_mean;
 
     if (threads_with_se > 0U) {
-      const double final_se{std::sqrt(global_variance_sum) * inv_num_threads};
+      const real_t final_se{std::sqrt(global_variance_sum) * inv_num_threads};
       std::cout << " +/- " << final_se;
     } else {
       std::cout << " +/- N/A (insufficient blocks)";

--- a/src/optimizer/jastrow_optimizer.cpp
+++ b/src/optimizer/jastrow_optimizer.cpp
@@ -10,15 +10,15 @@
 #include <numbers>
 #include <vector>
 
-double JastrowOptimizer::compute_rs(const Config& cfg) {
-  const double N{static_cast<double>(cfg.num_particles)};
-  const double volume{cfg.box_length * cfg.box_length * cfg.box_length};
-  const double density{N / volume};
-  return std::cbrt(3.0 / (4.0 * std::numbers::pi * density));
+real_t JastrowOptimizer::compute_rs(const Config& cfg) {
+  const real_t N{static_cast<real_t>(cfg.num_particles)};
+  const real_t volume{cfg.box_length * cfg.box_length * cfg.box_length};
+  const real_t density{N / volume};
+  return std::cbrt(3.0_r / (4.0_r * std::numbers::pi_v<real_t> * density));
 }
 
 JastrowOptimizer::Result JastrowOptimizer::optimize(const Config& base_config, bool verbose) {
-  const double R_S{compute_rs(base_config)};
+  const real_t R_S{compute_rs(base_config)};
   const std::size_t N{base_config.num_particles};
 
   // b controls the inverse Jastrow range: effective range ~ 1/b.
@@ -28,8 +28,8 @@ JastrowOptimizer::Result JastrowOptimizer::optimize(const Config& base_config, b
   // b_max = 5.0: at b=5 the Jastrow range is 0.2 bohr, capturing only
   //         the electron-electron cusp with negligible correlation beyond.
   //         The energy is flat well before this point.
-  const double b_min{1.0 / R_S};
-  const double b_max{std::max(5.0, b_min + 0.5)};
+  const real_t b_min{1.0_r / R_S};
+  const real_t b_max{std::max(5.0_r, b_min + 0.5_r)};
   const std::size_t grid_points{2U * base_config.num_threads};
 
   // Adapt scan statistics based on system size.
@@ -48,10 +48,10 @@ JastrowOptimizer::Result JastrowOptimizer::optimize(const Config& base_config, b
   }
 
   // Build b values
-  std::vector<double> b_values(grid_points);
+  std::vector<real_t> b_values(grid_points);
   for (std::size_t i = 0; i < grid_points; ++i) {
     b_values[i] =
-        b_min + (b_max - b_min) * static_cast<double>(i) / static_cast<double>(grid_points - 1);
+        b_min + (b_max - b_min) * static_cast<real_t>(i) / static_cast<real_t>(grid_points - 1);
   }
 
   // Phase 1: parallel grid scan
@@ -59,7 +59,7 @@ JastrowOptimizer::Result JastrowOptimizer::optimize(const Config& base_config, b
   futures.reserve(grid_points);
 
   for (std::size_t i = 0; i < grid_points; ++i) {
-    const double b{b_values[i]};
+    const real_t b{b_values[i]};
     const std::size_t warmup{scan_warmup};
     const std::size_t measure{scan_measure};
     futures.push_back(std::async(std::launch::async, [&base_config, b, warmup, measure]() {
@@ -84,9 +84,9 @@ JastrowOptimizer::Result JastrowOptimizer::optimize(const Config& base_config, b
   // second-best, the long-range Jastrow bias is dominating. In that case,
   // skip the boundary point and take the best of the interior points.
   // "Significantly lower" = more than 2x the spread of the interior points.
-  double best_b{1.0};
-  double best_energy{std::numeric_limits<double>::max()};
-  double second_best_energy{std::numeric_limits<double>::max()};
+  real_t best_b{1.0_r};
+  real_t best_energy{std::numeric_limits<real_t>::max()};
+  real_t second_best_energy{std::numeric_limits<real_t>::max()};
 
   for (const auto& r : results) {
     if (r.energy < best_energy) {
@@ -99,31 +99,31 @@ JastrowOptimizer::Result JastrowOptimizer::optimize(const Config& base_config, b
   }
 
   // Check if the winner is the boundary point and an outlier
-  const bool at_boundary{std::abs(best_b - b_min) < 1e-10};
+  const bool at_boundary{std::abs(best_b - b_min) < 1e-10_r};
   if (at_boundary && results.size() > 2) {
     // Compute the energy spread of all non-boundary points
-    double interior_min{std::numeric_limits<double>::max()};
-    double interior_max{std::numeric_limits<double>::lowest()};
+    real_t interior_min{std::numeric_limits<real_t>::max()};
+    real_t interior_max{std::numeric_limits<real_t>::lowest()};
     for (const auto& r : results) {
-      if (std::abs(r.b - b_min) < 1e-10)
+      if (std::abs(r.b - b_min) < 1e-10_r)
         continue;
       interior_min = std::min(interior_min, r.energy);
       interior_max = std::max(interior_max, r.energy);
     }
-    const double interior_spread{interior_max - interior_min};
-    const double boundary_gap{interior_min - best_energy};
+    const real_t interior_spread{interior_max - interior_min};
+    const real_t boundary_gap{interior_min - best_energy};
 
     // If the boundary point is more than 2x the interior spread below
     // the interior minimum, it's an artifact; use the interior best instead.
-    if (boundary_gap > 2.0 * interior_spread) {
+    if (boundary_gap > 2.0_r * interior_spread) {
       if (verbose) {
         std::cout << "[Optimizer] Boundary b=" << std::setprecision(3) << best_b
                   << " rejected (artifact), using interior best\n";
       }
-      best_b = 1.0;
-      best_energy = std::numeric_limits<double>::max();
+      best_b = 1.0_r;
+      best_energy = std::numeric_limits<real_t>::max();
       for (const auto& r : results) {
-        if (std::abs(r.b - b_min) < 1e-10)
+        if (std::abs(r.b - b_min) < 1e-10_r)
           continue;
         if (r.energy < best_energy) {
           best_energy = r.energy;
@@ -137,12 +137,12 @@ JastrowOptimizer::Result JastrowOptimizer::optimize(const Config& base_config, b
     std::cout << "[Optimizer] Result: b=" << std::setprecision(4) << best_b << "\n";
   }
 
-  return Result{.optimal_b = best_b, .energy = best_energy, .standard_error = 0.0};
+  return Result{.optimal_b = best_b, .energy = best_energy, .standard_error = 0.0_r};
 }
 
 JastrowOptimizer::EvalResult JastrowOptimizer::evaluate(
   const Config& base_config,
-  double b,
+  real_t b,
   std::size_t warmup_sweeps,
   std::size_t measure_sweeps
 ) {
@@ -160,7 +160,7 @@ JastrowOptimizer::EvalResult JastrowOptimizer::evaluate(
   cfg.block_size = std::max<std::size_t>(50U, measure_sweeps / 5U);
   cfg.warmup_steps = cfg.num_particles * warmup_sweeps;
   cfg.measure_steps = cfg.num_particles * measure_sweeps;
-  cfg.step_size = base_config.box_length / 10.0;
+  cfg.step_size = base_config.box_length / 10.0_r;
 
   Simulation sim{cfg};
   const auto summary{sim.run()};
@@ -168,6 +168,6 @@ JastrowOptimizer::EvalResult JastrowOptimizer::evaluate(
   return EvalResult{
     .b = b,
     .energy = summary.mean_energy,
-    .standard_error = summary.standard_error.value_or(0.0)
+    .standard_error = summary.standard_error.value_or(0.0_r)
   };
 }

--- a/src/optimizer/jastrow_optimizer.hpp
+++ b/src/optimizer/jastrow_optimizer.hpp
@@ -5,9 +5,9 @@
 class JastrowOptimizer {
 public:
   struct Result {
-    double optimal_b;
-    double energy;
-    double standard_error;
+    real_t optimal_b;
+    real_t energy;
+    real_t standard_error;
   };
 
   // Optimize the Jastrow b parameter for the given config.
@@ -18,16 +18,16 @@ public:
 
 private:
   struct EvalResult {
-    double b;
-    double energy;
-    double standard_error;
+    real_t b;
+    real_t energy;
+    real_t standard_error;
   };
 
   [[nodiscard]] static EvalResult evaluate(
     const Config& base_config,
-    double b,
+    real_t b,
     std::size_t warmup_sweeps,
     std::size_t measure_sweeps
   );
-  [[nodiscard]] static double compute_rs(const Config& cfg);
+  [[nodiscard]] static real_t compute_rs(const Config& cfg);
 };

--- a/src/output_writer/output_writer.cpp
+++ b/src/output_writer/output_writer.cpp
@@ -49,7 +49,7 @@ void write_json_string(std::ostream& out, std::string_view value) {
   out << '"';
 }
 
-void write_positions(std::ostream& out, const std::vector<double>& positions) {
+void write_positions(std::ostream& out, const std::vector<real_t>& positions) {
   out << '[';
   for (std::size_t i{}; i < positions.size(); ++i) {
     if (i != 0U) {
@@ -65,7 +65,7 @@ void write_positions(std::ostream& out, const std::vector<double>& positions) {
 JsonOutputWriter::JsonOutputWriter(std::ostream& out)
 : out_{out}
 {
-  out_.precision(std::numeric_limits<double>::max_digits10);
+  out_.precision(std::numeric_limits<real_t>::max_digits10);
 }
 
 void JsonOutputWriter::write_init(const InitData& data) {
@@ -134,7 +134,7 @@ BinOutputWriter::BinOutputWriter(std::ostream& out)
 
 void BinOutputWriter::write_init(const InitData& data) {
   const uint64_t np{static_cast<uint64_t>(data.num_particles)};
-  const double bl{data.box_length};
+  const real_t bl{data.box_length};
   const uint64_t ms{static_cast<uint64_t>(data.measure_steps)};
   out_.write(reinterpret_cast<const char*>(&np), sizeof(np));
   out_.write(reinterpret_cast<const char*>(&bl), sizeof(bl));
@@ -143,14 +143,14 @@ void BinOutputWriter::write_init(const InitData& data) {
 }
 
 void BinOutputWriter::write_frame(const FrameData& data) {
-  const double se{data.standard_error.value_or(0.0)};
-  out_.write(reinterpret_cast<const char*>(&data.local_energy), sizeof(double));
-  out_.write(reinterpret_cast<const char*>(&data.mean_energy), sizeof(double));
-  out_.write(reinterpret_cast<const char*>(&se), sizeof(double));
-  out_.write(reinterpret_cast<const char*>(&data.acceptance_rate), sizeof(double));
+  const real_t se{data.standard_error.value_or(0.0_r)};
+  out_.write(reinterpret_cast<const char*>(&data.local_energy), sizeof(real_t));
+  out_.write(reinterpret_cast<const char*>(&data.mean_energy), sizeof(real_t));
+  out_.write(reinterpret_cast<const char*>(&se), sizeof(real_t));
+  out_.write(reinterpret_cast<const char*>(&data.acceptance_rate), sizeof(real_t));
   out_.write(
     reinterpret_cast<const char*>(data.positions.data()),
-    static_cast<std::streamsize>(data.positions.size() * sizeof(double))
+    static_cast<std::streamsize>(data.positions.size() * sizeof(real_t))
   );
 }
 

--- a/src/output_writer/output_writer.hpp
+++ b/src/output_writer/output_writer.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "../utilities/macros.hpp"
+
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -12,10 +14,10 @@ struct InitData {
   std::string run_id;
 
   std::size_t num_particles;
-  double box_length;
+  real_t box_length;
   std::size_t warmup_steps;
   std::size_t measure_steps;
-  double step_size;
+  real_t step_size;
   uint64_t seed;
   std::size_t block_size;
 };
@@ -24,19 +26,19 @@ struct FrameData {
   std::size_t step;
   std::size_t accepted;
   std::size_t proposed;
-  double acceptance_rate;
-  double local_energy;
-  double mean_energy;
-  std::optional<double> standard_error;
-  std::vector<double> positions; // size = 3 * num_particles
+  real_t acceptance_rate;
+  real_t local_energy;
+  real_t mean_energy;
+  std::optional<real_t> standard_error;
+  std::vector<real_t> positions; // size = 3 * num_particles
 };
 
 struct DoneData {
   std::size_t total_accepted;
   std::size_t total_proposed;
-  double final_acceptance_rate;
-  double final_mean_energy;
-  std::optional<double> final_standard_error;
+  real_t final_acceptance_rate;
+  real_t final_mean_energy;
+  std::optional<real_t> final_standard_error;
 };
 
 enum class OutputFormat { JSON, CSV, BIN };

--- a/src/particles/particles.hpp
+++ b/src/particles/particles.hpp
@@ -23,7 +23,7 @@ private:
     LAP_LOG_PSI,
     NUM_SUB_ARRAYS
   };
-  AlignedSoA<double> data_;
+  AlignedSoA<real_t> data_;
 
 public:
   explicit Particles(std::size_t num_particles)
@@ -34,12 +34,12 @@ public:
   [[nodiscard]] std::size_t size() const { return size_; }
   [[nodiscard]] std::size_t p_stride() const { return data_.stride(); }
 
-  [[nodiscard]] double*       lap_log_psi()       noexcept { return data_[LAP_LOG_PSI]; }
-  [[nodiscard]] double const* lap_log_psi() const noexcept { return data_[LAP_LOG_PSI]; }
+  [[nodiscard]] real_t*       lap_log_psi()       noexcept { return data_[LAP_LOG_PSI]; }
+  [[nodiscard]] real_t const* lap_log_psi() const noexcept { return data_[LAP_LOG_PSI]; }
 
-  Ptr3D<      double> pos()       noexcept { return {data_[POS_X], data_[POS_Y], data_[POS_Z]}; }
-  Ptr3D<const double> pos() const noexcept { return {data_[POS_X], data_[POS_Y], data_[POS_Z]}; }
+  Ptr3D<      real_t> pos()       noexcept { return {data_[POS_X], data_[POS_Y], data_[POS_Z]}; }
+  Ptr3D<const real_t> pos() const noexcept { return {data_[POS_X], data_[POS_Y], data_[POS_Z]}; }
 
-  Ptr3D<      double> grad_log_psi()       noexcept { return {data_[GRAD_X], data_[GRAD_Y], data_[GRAD_Z]}; }
-  Ptr3D<const double> grad_log_psi() const noexcept { return {data_[GRAD_X], data_[GRAD_Y], data_[GRAD_Z]}; }
+  Ptr3D<      real_t> grad_log_psi()       noexcept { return {data_[GRAD_X], data_[GRAD_Y], data_[GRAD_Z]}; }
+  Ptr3D<const real_t> grad_log_psi() const noexcept { return {data_[GRAD_X], data_[GRAD_Y], data_[GRAD_Z]}; }
 };

--- a/src/simulation/simulation.cpp
+++ b/src/simulation/simulation.cpp
@@ -14,7 +14,7 @@ Simulation::Simulation(Config config, std::unique_ptr<OutputWriter> output_write
 , particles_{config_.num_particles}
 , wave_function_{particles_, config_.box_length, config_.jastrow_a, config_.jastrow_b}
 , blocking_analysis_{config_.block_size}
-, energy_tracker_{config_.box_length, static_cast<double>(config_.num_particles)}
+, energy_tracker_{config_.box_length, static_cast<real_t>(config_.num_particles)}
 , output_writer_{std::move(output_writer)}
 , proposed_{}
 , accepted_{}
@@ -24,11 +24,11 @@ Simulation::Simulation(Config config, std::unique_ptr<OutputWriter> output_write
 , pick_particle_{0, config_.num_particles - 1}
 { }
 
-std::vector<double> Simulation::positions_snapshot() const {
+std::vector<real_t> Simulation::positions_snapshot() const {
   const std::size_t N{particles_.size()};
   auto [p_x, p_y, p_z]{particles_.pos().align()};
 
-  std::vector<double> positions{};
+  std::vector<real_t> positions{};
   positions.reserve(N * 3U);
 
   for (std::size_t i{}; i < N; ++i) {
@@ -41,7 +41,7 @@ std::vector<double> Simulation::positions_snapshot() const {
 
 void Simulation::initialize_positions() {
   const std::size_t N{particles_.size()};
-  const double length{config_.box_length};
+  const real_t length{config_.box_length};
   auto [p_x, p_y, p_z]{particles_.pos().align()};
 
   constexpr std::size_t MAX_INIT_ATTEMPTS{100};
@@ -71,12 +71,12 @@ Simulation::StepResult Simulation::metropolis_step() {
   auto [p_x, p_y, p_z]{particles_.pos().align()};
 
   const std::size_t rand{rand_particle()};
-  const double L{config_.box_length};
-  const double inv_L{1.0 / L};
+  const real_t L{config_.box_length};
+  const real_t inv_L{1.0_r / L};
 
-  const double old_x{p_x[rand]};
-  const double old_y{p_y[rand]};
-  const double old_z{p_z[rand]};
+  const real_t old_x{p_x[rand]};
+  const real_t old_y{p_y[rand]};
+  const real_t old_z{p_z[rand]};
 
   p_x[rand] += rand_proposal();
   p_y[rand] += rand_proposal();
@@ -92,20 +92,20 @@ Simulation::StepResult Simulation::metropolis_step() {
   slater.save_trig_row(rand);
   slater.update_trig_cache(rand, particles_);
 
-  const double* new_row{slater.build_row(rand)};
-  const double slater_ratio{slater.determinant_ratio(rand, new_row)};
+  const real_t* new_row{slater.build_row(rand)};
+  const real_t slater_ratio{slater.determinant_ratio(rand, new_row)};
 
-  const double delta_jastrow{
+  const real_t delta_jastrow{
     wave_function_.jastrow_pade().delta_value(
       particles_,
       rand, old_x, old_y, old_z
     )
   };
-  const double log_ratio_sq{2.0 * std::log(std::abs(slater_ratio)) + 2.0 * delta_jastrow};
+  const real_t log_ratio_sq{2.0_r * std::log(std::abs(slater_ratio)) + 2.0_r * delta_jastrow};
 
-  const double u{std::max(rand_uniform(), std::numeric_limits<double>::min())};
-  const double log_u{std::log(u)};
-  const double min_term{std::min(0.0, log_ratio_sq)};
+  const real_t u{std::max(rand_uniform(), std::numeric_limits<real_t>::min())};
+  const real_t log_u{std::log(u)};
+  const real_t min_term{std::min(0.0_r, log_ratio_sq)};
 
   const bool accepted{log_u < min_term};
 
@@ -131,7 +131,7 @@ Simulation::StepResult Simulation::metropolis_step() {
 }
 
 void Simulation::warmup() {
-  double& step_size{config_.step_size};
+  real_t& step_size{config_.step_size};
 
   const std::size_t warmup_steps{config_.warmup_steps};
   const std::size_t warmup_batch_size{particles_.size()};
@@ -139,9 +139,9 @@ void Simulation::warmup() {
   std::size_t window_proposed{};
   std::size_t window_accepted{};
 
-  double acceptance_rate_window{};
-  const double acceptance_target{0.50};
-  const double gain{0.25};
+  real_t acceptance_rate_window{};
+  const real_t acceptance_target{0.50_r};
+  const real_t gain{0.25_r};
 
   for (std::size_t i{}; i < warmup_steps; i++) {
     window_proposed++;
@@ -151,15 +151,15 @@ void Simulation::warmup() {
 
     if (window_proposed % warmup_batch_size == 0) {
       acceptance_rate_window =
-          static_cast<double>(window_accepted) / static_cast<double>(window_proposed);
-      step_size *= exp(gain * (acceptance_rate_window - acceptance_target));
+          static_cast<real_t>(window_accepted) / static_cast<real_t>(window_proposed);
+      step_size *= static_cast<real_t>(exp(gain * (acceptance_rate_window - acceptance_target)));
 
-      const double MAX_STEP{config_.box_length * 0.5};
+      const real_t MAX_STEP{config_.box_length * 0.5_r};
       if (step_size > MAX_STEP) {
         step_size = MAX_STEP;
       }
 
-      proposal_.param(std::uniform_real_distribution<double>::param_type(-step_size, step_size));
+      proposal_.param(std::uniform_real_distribution<real_t>::param_type(-step_size, step_size));
 
       window_accepted = 0;
       window_proposed = 0;
@@ -177,9 +177,9 @@ Simulation::MeasurementSummary Simulation::measure() {
   proposed_ = 0U;
   accepted_ = 0U;
 
-  double running_energy_sum{};
-  double final_mean_energy{};
-  std::optional<double> final_standard_error{};
+  real_t running_energy_sum{};
+  real_t final_mean_energy{};
+  std::optional<real_t> final_standard_error{};
 
   for (std::size_t i = 0; i < measure_steps; ++i) {
     ++proposed_;
@@ -193,14 +193,14 @@ Simulation::MeasurementSummary Simulation::measure() {
       result.old_x, result.old_y, result.old_z
     );
 
-    const double E_local{energy_tracker.eval_total_energy(particles)};
+    const real_t E_local{energy_tracker.eval_total_energy(particles)};
     running_energy_sum += E_local;
     blocking_analysis.add(E_local);
 
-    const double running_mean{running_energy_sum / static_cast<double>(i + 1U)};
+    const real_t running_mean{running_energy_sum / static_cast<real_t>(i + 1U)};
     final_mean_energy = running_mean;
 
-    std::optional<double> frame_standard_error{};
+    std::optional<real_t> frame_standard_error{};
     if (blocking_analysis.ready()) {
       const auto [blocked_mean, standard_error]{blocking_analysis.mean_and_standard_error()};
       final_mean_energy = blocked_mean;

--- a/src/simulation/simulation.hpp
+++ b/src/simulation/simulation.hpp
@@ -24,39 +24,39 @@ private:
 
   std::size_t proposed_;
   std::size_t accepted_;
-  double log_psi_current_;
+  real_t log_psi_current_;
 
   std::mt19937_64 rng_;
-  std::uniform_real_distribution<double> uniform01_{0.0, 1.0};
-  std::uniform_real_distribution<double> proposal_;
+  std::uniform_real_distribution<real_t> uniform01_{0.0_r, 1.0_r};
+  std::uniform_real_distribution<real_t> proposal_;
   std::uniform_int_distribution<std::size_t> pick_particle_;
 
-  [[nodiscard]] double rand_uniform() { return uniform01_(rng_); }
-  [[nodiscard]] double rand_proposal() { return proposal_(rng_); }
+  [[nodiscard]] real_t rand_uniform() { return uniform01_(rng_); }
+  [[nodiscard]] real_t rand_proposal() { return proposal_(rng_); }
   [[nodiscard]] std::size_t rand_particle() { return pick_particle_(rng_); }
 
-  [[nodiscard]] double acceptance_rate() const {
+  [[nodiscard]] real_t acceptance_rate() const {
     if (proposed_ == 0U) {
-      return 0.0;
+      return 0.0_r;
     }
-    return static_cast<double>(accepted_) / static_cast<double>(proposed_);
+    return static_cast<real_t>(accepted_) / static_cast<real_t>(proposed_);
   }
 
   struct StepResult {
     bool accepted;
     std::size_t moved_particle;
-    double old_x;
-    double old_y;
-    double old_z;
+    real_t old_x;
+    real_t old_y;
+    real_t old_z;
   };
 
-  [[nodiscard]] std::vector<double> positions_snapshot() const;
+  [[nodiscard]] std::vector<real_t> positions_snapshot() const;
 
 public:
   struct MeasurementSummary {
-    double mean_energy;
-    std::optional<double> standard_error;
-    double acceptance_rate;
+    real_t mean_energy;
+    std::optional<real_t> standard_error;
+    real_t acceptance_rate;
   };
 
   explicit Simulation(Config cfg, std::unique_ptr<OutputWriter> output_writer = nullptr);

--- a/src/slater_plane_wave/slater_plane_wave.cpp
+++ b/src/slater_plane_wave/slater_plane_wave.cpp
@@ -26,9 +26,9 @@
 //
 // Orbital count: N = 1 + 2 × (number of nonzero canonical k-vectors)
 // Closed shells: N = 1, 7, 19, 27, 33, 57, ...
-SlaterPlaneWave::SlaterPlaneWave(const Particles& particles, double box_lengthL)
+SlaterPlaneWave::SlaterPlaneWave(const Particles& particles, real_t box_lengthL)
 : num_orbitals_{particles.size()}
-, matrix_row_stride_{AlignedSoA<double>::round_up(particles.size())}
+, matrix_row_stride_{AlignedSoA<real_t>::round_up(particles.size())}
 , matrix_size_{matrix_row_stride_ * particles.size()}
 , box_length_{box_lengthL}
 , orbital_k_index_(particles.size())
@@ -54,7 +54,7 @@ SlaterPlaneWave::SlaterPlaneWave(const Particles& particles, double box_lengthL)
   };
 
   // Increase vector size to be safe
-  const int N_MAX{static_cast<int>(std::ceil(std::cbrt(static_cast<double>(N)))) + 2};
+  const int N_MAX{static_cast<int>(std::ceil(std::cbrt(static_cast<real_t>(N)))) + 2};
   const std::size_t side{static_cast<std::size_t>((2 * N_MAX + 1))};
 
   // Vector for all possible n-vector candidates
@@ -124,26 +124,26 @@ SlaterPlaneWave::SlaterPlaneWave(const Particles& particles, double box_lengthL)
   }
 
   num_unique_k_ = k_idx;
-  trig_row_stride_ = AlignedSoA<double>::round_up(k_idx);
+  trig_row_stride_ = AlignedSoA<real_t>::round_up(k_idx);
 
   const auto kv{k_vector().align()};
 
-  const double inv_L{1.0 / box_length()};
+  const real_t inv_L{1.0_r / box_length()};
 
   // Follows the calculation: K = (2pi/L) * n;
   #pragma omp simd
   for (std::size_t i = 0; i < k_idx; ++i) {
-    kv.x_[i] = 2 * std::numbers::pi * inv_L * static_cast<double>(nv.x_[i]);
-    kv.y_[i] = 2 * std::numbers::pi * inv_L * static_cast<double>(nv.y_[i]);
-    kv.z_[i] = 2 * std::numbers::pi * inv_L * static_cast<double>(nv.z_[i]);
+    kv.x_[i] = 2.0_r * std::numbers::pi_v<real_t> * inv_L * static_cast<real_t>(nv.x_[i]);
+    kv.y_[i] = 2.0_r * std::numbers::pi_v<real_t> * inv_L * static_cast<real_t>(nv.y_[i]);
+    kv.z_[i] = 2.0_r * std::numbers::pi_v<real_t> * inv_L * static_cast<real_t>(nv.z_[i]);
   }
 
-  trig_cache_ = AlignedSoA<double>(num_particles * trig_row_stride(), NUM_TRIG_ARRAYS);
-  trig_scratch_ = AlignedSoA<double>(num_unique_k(), NUM_SCRATCH_TRIG);
+  trig_cache_ = AlignedSoA<real_t>(num_particles * trig_row_stride(), NUM_TRIG_ARRAYS);
+  trig_scratch_ = AlignedSoA<real_t>(num_unique_k(), NUM_SCRATCH_TRIG);
 
   std::size_t trig_size{trig_cache_.num_elements()};
-  std::fill_n(sin_cache(), trig_size, 0.0);
-  std::fill_n(cos_cache(), trig_size, 0.0);
+  std::fill_n(sin_cache(), trig_size, 0.0_r);
+  std::fill_n(cos_cache(), trig_size, 0.0_r);
 };
 
 void SlaterPlaneWave::save_trig_row(std::size_t particle) noexcept {
@@ -151,8 +151,8 @@ void SlaterPlaneWave::save_trig_row(std::size_t particle) noexcept {
   const std::size_t ROW_STRIDE{trig_row_stride()};
   const std::size_t offset{particle * ROW_STRIDE};
 
-  std::memcpy(trig_scratch_[SIN_SAVED], sin_cache() + offset, num_k * sizeof(double));
-  std::memcpy(trig_scratch_[COS_SAVED], cos_cache() + offset, num_k * sizeof(double));
+  std::memcpy(trig_scratch_[SIN_SAVED], sin_cache() + offset, num_k * sizeof(real_t));
+  std::memcpy(trig_scratch_[COS_SAVED], cos_cache() + offset, num_k * sizeof(real_t));
 }
 
 void SlaterPlaneWave::restore_trig_row(std::size_t particle) noexcept {
@@ -160,8 +160,8 @@ void SlaterPlaneWave::restore_trig_row(std::size_t particle) noexcept {
   const std::size_t ROW_STRIDE{trig_row_stride()};
   const std::size_t offset{particle * ROW_STRIDE};
 
-  std::memcpy(sin_cache() + offset, trig_scratch_[SIN_SAVED], num_k * sizeof(double));
-  std::memcpy(cos_cache() + offset, trig_scratch_[COS_SAVED], num_k * sizeof(double));
+  std::memcpy(sin_cache() + offset, trig_scratch_[SIN_SAVED], num_k * sizeof(real_t));
+  std::memcpy(cos_cache() + offset, trig_scratch_[COS_SAVED], num_k * sizeof(real_t));
 }
 
 void SlaterPlaneWave::update_trig_cache(std::size_t particle, const Particles& particles) noexcept {
@@ -171,15 +171,15 @@ void SlaterPlaneWave::update_trig_cache(std::size_t particle, const Particles& p
   const auto pos{particles.pos().align()};
   const auto kv{k_vector().align()};
 
-  double* RESTRICT c_row{cos_cache() + particle * ROW_STRIDE};
-  double* RESTRICT s_row{sin_cache() + particle * ROW_STRIDE};
+  real_t* RESTRICT c_row{cos_cache() + particle * ROW_STRIDE};
+  real_t* RESTRICT s_row{sin_cache() + particle * ROW_STRIDE};
 
   ASSUME_ALIGNED(c_row, SIMD_BYTES);
   ASSUME_ALIGNED(s_row, SIMD_BYTES);
 
   #pragma omp simd
   for (std::size_t k = 0; k < num_k; ++k) {
-    const double dot{
+    const real_t dot{
       kv.x_[k] * pos.x_[particle] +
       kv.y_[k] * pos.y_[particle] +
       kv.z_[k] * pos.z_[particle]
@@ -189,7 +189,7 @@ void SlaterPlaneWave::update_trig_cache(std::size_t particle, const Particles& p
   }
 }
 
-double SlaterPlaneWave::log_abs_det(const Particles& particles) {
+real_t SlaterPlaneWave::log_abs_det(const Particles& particles) {
   const std::size_t N{num_orbitals()};
   const std::size_t S{matrix_row_stride()};
   const std::size_t padded_N{particles.p_stride()};
@@ -200,18 +200,18 @@ double SlaterPlaneWave::log_abs_det(const Particles& particles) {
   const auto& k_index{orbital_k_index()};
   const auto& orb_type{orbital_type()};
 
-  double* RESTRICT det_matrix{determinant()};
-  double* RESTRICT lower_upper_matrix{lower_upper()};
-  double* RESTRICT inv_det_matrix{inv_determinant()};
+  real_t* RESTRICT det_matrix{determinant()};
+  real_t* RESTRICT lower_upper_matrix{lower_upper()};
+  real_t* RESTRICT inv_det_matrix{inv_determinant()};
 
   int* RESTRICT pivot_vector{pivot()};
 
-  double* RESTRICT rhs{this->rhs()};
-  double* RESTRICT solution{this->solution()};
+  real_t* RESTRICT rhs{this->rhs()};
+  real_t* RESTRICT solution{this->solution()};
 
   const std::size_t num_k{num_unique_k()};
-  double* RESTRICT cos_cache{this->cos_cache()};
-  double* RESTRICT sin_cache{this->sin_cache()};
+  real_t* RESTRICT cos_cache{this->cos_cache()};
+  real_t* RESTRICT sin_cache{this->sin_cache()};
 
   ASSUME_ALIGNED(det_matrix, SIMD_BYTES);
   ASSUME_ALIGNED(lower_upper_matrix, SIMD_BYTES);
@@ -232,7 +232,7 @@ double SlaterPlaneWave::log_abs_det(const Particles& particles) {
 
     #pragma omp simd
     for (std::size_t k = 0; k < num_k; ++k) {
-      const double dot{
+      const real_t dot{
         kv.x_[k] * pos.x_[particle] +
         kv.y_[k] * pos.y_[particle] +
         kv.z_[k] * pos.z_[particle]
@@ -247,9 +247,9 @@ double SlaterPlaneWave::log_abs_det(const Particles& particles) {
     for (std::size_t orbital = 0; orbital < N; ++orbital) {
       const std::size_t k_idx{k_index[orbital]};
 
-      const double type{static_cast<double>(orb_type[orbital])};
-      const double cos_term{cos_cache[offset + k_idx]};
-      const double sin_term{sin_cache[offset + k_idx]};
+      const real_t type{static_cast<real_t>(orb_type[orbital])};
+      const real_t cos_term{cos_cache[offset + k_idx]};
+      const real_t sin_term{sin_cache[offset + k_idx]};
 
       det_matrix[particle * S + orbital] = cos_term + type * (sin_term - cos_term);
     }
@@ -264,26 +264,26 @@ double SlaterPlaneWave::log_abs_det(const Particles& particles) {
   );
 
   // Compute log|det(D)| = Σ log|U_ii|
-  double log_abs_det{};
+  real_t log_abs_det{};
 
   #pragma omp simd reduction(+ : log_abs_det)
   for (std::size_t diag = 0; diag < N; ++diag) {
-    const double U_ii{lower_upper_matrix[diag * S + diag]};
-    const double abs_U_ii{std::abs(U_ii)};
+    const real_t U_ii{lower_upper_matrix[diag * S + diag]};
+    const real_t abs_U_ii{std::abs(U_ii)};
 
     log_abs_det += std::log(abs_U_ii);
   }
 
   if (!std::isfinite(log_abs_det)) {
-    return -std::numeric_limits<double>::infinity();
+    return -std::numeric_limits<real_t>::infinity();
   }
 
   for (std::size_t column = 0; column < N; ++column) {
     // Using pointer arithmetic to start at rhs[start]
     // and jump to rhs[end] - used padded_N since
     // SIMD alignment might mess up pointer math
-    std::fill(rhs, rhs + padded_N, 0.0);
-    rhs[column] = 1.0;
+    std::fill(rhs, rhs + padded_N, 0.0_r);
+    rhs[column] = 1.0_r;
 
     solve_lower_upper(lower_upper_matrix, pivot_vector, rhs, solution, N, S);
 
@@ -295,16 +295,16 @@ double SlaterPlaneWave::log_abs_det(const Particles& particles) {
   return log_abs_det;
 }
 
-double* SlaterPlaneWave::build_row(std::size_t particle) noexcept {
+real_t* SlaterPlaneWave::build_row(std::size_t particle) noexcept {
   const std::size_t N{num_orbitals()};
   const std::size_t ROW_STRIDE{trig_row_stride()};
 
   const auto& k_index{orbital_k_index()};
   const auto& orb_type{orbital_type()};
 
-  double* RESTRICT row{new_row()};
-  double* RESTRICT sin_cache{this->sin_cache()};
-  double* RESTRICT cos_cache{this->cos_cache()};
+  real_t* RESTRICT row{new_row()};
+  real_t* RESTRICT sin_cache{this->sin_cache()};
+  real_t* RESTRICT cos_cache{this->cos_cache()};
 
   ASSUME_ALIGNED(row, SIMD_BYTES);
   ASSUME_ALIGNED(sin_cache, SIMD_BYTES);
@@ -314,10 +314,10 @@ double* SlaterPlaneWave::build_row(std::size_t particle) noexcept {
   for (std::size_t orbital = 0; orbital < N; ++orbital) {
     const std::size_t k_idx{k_index[orbital]};
 
-    const double type{static_cast<double>(orb_type[orbital])};
+    const real_t type{static_cast<real_t>(orb_type[orbital])};
 
-    const double cos_term{cos_cache[particle * ROW_STRIDE + k_idx]};
-    const double sin_term{sin_cache[particle * ROW_STRIDE + k_idx]};
+    const real_t cos_term{cos_cache[particle * ROW_STRIDE + k_idx]};
+    const real_t sin_term{sin_cache[particle * ROW_STRIDE + k_idx]};
 
     row[orbital] = cos_term + type * (sin_term - cos_term);
   }
@@ -325,16 +325,16 @@ double* SlaterPlaneWave::build_row(std::size_t particle) noexcept {
   return row;
 }
 
-double SlaterPlaneWave::determinant_ratio(
+real_t SlaterPlaneWave::determinant_ratio(
   std::size_t particle,
-  const double* new_row
+  const real_t* new_row
 ) const noexcept {
   const std::size_t N{num_orbitals()};
   const std::size_t S{matrix_row_stride()};
-  const double* RESTRICT inv_det{inv_determinant()};
+  const real_t* RESTRICT inv_det{inv_determinant()};
   ASSUME_ALIGNED(inv_det, SIMD_BYTES);
 
-  double ratio{};
+  real_t ratio{};
   #pragma omp simd reduction(+ : ratio)
   for (std::size_t j = 0; j < N; ++j) {
     ratio += new_row[j] * inv_det[particle * S + j];
@@ -345,21 +345,21 @@ double SlaterPlaneWave::determinant_ratio(
 
 void SlaterPlaneWave::accept_move(
   std::size_t particle,
-  const double* new_row,
-  double ratio
+  const real_t* new_row,
+  real_t ratio
 ) noexcept {
   const std::size_t N{num_orbitals()};
   const std::size_t S{matrix_row_stride()};
 
-  double* RESTRICT inv_det{inv_determinant()};
-  double* RESTRICT det_matrix{determinant()};
-  double* RESTRICT inv_d_col{this->inv_d_col()};
+  real_t* RESTRICT inv_det{inv_determinant()};
+  real_t* RESTRICT det_matrix{determinant()};
+  real_t* RESTRICT inv_d_col{this->inv_d_col()};
 
   ASSUME_ALIGNED(inv_det, SIMD_BYTES);
   ASSUME_ALIGNED(det_matrix, SIMD_BYTES);
   ASSUME_ALIGNED(inv_d_col, SIMD_BYTES);
 
-  const double inv_ratio{1.0 / ratio};
+  const real_t inv_ratio{1.0_r / ratio};
 
   if (!std::isfinite(inv_ratio)) {
     return;
@@ -380,7 +380,7 @@ void SlaterPlaneWave::accept_move(
       continue;
 
     const std::size_t k_offset{k * S}; // Pre-calculate row offset
-    double s_k{};
+    real_t s_k{};
 
     // Compiler can now easily auto-vectorize this
     #pragma omp simd reduction(+ : s_k)
@@ -388,7 +388,7 @@ void SlaterPlaneWave::accept_move(
       s_k += new_row[m] * inv_det[k_offset + m];
     }
 
-    const double factor{s_k * inv_ratio};
+    const real_t factor{s_k * inv_ratio};
 
     #pragma omp simd
     for (std::size_t j = 0; j < N; ++j) {
@@ -410,10 +410,10 @@ void SlaterPlaneWave::accept_move(
 }
 
 void SlaterPlaneWave::add_derivatives(
-  double* RESTRICT grad_x,
-  double* RESTRICT grad_y,
-  double* RESTRICT grad_z,
-  double* RESTRICT laplacian
+  real_t* RESTRICT grad_x,
+  real_t* RESTRICT grad_y,
+  real_t* RESTRICT grad_z,
+  real_t* RESTRICT laplacian
 ) const noexcept {
   const std::size_t N{num_orbitals()};
   const std::size_t S{matrix_row_stride()};
@@ -423,9 +423,9 @@ void SlaterPlaneWave::add_derivatives(
   const auto& k_index{orbital_k_index()};
   const auto& o_type{orbital_type()};
 
-  const double* RESTRICT inv_det{inv_determinant()};
-  const double* RESTRICT cos_cache{this->cos_cache()};
-  const double* RESTRICT sin_cache{this->sin_cache()};
+  const real_t* RESTRICT inv_det{inv_determinant()};
+  const real_t* RESTRICT cos_cache{this->cos_cache()};
+  const real_t* RESTRICT sin_cache{this->sin_cache()};
 
   ASSUME_ALIGNED(inv_det, SIMD_BYTES);
   ASSUME_ALIGNED(cos_cache, SIMD_BYTES);
@@ -437,8 +437,8 @@ void SlaterPlaneWave::add_derivatives(
   ASSUME_ALIGNED(laplacian, SIMD_BYTES);
 
   for (std::size_t particle = 0; particle < N; ++particle) {
-    double d_log_det_dx{}, d_log_det_dy{}, d_log_det_dz{};
-    double laplace_det_term{};
+    real_t d_log_det_dx{}, d_log_det_dy{}, d_log_det_dz{};
+    real_t laplace_det_term{};
 
     const std::size_t offset{particle * trig_row_stride()};
     const std::size_t p_offset{particle * S};
@@ -448,25 +448,25 @@ void SlaterPlaneWave::add_derivatives(
     for (std::size_t orbital = 0; orbital < N; ++orbital) {
       const std::size_t k_idx{k_index[orbital]};
 
-      const double k_x_orbital{kv.x_[k_idx]};
-      const double k_y_orbital{kv.y_[k_idx]};
-      const double k_z_orbital{kv.z_[k_idx]};
+      const real_t k_x_orbital{kv.x_[k_idx]};
+      const real_t k_y_orbital{kv.y_[k_idx]};
+      const real_t k_z_orbital{kv.z_[k_idx]};
 
-      const double k_sq{
+      const real_t k_sq{
         k_x_orbital * k_x_orbital +
         k_y_orbital * k_y_orbital +
         k_z_orbital * k_z_orbital
       };
 
-      const double type{static_cast<double>(o_type[orbital])};
+      const real_t type{static_cast<real_t>(o_type[orbital])};
 
-      const double cos_term{cos_cache[offset + k_idx]};
-      const double sin_term{sin_cache[offset + k_idx]};
+      const real_t cos_term{cos_cache[offset + k_idx]};
+      const real_t sin_term{sin_cache[offset + k_idx]};
 
-      const double grad_factor{-sin_term + type * (sin_term + cos_term)};
-      const double lap_factor{-cos_term + type * (cos_term - sin_term)};
+      const real_t grad_factor{-sin_term + type * (sin_term + cos_term)};
+      const real_t lap_factor{-cos_term + type * (cos_term - sin_term)};
 
-      const double weight{inv_det[p_offset + orbital]};
+      const real_t weight{inv_det[p_offset + orbital]};
 
       d_log_det_dx += weight * k_x_orbital * grad_factor;
       d_log_det_dy += weight * k_y_orbital * grad_factor;
@@ -474,7 +474,7 @@ void SlaterPlaneWave::add_derivatives(
       laplace_det_term += weight * k_sq * lap_factor;
     }
 
-    const double grad_sq{
+    const real_t grad_sq{
       d_log_det_dx * d_log_det_dx +
       d_log_det_dy * d_log_det_dy +
       d_log_det_dz * d_log_det_dz

--- a/src/slater_plane_wave/slater_plane_wave.hpp
+++ b/src/slater_plane_wave/slater_plane_wave.hpp
@@ -18,7 +18,7 @@ private:
   std::size_t trig_row_stride_;
   std::size_t matrix_row_stride_;
   std::size_t matrix_size_;
-  double box_length_;
+  real_t box_length_;
 
   std::vector<std::size_t> orbital_k_index_;
   std::vector<std::uint8_t> orbital_type_;
@@ -36,26 +36,26 @@ private:
     INV_D_COL,
     NUM_DOUBLE_VECTORS
   };
-  AlignedSoA<double> double_vec_;
+  AlignedSoA<real_t> double_vec_;
 
   enum TrigIndex : std::size_t { SIN_CACHE, COS_CACHE, NUM_TRIG_ARRAYS };
-  AlignedSoA<double> trig_cache_;
+  AlignedSoA<real_t> trig_cache_;
 
   enum ScratchTrigIndex : std::size_t { SIN_SAVED, COS_SAVED, NUM_SCRATCH_TRIG };
-  AlignedSoA<double> trig_scratch_;
+  AlignedSoA<real_t> trig_scratch_;
 
   enum MatrixIndex : std::size_t { D, INV_D, LU, NUM_MATRIX };
-  AlignedSoA<double> matrices_;
+  AlignedSoA<real_t> matrices_;
 
 public:
-  explicit SlaterPlaneWave(const Particles& particles, double box_length);
+  explicit SlaterPlaneWave(const Particles& particles, real_t box_length);
 
   [[nodiscard]] std::size_t num_orbitals() const noexcept { return num_orbitals_; }
   [[nodiscard]] std::size_t num_unique_k() const noexcept { return num_unique_k_; }
   [[nodiscard]] std::size_t trig_row_stride() const noexcept { return trig_row_stride_; }
   [[nodiscard]] std::size_t matrix_row_stride() const noexcept { return matrix_row_stride_; }
   [[nodiscard]] std::size_t matrix_size() const noexcept { return matrix_size_; }
-  [[nodiscard]] double box_length() const noexcept { return box_length_; }
+  [[nodiscard]] real_t box_length() const noexcept { return box_length_; }
 
   [[nodiscard]]       std::vector<std::size_t>& orbital_k_index()       noexcept { return orbital_k_index_; }
   [[nodiscard]] const std::vector<std::size_t>& orbital_k_index() const noexcept { return orbital_k_index_; }
@@ -63,14 +63,14 @@ public:
   [[nodiscard]]       std::vector<std::uint8_t>& orbital_type()       noexcept { return orbital_type_; }
   [[nodiscard]] const std::vector<std::uint8_t>& orbital_type() const noexcept { return orbital_type_; }
 
-  [[nodiscard]] double*       determinant()       noexcept { return matrices_[D]; }
-  [[nodiscard]] double const* determinant() const noexcept { return matrices_[D]; }
+  [[nodiscard]] real_t*       determinant()       noexcept { return matrices_[D]; }
+  [[nodiscard]] real_t const* determinant() const noexcept { return matrices_[D]; }
 
-  [[nodiscard]] double*       inv_determinant()       noexcept { return matrices_[INV_D]; }
-  [[nodiscard]] double const* inv_determinant() const noexcept { return matrices_[INV_D]; }
+  [[nodiscard]] real_t*       inv_determinant()       noexcept { return matrices_[INV_D]; }
+  [[nodiscard]] real_t const* inv_determinant() const noexcept { return matrices_[INV_D]; }
 
-  [[nodiscard]] double*       lower_upper()       noexcept { return matrices_[LU]; }
-  [[nodiscard]] double const* lower_upper() const noexcept { return matrices_[LU]; }
+  [[nodiscard]] real_t*       lower_upper()       noexcept { return matrices_[LU]; }
+  [[nodiscard]] real_t const* lower_upper() const noexcept { return matrices_[LU]; }
 
   [[nodiscard]] int*       pivot()       noexcept { return int_vec_[PIVOT]; }
   [[nodiscard]] int const* pivot() const noexcept { return int_vec_[PIVOT]; }
@@ -78,45 +78,45 @@ public:
   Ptr3D<      int> n_vector()       noexcept { return {int_vec_[N_X], int_vec_[N_Y], int_vec_[N_Z]}; }
   Ptr3D<const int> n_vector() const noexcept { return {int_vec_[N_X], int_vec_[N_Y], int_vec_[N_Z]}; }
 
-  Ptr3D<      double> k_vector()       noexcept { return {double_vec_[K_X], double_vec_[K_Y], double_vec_[K_Z]}; }
-  Ptr3D<const double> k_vector() const noexcept { return {double_vec_[K_X], double_vec_[K_Y], double_vec_[K_Z]}; }
+  Ptr3D<      real_t> k_vector()       noexcept { return {double_vec_[K_X], double_vec_[K_Y], double_vec_[K_Z]}; }
+  Ptr3D<const real_t> k_vector() const noexcept { return {double_vec_[K_X], double_vec_[K_Y], double_vec_[K_Z]}; }
 
-  [[nodiscard]] double*       solution()       noexcept { return double_vec_[SOLUTION]; }
-  [[nodiscard]] double const* solution() const noexcept { return double_vec_[SOLUTION]; }
+  [[nodiscard]] real_t*       solution()       noexcept { return double_vec_[SOLUTION]; }
+  [[nodiscard]] real_t const* solution() const noexcept { return double_vec_[SOLUTION]; }
 
-  [[nodiscard]] double*       rhs()       noexcept { return double_vec_[RHS]; }
-  [[nodiscard]] double const* rhs() const noexcept { return double_vec_[RHS]; }
+  [[nodiscard]] real_t*       rhs()       noexcept { return double_vec_[RHS]; }
+  [[nodiscard]] real_t const* rhs() const noexcept { return double_vec_[RHS]; }
 
-  [[nodiscard]] double*       sin_cache()       noexcept { return trig_cache_[SIN_CACHE]; }
-  [[nodiscard]] double const* sin_cache() const noexcept { return trig_cache_[SIN_CACHE]; }
+  [[nodiscard]] real_t*       sin_cache()       noexcept { return trig_cache_[SIN_CACHE]; }
+  [[nodiscard]] real_t const* sin_cache() const noexcept { return trig_cache_[SIN_CACHE]; }
 
-  [[nodiscard]] double*       cos_cache()       noexcept { return trig_cache_[COS_CACHE]; }
-  [[nodiscard]] double const* cos_cache() const noexcept { return trig_cache_[COS_CACHE]; }
+  [[nodiscard]] real_t*       cos_cache()       noexcept { return trig_cache_[COS_CACHE]; }
+  [[nodiscard]] real_t const* cos_cache() const noexcept { return trig_cache_[COS_CACHE]; }
 
   void save_trig_row(std::size_t particle) noexcept;
   void restore_trig_row(std::size_t particle) noexcept;
 
   void update_trig_cache(std::size_t particle, const Particles& particles) noexcept;
 
-  double log_abs_det(const Particles& particles);
+  real_t log_abs_det(const Particles& particles);
 
-  double* build_row(std::size_t particle) noexcept;
+  real_t* build_row(std::size_t particle) noexcept;
 
-  [[nodiscard]] double determinant_ratio(
+  [[nodiscard]] real_t determinant_ratio(
     std::size_t particle,
-    const double* new_row
+    const real_t* new_row
   ) const noexcept;
 
-  void accept_move(std::size_t particle, const double* new_row, double ratio) noexcept;
+  void accept_move(std::size_t particle, const real_t* new_row, real_t ratio) noexcept;
 
   void add_derivatives(
-    double* RESTRICT grad_x,
-    double* RESTRICT grad_y,
-    double* RESTRICT grad_z,
-    double* RESTRICT laplacian
+    real_t* RESTRICT grad_x,
+    real_t* RESTRICT grad_y,
+    real_t* RESTRICT grad_z,
+    real_t* RESTRICT laplacian
   ) const noexcept;
 
 private:
-  [[nodiscard]] double* new_row() noexcept { return double_vec_[NEW_ROW]; }
-  [[nodiscard]] double* inv_d_col() noexcept { return double_vec_[INV_D_COL]; }
+  [[nodiscard]] real_t* new_row() noexcept { return double_vec_[NEW_ROW]; }
+  [[nodiscard]] real_t* inv_d_col() noexcept { return double_vec_[INV_D_COL]; }
 };

--- a/src/utilities/macros.hpp
+++ b/src/utilities/macros.hpp
@@ -4,12 +4,28 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cmath>
+#include <complex>
 #include <concepts>
 #include <memory>
 #include <type_traits>
 
 template <typename T>
 concept arithmetic = std::is_arithmetic_v<T>;
+
+#ifdef FP_64
+using real_t = double;
+#else
+using real_t = float;
+#endif
+
+using complex_t = std::complex<real_t>;
+
+[[nodiscard]] constexpr real_t operator""_r(long double value) {
+  return static_cast<real_t>(value);
+}
+[[nodiscard]] constexpr real_t operator""_r(unsigned long long value) {
+  return static_cast<real_t>(value);
+}
 
 // Restrict pointers:
 #if defined(__GNUC__) || defined(__clang__)
@@ -34,11 +50,17 @@ constexpr std::size_t SIMD_BYTES{alignof(std::max_align_t)};
 // Sincos support for all compilers
 #if defined(__APPLE__)
 inline void PORTABLE_SINCOS(double theta, double* s, double* c) { __sincos(theta, s, c); }
+inline void PORTABLE_SINCOS(float theta, float* s, float* c) { __sincosf(theta, s, c); }
 #elif defined(__GNUC__) || defined(__clang__)
 #include <math.h>
 inline void PORTABLE_SINCOS(double theta, double* s, double* c) { sincos(theta, s, c); }
+inline void PORTABLE_SINCOS(float theta, float* s, float* c) { sincosf(theta, s, c); }
 #else
 inline void PORTABLE_SINCOS(double theta, double* s, double* c) {
+  *s = std::sin(theta);
+  *c = std::cos(theta);
+}
+inline void PORTABLE_SINCOS(float theta, float* s, float* c) {
   *s = std::sin(theta);
   *c = std::cos(theta);
 }

--- a/src/utilities/matrix.hpp
+++ b/src/utilities/matrix.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
+#include "macros.hpp"
+
 #include <cmath>
 #include <cstddef>
 #include <limits>
 #include <utility>
 
 inline int lower_upper_decomp(
-  double* lower_upper,
+  real_t* lower_upper,
   int* pivot,
   std::size_t N,
   std::size_t stride
@@ -19,19 +21,19 @@ inline int lower_upper_decomp(
 
   for (std::size_t col = 0; col < N; ++col) {
     std::size_t pivot_row{col};
-    double max_abs{std::abs(lower_upper[col * stride + col])};
+    real_t max_abs{std::abs(lower_upper[col * stride + col])};
 
     for (std::size_t row = col + 1; row < N; ++row) {
-      const double value{std::abs(lower_upper[row * stride + col])};
+      const real_t value{std::abs(lower_upper[row * stride + col])};
       if (value > max_abs) {
         max_abs = value;
         pivot_row = row;
       }
     }
 
-    constexpr double PIVOT_TOLERANCE{1e-12};
+    constexpr real_t PIVOT_TOLERANCE{1e-12_r};
     if (max_abs < PIVOT_TOLERANCE) {
-      lower_upper[col * stride + col] = 0.0;
+      lower_upper[col * stride + col] = 0.0_r;
       continue;
     }
 
@@ -43,10 +45,10 @@ inline int lower_upper_decomp(
       ++swap_count;
     }
 
-    const double pivot_value{lower_upper[col * stride + col]};
+    const real_t pivot_value{lower_upper[col * stride + col]};
     for (std::size_t row = col + 1; row < N; ++row) {
       lower_upper[row * stride + col] /= pivot_value;
-      const double multiplier{lower_upper[row * stride + col]};
+      const real_t multiplier{lower_upper[row * stride + col]};
       for (std::size_t col2 = col + 1; col2 < N; ++col2) {
         lower_upper[row * stride + col2] -= multiplier * lower_upper[col * stride + col2];
       }
@@ -57,10 +59,10 @@ inline int lower_upper_decomp(
 }
 
 inline void solve_lower_upper(
-  const double* lower_upper,
+  const real_t* lower_upper,
   const int* pivot,
-  const double* b,
-  double* x,
+  const real_t* b,
+  real_t* x,
   std::size_t N,
   std::size_t stride
 ) {
@@ -70,7 +72,7 @@ inline void solve_lower_upper(
   }
 
   for (std::size_t row = 0; row < N; ++row) {
-    double sum{x[row]};
+    real_t sum{x[row]};
     for (std::size_t col = 0; col < row; ++col) {
       sum -= lower_upper[row * stride + col] * x[col];
     }
@@ -79,13 +81,13 @@ inline void solve_lower_upper(
 
   for (std::size_t rev = 0; rev < N; ++rev) {
     const std::size_t row{N - 1 - rev};
-    double sum{x[row]};
+    real_t sum{x[row]};
     for (std::size_t col = row + 1; col < N; ++col) {
       sum -= lower_upper[row * stride + col] * x[col];
     }
 
-    const double diag{lower_upper[row * stride + row]};
-    x[row] = (std::abs(diag) > std::numeric_limits<double>::min()) ? (sum / diag) : 0.0;
+    const real_t diag{lower_upper[row * stride + row]};
+    x[row] = (std::abs(diag) > std::numeric_limits<real_t>::min()) ? (sum / diag) : 0.0_r;
   }
 }
 

--- a/src/wavefunction/wavefunction.cpp
+++ b/src/wavefunction/wavefunction.cpp
@@ -2,9 +2,9 @@
 
 #include <algorithm>
 
-double WaveFunction::evaluate_log_psi(const Particles& particles) {
-  const double log_det{slater_plane_wave().log_abs_det(particles)};
-  const double jastrow{jastrow_pade().value(particles)};
+real_t WaveFunction::evaluate_log_psi(const Particles& particles) {
+  const real_t log_det{slater_plane_wave().log_abs_det(particles)};
+  const real_t jastrow{jastrow_pade().value(particles)};
 
   return log_det + jastrow;
 }
@@ -13,23 +13,23 @@ void WaveFunction::evaluate_derivatives(Particles& particles) noexcept {
   const std::size_t padded_stride{particles.p_stride()};
 
   const auto log_grad{particles.grad_log_psi().align()};
-  double* RESTRICT log_lap{particles.lap_log_psi()};
+  real_t* RESTRICT log_lap{particles.lap_log_psi()};
 
   const auto jg{j_grad().align()};
-  double* RESTRICT jastrow_lap{j_lap()};
+  real_t* RESTRICT jastrow_lap{j_lap()};
 
   ASSUME_ALIGNED(log_lap, SIMD_BYTES);
   ASSUME_ALIGNED(jastrow_lap, SIMD_BYTES);
 
-  std::fill_n(log_grad.x_, padded_stride, 0.0);
-  std::fill_n(log_grad.y_, padded_stride, 0.0);
-  std::fill_n(log_grad.z_, padded_stride, 0.0);
-  std::fill_n(log_lap, padded_stride, 0.0);
+  std::fill_n(log_grad.x_, padded_stride, 0.0_r);
+  std::fill_n(log_grad.y_, padded_stride, 0.0_r);
+  std::fill_n(log_grad.z_, padded_stride, 0.0_r);
+  std::fill_n(log_lap, padded_stride, 0.0_r);
 
-  std::fill_n(jg.x_, padded_stride, 0.0);
-  std::fill_n(jg.y_, padded_stride, 0.0);
-  std::fill_n(jg.z_, padded_stride, 0.0);
-  std::fill_n(jastrow_lap, padded_stride, 0.0);
+  std::fill_n(jg.x_, padded_stride, 0.0_r);
+  std::fill_n(jg.y_, padded_stride, 0.0_r);
+  std::fill_n(jg.z_, padded_stride, 0.0_r);
+  std::fill_n(jastrow_lap, padded_stride, 0.0_r);
 
   slater_plane_wave_.add_derivatives(log_grad.x_, log_grad.y_, log_grad.z_, log_lap);
   jastrow_pade_.add_derivatives(particles, jg.x_, jg.y_, jg.z_, jastrow_lap);
@@ -49,7 +49,7 @@ void WaveFunction::evaluate_derivatives(
   Particles& particles,
   bool move_accepted,
   std::size_t moved,
-  double old_x, double old_y, double old_z
+  real_t old_x, real_t old_y, real_t old_z
 ) noexcept {
   if (!jastrow_cache_valid()) {
     evaluate_derivatives(particles);
@@ -67,10 +67,10 @@ void WaveFunction::evaluate_derivatives(
   const std::size_t padded_stride{particles.p_stride()};
 
   const auto log_grad{particles.grad_log_psi().align()};
-  double* RESTRICT log_lap{particles.lap_log_psi()};
+  real_t* RESTRICT log_lap{particles.lap_log_psi()};
 
   const auto jg{j_grad().align()};
-  double* RESTRICT jastrow_lap{j_lap()};
+  real_t* RESTRICT jastrow_lap{j_lap()};
 
   ASSUME_ALIGNED(log_lap, SIMD_BYTES);
   ASSUME_ALIGNED(jastrow_lap, SIMD_BYTES);
@@ -83,10 +83,10 @@ void WaveFunction::evaluate_derivatives(
     jastrow_lap
   );
 
-  std::fill_n(log_grad.x_, padded_stride, 0.0);
-  std::fill_n(log_grad.y_, padded_stride, 0.0);
-  std::fill_n(log_grad.z_, padded_stride, 0.0);
-  std::fill_n(log_lap, padded_stride, 0.0);
+  std::fill_n(log_grad.x_, padded_stride, 0.0_r);
+  std::fill_n(log_grad.y_, padded_stride, 0.0_r);
+  std::fill_n(log_grad.z_, padded_stride, 0.0_r);
+  std::fill_n(log_lap, padded_stride, 0.0_r);
 
   slater_plane_wave_.add_derivatives(
     log_grad.x_, log_grad.y_, log_grad.z_,

--- a/src/wavefunction/wavefunction.hpp
+++ b/src/wavefunction/wavefunction.hpp
@@ -17,14 +17,14 @@ private:
   std::size_t steps_since_refresh_;
 
   enum ArrayIndex : std::size_t { GRAD_X, GRAD_Y, GRAD_Z, LAP, NUM_ARRAYS };
-  AlignedSoA<double> deriv_;
+  AlignedSoA<real_t> deriv_;
 
 public:
   explicit WaveFunction(
     const Particles& particles,
-    double box_length,
-    double a = 0.25,
-    double b = 1.0
+    real_t box_length,
+    real_t a = 0.25_r,
+    real_t b = 1.0_r
   )
   : jastrow_pade_{box_length, a, b}
   , slater_plane_wave_{particles, box_length}
@@ -39,11 +39,11 @@ public:
   [[nodiscard]]       SlaterPlaneWave& slater_plane_wave()       noexcept { return slater_plane_wave_; }
   [[nodiscard]] const SlaterPlaneWave& slater_plane_wave() const noexcept { return slater_plane_wave_; }
 
-  Ptr3D<      double> j_grad()       noexcept { return {deriv_[GRAD_X], deriv_[GRAD_Y], deriv_[GRAD_Z]}; }
-  Ptr3D<const double> j_grad() const noexcept { return {deriv_[GRAD_X], deriv_[GRAD_Y], deriv_[GRAD_Z]}; }
+  Ptr3D<      real_t> j_grad()       noexcept { return {deriv_[GRAD_X], deriv_[GRAD_Y], deriv_[GRAD_Z]}; }
+  Ptr3D<const real_t> j_grad() const noexcept { return {deriv_[GRAD_X], deriv_[GRAD_Y], deriv_[GRAD_Z]}; }
 
-  [[nodiscard]] double*       j_lap()       noexcept { return deriv_[LAP]; }
-  [[nodiscard]] double const* j_lap() const noexcept { return deriv_[LAP]; }
+  [[nodiscard]] real_t*       j_lap()       noexcept { return deriv_[LAP]; }
+  [[nodiscard]] real_t const* j_lap() const noexcept { return deriv_[LAP]; }
 
   [[nodiscard]] bool jastrow_cache_valid() const noexcept { return jastrow_cache_valid_; }
   void set_jastrow_cache_valid(bool value) noexcept { jastrow_cache_valid_ = value; }
@@ -56,8 +56,8 @@ public:
     Particles& particles,
     bool move_accepted,
     std::size_t moved,
-    double old_x, double old_y, double old_z
+    real_t old_x, real_t old_y, real_t old_z
   ) noexcept;
 
-  double evaluate_log_psi(const Particles& particles);
+  real_t evaluate_log_psi(const Particles& particles);
 };

--- a/tests/test_blocking_analysis.cpp
+++ b/tests/test_blocking_analysis.cpp
@@ -10,43 +10,43 @@ TEST_CASE("BlockingAnalysis readiness requires two complete blocks", "[blocking]
   REQUIRE_FALSE(blocking.ready());
   REQUIRE_THROWS_AS(blocking.mean_and_standard_error(), std::runtime_error);
 
-  blocking.add(1.0);
-  blocking.add(2.0);
-  blocking.add(3.0);
+  blocking.add(1.0_r);
+  blocking.add(2.0_r);
+  blocking.add(3.0_r);
 
   REQUIRE_FALSE(blocking.ready());
   REQUIRE_THROWS_AS(blocking.mean_and_standard_error(), std::runtime_error);
 
-  blocking.add(4.0);
-  blocking.add(5.0);
-  blocking.add(6.0);
+  blocking.add(4.0_r);
+  blocking.add(5.0_r);
+  blocking.add(6.0_r);
 
   REQUIRE(blocking.ready());
 }
 
 TEST_CASE("BlockingAnalysis computes mean and standard error from block means", "[blocking]") {
   BlockingAnalysis blocking{2U};
-  blocking.add(1.0);
-  blocking.add(3.0);
-  blocking.add(5.0);
-  blocking.add(7.0);
+  blocking.add(1.0_r);
+  blocking.add(3.0_r);
+  blocking.add(5.0_r);
+  blocking.add(7.0_r);
 
   const auto [mean, standardError]{blocking.mean_and_standard_error()};
-  require_near(mean, 4.0);
-  require_near(standardError, 2.0);
+  require_near(mean, 4.0_r);
+  require_near(standardError, 2.0_r);
 }
 
 TEST_CASE("BlockingAnalysis ignores incomplete trailing blocks", "[blocking]") {
   BlockingAnalysis blocking{2U};
-  blocking.add(1.0);
-  blocking.add(2.0);
-  blocking.add(3.0);
-  blocking.add(4.0);
-  blocking.add(100.0);
+  blocking.add(1.0_r);
+  blocking.add(2.0_r);
+  blocking.add(3.0_r);
+  blocking.add(4.0_r);
+  blocking.add(100.0_r);
 
   REQUIRE(blocking.ready());
 
   const auto [mean, standardError]{blocking.mean_and_standard_error()};
-  require_near(mean, 2.5);
-  require_near(standardError, 1.0);
+  require_near(mean, 2.5_r);
+  require_near(standardError, 1.0_r);
 }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -28,7 +28,7 @@ TEST_CASE("Config default constructor produces expected defaults and derived val
   REQUIRE(cfg.num_particles == 7U);
   REQUIRE(cfg.warmup_sweeps == 100U);
   REQUIRE(cfg.measure_sweeps == 100U);
-  REQUIRE(cfg.box_length == 10.0);
+  REQUIRE(cfg.box_length == 10.0_r);
   REQUIRE(cfg.block_size == 100U);
   REQUIRE(cfg.master_seed == 42U);
   REQUIRE(cfg.is_master_thread == false);
@@ -36,7 +36,7 @@ TEST_CASE("Config default constructor produces expected defaults and derived val
   // Derived fields:
   REQUIRE(cfg.warmup_steps == 7U * 100U);
   REQUIRE(cfg.measure_steps == 7U * 100U);
-  require_near(cfg.step_size, 1.0); // 10.0 / 10.0
+  require_near(cfg.step_size, 1.0_r); // 10.0 / 10.0
 }
 
 TEST_CASE("Config::from_file parses all recognized keys", "[config]") {
@@ -52,14 +52,14 @@ TEST_CASE("Config::from_file parses all recognized keys", "[config]") {
   REQUIRE(cfg.num_particles == 19U);
   REQUIRE(cfg.warmup_sweeps == 200U);
   REQUIRE(cfg.measure_sweeps == 500U);
-  require_near(cfg.box_length, 8.5);
+  require_near(cfg.box_length, 8.5_r);
   REQUIRE(cfg.block_size == 50U);
   REQUIRE(cfg.master_seed == 99999U);
 
   // Derived:
   REQUIRE(cfg.warmup_steps == 19U * 200U);
   REQUIRE(cfg.measure_steps == 19U * 500U);
-  require_near(cfg.step_size, 8.5 / 10.0);
+  require_near(cfg.step_size, 8.5_r / 10.0_r);
 }
 
 TEST_CASE("Config::from_file ignores comments and blank lines", "[config]") {
@@ -70,7 +70,7 @@ TEST_CASE("Config::from_file ignores comments and blank lines", "[config]") {
                                        "Box_Length = 12.0\n")};
 
   REQUIRE(cfg.num_particles == 33U);
-  require_near(cfg.box_length, 12.0);
+  require_near(cfg.box_length, 12.0_r);
   // Other fields remain at defaults:
   REQUIRE(cfg.warmup_sweeps == 100U);
 }
@@ -80,7 +80,7 @@ TEST_CASE("Config::from_file handles whitespace around keys and values", "[confi
                                        "  Box_Length  =  7.5  \n")};
 
   REQUIRE(cfg.num_particles == 27U);
-  require_near(cfg.box_length, 7.5);
+  require_near(cfg.box_length, 7.5_r);
 }
 
 TEST_CASE("Config::from_file warns on unknown keys and preserves known values", "[config]") {
@@ -112,7 +112,7 @@ TEST_CASE("Config::from_file skips lines without an equals sign", "[config]") {
                                        "Box_Length = 5.0\n")};
 
   REQUIRE(cfg.num_particles == 19U);
-  require_near(cfg.box_length, 5.0);
+  require_near(cfg.box_length, 5.0_r);
 }
 
 TEST_CASE("Config derived fields recompute correctly for various particle counts", "[config]") {
@@ -124,7 +124,7 @@ TEST_CASE("Config derived fields recompute correctly for various particle counts
 
     REQUIRE(cfg.warmup_steps == 1U * 50U);
     REQUIRE(cfg.measure_steps == 1U * 200U);
-    require_near(cfg.step_size, 2.0);
+    require_near(cfg.step_size, 2.0_r);
   }
   {
     const Config cfg{parse_config_string("Num_Particles = 100\n"
@@ -134,7 +134,7 @@ TEST_CASE("Config derived fields recompute correctly for various particle counts
 
     REQUIRE(cfg.warmup_steps == 100U * 10U);
     REQUIRE(cfg.measure_steps == 100U * 30U);
-    require_near(cfg.step_size, 0.5);
+    require_near(cfg.step_size, 0.5_r);
   }
 }
 
@@ -145,7 +145,7 @@ TEST_CASE("Config::from_file handles empty config file gracefully", "[config]") 
   REQUIRE(cfg.num_particles == 7U);
   REQUIRE(cfg.warmup_sweeps == 100U);
   REQUIRE(cfg.measure_sweeps == 100U);
-  require_near(cfg.box_length, 10.0);
+  require_near(cfg.box_length, 10.0_r);
   REQUIRE(cfg.block_size == 100U);
   REQUIRE(cfg.master_seed == 42U);
 }
@@ -158,7 +158,7 @@ TEST_CASE("Config::from_file partial override leaves other fields at defaults", 
   REQUIRE(cfg.num_particles == 7U);
   REQUIRE(cfg.warmup_sweeps == 100U);
   REQUIRE(cfg.measure_sweeps == 100U);
-  require_near(cfg.box_length, 10.0);
+  require_near(cfg.box_length, 10.0_r);
   REQUIRE(cfg.master_seed == 42U);
 }
 

--- a/tests/test_energy_tracking.cpp
+++ b/tests/test_energy_tracking.cpp
@@ -8,48 +8,48 @@
 
 TEST_CASE("EnergyTracker total energy changes by expected kinetic contribution", "[energy]") {
   constexpr std::size_t n{3U};
-  constexpr double L{8.0};
-  const EnergyTracker tracker{L, static_cast<double>(n)};
+  constexpr real_t L{8.0_r};
+  const EnergyTracker tracker{L, static_cast<real_t>(n)};
 
   Particles reference{n};
-  reference.pos().x_[0] = 0.3;
-  reference.pos().y_[0] = 1.5;
-  reference.pos().z_[0] = 2.4;
-  reference.pos().x_[1] = 3.7;
-  reference.pos().y_[1] = 0.2;
-  reference.pos().z_[1] = 5.1;
-  reference.pos().x_[2] = 6.9;
-  reference.pos().y_[2] = 7.2;
-  reference.pos().z_[2] = 1.1;
+  reference.pos().x_[0] = 0.3_r;
+  reference.pos().y_[0] = 1.5_r;
+  reference.pos().z_[0] = 2.4_r;
+  reference.pos().x_[1] = 3.7_r;
+  reference.pos().y_[1] = 0.2_r;
+  reference.pos().z_[1] = 5.1_r;
+  reference.pos().x_[2] = 6.9_r;
+  reference.pos().y_[2] = 7.2_r;
+  reference.pos().z_[2] = 1.1_r;
 
   Particles with_derivatives{n};
   copy_positions(reference, with_derivatives);
 
-  with_derivatives.grad_log_psi().x_[0] = 0.2;
-  with_derivatives.grad_log_psi().y_[0] = -0.1;
-  with_derivatives.grad_log_psi().z_[0] = 0.3;
-  with_derivatives.lap_log_psi()[0] = 0.5;
+  with_derivatives.grad_log_psi().x_[0] = 0.2_r;
+  with_derivatives.grad_log_psi().y_[0] = -0.1_r;
+  with_derivatives.grad_log_psi().z_[0] = 0.3_r;
+  with_derivatives.lap_log_psi()[0] = 0.5_r;
 
-  with_derivatives.grad_log_psi().x_[1] = -0.4;
-  with_derivatives.grad_log_psi().y_[1] = 0.0;
-  with_derivatives.grad_log_psi().z_[1] = 0.1;
-  with_derivatives.lap_log_psi()[1] = -0.2;
+  with_derivatives.grad_log_psi().x_[1] = -0.4_r;
+  with_derivatives.grad_log_psi().y_[1] = 0.0_r;
+  with_derivatives.grad_log_psi().z_[1] = 0.1_r;
+  with_derivatives.lap_log_psi()[1] = -0.2_r;
 
-  with_derivatives.grad_log_psi().x_[2] = 0.3;
-  with_derivatives.grad_log_psi().y_[2] = -0.2;
-  with_derivatives.grad_log_psi().z_[2] = -0.5;
-  with_derivatives.lap_log_psi()[2] = 0.7;
+  with_derivatives.grad_log_psi().x_[2] = 0.3_r;
+  with_derivatives.grad_log_psi().y_[2] = -0.2_r;
+  with_derivatives.grad_log_psi().z_[2] = -0.5_r;
+  with_derivatives.lap_log_psi()[2] = 0.7_r;
 
-  const double energy_without_derivatives{tracker.eval_total_energy(reference)};
-  const double energy_with_derivatives{tracker.eval_total_energy(with_derivatives)};
+  const real_t energy_without_derivatives{tracker.eval_total_energy(reference)};
+  const real_t energy_with_derivatives{tracker.eval_total_energy(with_derivatives)};
 
-  double expected_kinetic{};
+  real_t expected_kinetic{};
   for (std::size_t i = 0; i < n; ++i) {
-    const double gx{with_derivatives.grad_log_psi().x_[i]};
-    const double gy{with_derivatives.grad_log_psi().y_[i]};
-    const double gz{with_derivatives.grad_log_psi().z_[i]};
-    const double lap{with_derivatives.lap_log_psi()[i]};
-    expected_kinetic += -0.5 * (lap + gx * gx + gy * gy + gz * gz);
+    const real_t gx{with_derivatives.grad_log_psi().x_[i]};
+    const real_t gy{with_derivatives.grad_log_psi().y_[i]};
+    const real_t gz{with_derivatives.grad_log_psi().z_[i]};
+    const real_t lap{with_derivatives.lap_log_psi()[i]};
+    expected_kinetic += -0.5_r * (lap + gx * gx + gy * gy + gz * gz);
   }
 
   require_near(energy_with_derivatives - energy_without_derivatives, expected_kinetic);
@@ -57,72 +57,72 @@ TEST_CASE("EnergyTracker total energy changes by expected kinetic contribution",
 
 TEST_CASE("EnergyTracker is invariant under box-periodic particle translations", "[energy]") {
   constexpr std::size_t n{3U};
-  constexpr double L{7.5};
-  const EnergyTracker tracker{L, static_cast<double>(n)};
+  constexpr real_t L{7.5_r};
+  const EnergyTracker tracker{L, static_cast<real_t>(n)};
 
   Particles particles{n};
-  particles.pos().x_[0] = 1.1;
-  particles.pos().y_[0] = 2.3;
-  particles.pos().z_[0] = 3.7;
-  particles.pos().x_[1] = 6.4;
-  particles.pos().y_[1] = 5.6;
-  particles.pos().z_[1] = 0.4;
-  particles.pos().x_[2] = 2.9;
-  particles.pos().y_[2] = 1.2;
-  particles.pos().z_[2] = 7.0;
+  particles.pos().x_[0] = 1.1_r;
+  particles.pos().y_[0] = 2.3_r;
+  particles.pos().z_[0] = 3.7_r;
+  particles.pos().x_[1] = 6.4_r;
+  particles.pos().y_[1] = 5.6_r;
+  particles.pos().z_[1] = 0.4_r;
+  particles.pos().x_[2] = 2.9_r;
+  particles.pos().y_[2] = 1.2_r;
+  particles.pos().z_[2] = 7.0_r;
 
-  particles.grad_log_psi().x_[0] = 0.12;
-  particles.grad_log_psi().y_[0] = -0.08;
-  particles.grad_log_psi().z_[0] = 0.05;
-  particles.lap_log_psi()[0] = 0.2;
+  particles.grad_log_psi().x_[0] = 0.12_r;
+  particles.grad_log_psi().y_[0] = -0.08_r;
+  particles.grad_log_psi().z_[0] = 0.05_r;
+  particles.lap_log_psi()[0] = 0.2_r;
 
-  particles.grad_log_psi().x_[1] = -0.15;
-  particles.grad_log_psi().y_[1] = 0.11;
-  particles.grad_log_psi().z_[1] = -0.03;
-  particles.lap_log_psi()[1] = -0.1;
+  particles.grad_log_psi().x_[1] = -0.15_r;
+  particles.grad_log_psi().y_[1] = 0.11_r;
+  particles.grad_log_psi().z_[1] = -0.03_r;
+  particles.lap_log_psi()[1] = -0.1_r;
 
-  particles.grad_log_psi().x_[2] = 0.07;
-  particles.grad_log_psi().y_[2] = 0.09;
-  particles.grad_log_psi().z_[2] = -0.04;
-  particles.lap_log_psi()[2] = 0.05;
+  particles.grad_log_psi().x_[2] = 0.07_r;
+  particles.grad_log_psi().y_[2] = 0.09_r;
+  particles.grad_log_psi().z_[2] = -0.04_r;
+  particles.lap_log_psi()[2] = 0.05_r;
 
   Particles translated{n};
   copy_positions(particles, translated);
   copy_derivatives(particles, translated);
 
   translated.pos().x_[0] += L;
-  translated.pos().y_[0] -= 2.0 * L;
-  translated.pos().z_[1] += 3.0 * L;
+  translated.pos().y_[0] -= 2.0_r * L;
+  translated.pos().z_[1] += 3.0_r * L;
   translated.pos().x_[2] -= L;
 
-  const double baseline{tracker.eval_total_energy(particles)};
-  const double shifted{tracker.eval_total_energy(translated)};
-  require_near(shifted, baseline, 1e-9);
+  const real_t baseline{tracker.eval_total_energy(particles)};
+  const real_t shifted{tracker.eval_total_energy(translated)};
+  require_near(shifted, baseline, 1e-9_r);
 }
 
 TEST_CASE("EnergyTracker handles degenerate positions and permutation symmetry", "[energy]") {
   constexpr std::size_t n{2U};
-  constexpr double L{6.0};
-  const EnergyTracker tracker{L, static_cast<double>(n)};
+  constexpr real_t L{6.0_r};
+  const EnergyTracker tracker{L, static_cast<real_t>(n)};
 
   Particles particles{n};
-  particles.pos().x_[0] = 2.0;
-  particles.pos().y_[0] = 2.0;
-  particles.pos().z_[0] = 2.0;
-  particles.pos().x_[1] = 2.0;
-  particles.pos().y_[1] = 2.0;
-  particles.pos().z_[1] = 2.0;
+  particles.pos().x_[0] = 2.0_r;
+  particles.pos().y_[0] = 2.0_r;
+  particles.pos().z_[0] = 2.0_r;
+  particles.pos().x_[1] = 2.0_r;
+  particles.pos().y_[1] = 2.0_r;
+  particles.pos().z_[1] = 2.0_r;
 
-  particles.grad_log_psi().x_[0] = 0.1;
-  particles.grad_log_psi().y_[0] = 0.2;
-  particles.grad_log_psi().z_[0] = 0.3;
-  particles.lap_log_psi()[0] = 0.4;
-  particles.grad_log_psi().x_[1] = -0.3;
-  particles.grad_log_psi().y_[1] = -0.1;
-  particles.grad_log_psi().z_[1] = 0.2;
-  particles.lap_log_psi()[1] = -0.5;
+  particles.grad_log_psi().x_[0] = 0.1_r;
+  particles.grad_log_psi().y_[0] = 0.2_r;
+  particles.grad_log_psi().z_[0] = 0.3_r;
+  particles.lap_log_psi()[0] = 0.4_r;
+  particles.grad_log_psi().x_[1] = -0.3_r;
+  particles.grad_log_psi().y_[1] = -0.1_r;
+  particles.grad_log_psi().z_[1] = 0.2_r;
+  particles.lap_log_psi()[1] = -0.5_r;
 
-  const double degenerate_energy{tracker.eval_total_energy(particles)};
+  const real_t degenerate_energy{tracker.eval_total_energy(particles)};
   REQUIRE(std::isfinite(degenerate_energy));
 
   Particles permuted{n};
@@ -142,28 +142,28 @@ TEST_CASE("EnergyTracker handles degenerate positions and permutation symmetry",
   permuted.grad_log_psi().z_[1] = particles.grad_log_psi().z_[0];
   permuted.lap_log_psi()[1] = particles.lap_log_psi()[0];
 
-  const double permuted_energy{tracker.eval_total_energy(permuted)};
-  require_near(permuted_energy, degenerate_energy, 1e-10);
+  const real_t permuted_energy{tracker.eval_total_energy(permuted)};
+  require_near(permuted_energy, degenerate_energy, 1e-10_r);
 }
 
 TEST_CASE("EnergyTracker incremental reciprocal and real-energy updates match full recomputation",
           "[energy]") {
   constexpr std::size_t n{3U};
-  constexpr double L{8.5};
+  constexpr real_t L{8.5_r};
   constexpr std::size_t moved{1U};
 
   Particles initial{n};
-  initial.pos().x_[0] = 0.7;
-  initial.pos().y_[0] = 1.1;
-  initial.pos().z_[0] = 2.3;
-  initial.pos().x_[1] = 3.2;
-  initial.pos().y_[1] = 2.7;
-  initial.pos().z_[1] = 1.4;
-  initial.pos().x_[2] = 5.6;
-  initial.pos().y_[2] = 0.9;
-  initial.pos().z_[2] = 4.8;
+  initial.pos().x_[0] = 0.7_r;
+  initial.pos().y_[0] = 1.1_r;
+  initial.pos().z_[0] = 2.3_r;
+  initial.pos().x_[1] = 3.2_r;
+  initial.pos().y_[1] = 2.7_r;
+  initial.pos().z_[1] = 1.4_r;
+  initial.pos().x_[2] = 5.6_r;
+  initial.pos().y_[2] = 0.9_r;
+  initial.pos().z_[2] = 4.8_r;
 
-  EnergyTracker incremental{L, static_cast<double>(n)};
+  EnergyTracker incremental{L, static_cast<real_t>(n)};
   incremental.initialize_structure_factors(initial);
   incremental.initialize_reciprocal_energy();
   incremental.initialize_real_energy(initial);
@@ -171,13 +171,13 @@ TEST_CASE("EnergyTracker incremental reciprocal and real-energy updates match fu
   Particles moved_particles{n};
   copy_positions(initial, moved_particles);
 
-  const double old_x{moved_particles.pos().x_[moved]};
-  const double old_y{moved_particles.pos().y_[moved]};
-  const double old_z{moved_particles.pos().z_[moved]};
+  const real_t old_x{moved_particles.pos().x_[moved]};
+  const real_t old_y{moved_particles.pos().y_[moved]};
+  const real_t old_z{moved_particles.pos().z_[moved]};
 
-  moved_particles.pos().x_[moved] = old_x + 0.21;
-  moved_particles.pos().y_[moved] = old_y - 0.17;
-  moved_particles.pos().z_[moved] = old_z + 0.33;
+  moved_particles.pos().x_[moved] = old_x + 0.21_r;
+  moved_particles.pos().y_[moved] = old_y - 0.17_r;
+  moved_particles.pos().z_[moved] = old_z + 0.33_r;
 
   incremental.update_structure_factors(
     old_x, old_y, old_z,
@@ -187,15 +187,15 @@ TEST_CASE("EnergyTracker incremental reciprocal and real-energy updates match fu
   );
   incremental.update_real_energy(moved, old_x, old_y, old_z, moved_particles);
 
-  EnergyTracker rebuilt{L, static_cast<double>(n)};
+  EnergyTracker rebuilt{L, static_cast<real_t>(n)};
   rebuilt.initialize_structure_factors(moved_particles);
   rebuilt.initialize_reciprocal_energy();
   rebuilt.initialize_real_energy(moved_particles);
 
-  const double incremental_total{incremental.eval_total_energy(moved_particles)};
-  const double rebuilt_total{rebuilt.eval_total_energy(moved_particles)};
+  const real_t incremental_total{incremental.eval_total_energy(moved_particles)};
+  const real_t rebuilt_total{rebuilt.eval_total_energy(moved_particles)};
 
   INFO("Incremental Ewald updates should agree with a full reinitialization after one move.");
   CAPTURE(moved, old_x, old_y, old_z, incremental_total, rebuilt_total);
-  require_near(incremental_total, rebuilt_total, 1e-9);
+  require_near(incremental_total, rebuilt_total, 1e-9_r);
 }

--- a/tests/test_jastrow_pade.cpp
+++ b/tests/test_jastrow_pade.cpp
@@ -7,11 +7,11 @@
 
 namespace {
 
-double valueAtOffset(
+real_t valueAtOffset(
   const JastrowPade& jastrow,
   const Particles& reference,
   std::size_t particle,
-  double dx, double dy, double dz
+  real_t dx, real_t dy, real_t dz
 ) {
   Particles shifted{copy_particle_positions(reference)};
   shifted.pos().x_[particle] += dx;
@@ -23,176 +23,176 @@ double valueAtOffset(
 } // namespace
 
 TEST_CASE("Jastrow value uses minimum-image pair distances", "[jastrow]") {
-  const JastrowPade jastrow{10.0, 0.25, 1.0};
+  const JastrowPade jastrow{10.0_r, 0.25_r, 1.0_r};
   Particles particles{2U};
 
-  particles.pos().x_[0] = 0.1;
-  particles.pos().y_[0] = 0.0;
-  particles.pos().z_[0] = 0.0;
+  particles.pos().x_[0] = 0.1_r;
+  particles.pos().y_[0] = 0.0_r;
+  particles.pos().z_[0] = 0.0_r;
 
-  particles.pos().x_[1] = 9.9;
-  particles.pos().y_[1] = 0.0;
-  particles.pos().z_[1] = 0.0;
+  particles.pos().x_[1] = 9.9_r;
+  particles.pos().y_[1] = 0.0_r;
+  particles.pos().z_[1] = 0.0_r;
 
-  const double r{0.2};
-  const double expected{(0.25 * r) / (1.0 + r)};
+  const real_t r{0.2_r};
+  const real_t expected{(0.25_r * r) / (1.0_r + r)};
   require_near(jastrow.value(particles), expected);
 }
 
 TEST_CASE("Jastrow value skips degenerate pairs", "[jastrow]") {
-  const JastrowPade jastrow{10.0, 0.25, 1.0};
+  const JastrowPade jastrow{10.0_r, 0.25_r, 1.0_r};
   Particles particles{2U};
 
-  particles.pos().x_[0] = 1.0;
-  particles.pos().y_[0] = 2.0;
-  particles.pos().z_[0] = 3.0;
+  particles.pos().x_[0] = 1.0_r;
+  particles.pos().y_[0] = 2.0_r;
+  particles.pos().z_[0] = 3.0_r;
 
-  particles.pos().x_[1] = 1.0;
-  particles.pos().y_[1] = 2.0;
-  particles.pos().z_[1] = 3.0;
+  particles.pos().x_[1] = 1.0_r;
+  particles.pos().y_[1] = 2.0_r;
+  particles.pos().z_[1] = 3.0_r;
 
-  require_near(jastrow.value(particles), 0.0);
+  require_near(jastrow.value(particles), 0.0_r);
 }
 
 TEST_CASE("Jastrow derivatives match the analytic two-particle result", "[jastrow]") {
-  const JastrowPade jastrow{100.0, 0.25, 1.0};
+  const JastrowPade jastrow{100.0_r, 0.25_r, 1.0_r};
   Particles particles{2U};
 
-  particles.pos().x_[0] = 0.0;
-  particles.pos().y_[0] = 0.0;
-  particles.pos().z_[0] = 0.0;
+  particles.pos().x_[0] = 0.0_r;
+  particles.pos().y_[0] = 0.0_r;
+  particles.pos().z_[0] = 0.0_r;
 
-  particles.pos().x_[1] = 1.0;
-  particles.pos().y_[1] = 0.0;
-  particles.pos().z_[1] = 0.0;
+  particles.pos().x_[1] = 1.0_r;
+  particles.pos().y_[1] = 0.0_r;
+  particles.pos().z_[1] = 0.0_r;
 
   const std::size_t stride{particles.p_stride()};
-  std::vector<double> gradX(stride, 0.0);
-  std::vector<double> gradY(stride, 0.0);
-  std::vector<double> gradZ(stride, 0.0);
-  std::vector<double> lap(stride, 0.0);
+  std::vector<real_t> gradX(stride, 0.0_r);
+  std::vector<real_t> gradY(stride, 0.0_r);
+  std::vector<real_t> gradZ(stride, 0.0_r);
+  std::vector<real_t> lap(stride, 0.0_r);
 
   jastrow.add_derivatives(particles, gradX.data(), gradY.data(), gradZ.data(), lap.data());
 
-  require_near(gradX[0], -0.0625);
-  require_near(gradX[1], 0.0625);
-  require_near(gradX[0] + gradX[1], 0.0);
+  require_near(gradX[0], -0.0625_r);
+  require_near(gradX[1], 0.0625_r);
+  require_near(gradX[0] + gradX[1], 0.0_r);
 
-  require_near(gradY[0], 0.0);
-  require_near(gradY[1], 0.0);
-  require_near(gradZ[0], 0.0);
-  require_near(gradZ[1], 0.0);
+  require_near(gradY[0], 0.0_r);
+  require_near(gradY[1], 0.0_r);
+  require_near(gradZ[0], 0.0_r);
+  require_near(gradZ[1], 0.0_r);
 
   // ∇²u = u'' + (2/r)u' = -0.0625 + 2(0.0625) = 0.0625
-  require_near(lap[0], 0.0625);
-  require_near(lap[1], 0.0625);
+  require_near(lap[0], 0.0625_r);
+  require_near(lap[1], 0.0625_r);
 
   for (std::size_t i = 2; i < stride; ++i) {
-    require_near(gradX[i], 0.0);
-    require_near(gradY[i], 0.0);
-    require_near(gradZ[i], 0.0);
-    require_near(lap[i], 0.0);
+    require_near(gradX[i], 0.0_r);
+    require_near(gradY[i], 0.0_r);
+    require_near(gradZ[i], 0.0_r);
+    require_near(lap[i], 0.0_r);
   }
 }
 
 TEST_CASE("Jastrow derivatives are unchanged for degenerate pairs", "[jastrow]") {
-  const JastrowPade jastrow{10.0, 0.25, 1.0};
+  const JastrowPade jastrow{10.0_r, 0.25_r, 1.0_r};
   Particles particles{2U};
 
-  particles.pos().x_[0] = 4.0;
-  particles.pos().y_[0] = 5.0;
-  particles.pos().z_[0] = 6.0;
+  particles.pos().x_[0] = 4.0_r;
+  particles.pos().y_[0] = 5.0_r;
+  particles.pos().z_[0] = 6.0_r;
 
-  particles.pos().x_[1] = 4.0;
-  particles.pos().y_[1] = 5.0;
-  particles.pos().z_[1] = 6.0;
+  particles.pos().x_[1] = 4.0_r;
+  particles.pos().y_[1] = 5.0_r;
+  particles.pos().z_[1] = 6.0_r;
 
   const std::size_t stride{particles.p_stride()};
-  std::vector<double> gradX(stride, 3.0);
-  std::vector<double> gradY(stride, -2.0);
-  std::vector<double> gradZ(stride, 1.5);
-  std::vector<double> lap(stride, 7.0);
+  std::vector<real_t> gradX(stride, 3.0_r);
+  std::vector<real_t> gradY(stride, -2.0_r);
+  std::vector<real_t> gradZ(stride, 1.5_r);
+  std::vector<real_t> lap(stride, 7.0_r);
 
   jastrow.add_derivatives(particles, gradX.data(), gradY.data(), gradZ.data(), lap.data());
 
   for (std::size_t i = 0; i < stride; ++i) {
-    require_near(gradX[i], 3.0);
-    require_near(gradY[i], -2.0);
-    require_near(gradZ[i], 1.5);
-    require_near(lap[i], 7.0);
+    require_near(gradX[i], 3.0_r);
+    require_near(gradY[i], -2.0_r);
+    require_near(gradZ[i], 1.5_r);
+    require_near(lap[i], 7.0_r);
   }
 }
 
 TEST_CASE("Jastrow derivatives match finite-difference gradients and Laplacians", "[jastrow]") {
-  const JastrowPade jastrow{20.0, 0.6, 0.9};
+  const JastrowPade jastrow{20.0_r, 0.6_r, 0.9_r};
   Particles particles{3U};
 
-  particles.pos().x_[0] = 1.1;
-  particles.pos().y_[0] = 2.2;
-  particles.pos().z_[0] = 0.7;
+  particles.pos().x_[0] = 1.1_r;
+  particles.pos().y_[0] = 2.2_r;
+  particles.pos().z_[0] = 0.7_r;
 
-  particles.pos().x_[1] = 3.8;
-  particles.pos().y_[1] = 1.4;
-  particles.pos().z_[1] = 2.5;
+  particles.pos().x_[1] = 3.8_r;
+  particles.pos().y_[1] = 1.4_r;
+  particles.pos().z_[1] = 2.5_r;
 
-  particles.pos().x_[2] = 0.2;
-  particles.pos().y_[2] = 4.1;
-  particles.pos().z_[2] = 3.3;
+  particles.pos().x_[2] = 0.2_r;
+  particles.pos().y_[2] = 4.1_r;
+  particles.pos().z_[2] = 3.3_r;
 
   const std::size_t stride{particles.p_stride()};
-  std::vector<double> gradX(stride, 0.0);
-  std::vector<double> gradY(stride, 0.0);
-  std::vector<double> gradZ(stride, 0.0);
-  std::vector<double> lap(stride, 0.0);
+  std::vector<real_t> gradX(stride, 0.0_r);
+  std::vector<real_t> gradY(stride, 0.0_r);
+  std::vector<real_t> gradZ(stride, 0.0_r);
+  std::vector<real_t> lap(stride, 0.0_r);
   jastrow.add_derivatives(particles, gradX.data(), gradY.data(), gradZ.data(), lap.data());
 
-  const double h{1e-5};
-  const double valueCenter{jastrow.value(particles)};
+  const real_t h{1e-5_r};
+  const real_t valueCenter{jastrow.value(particles)};
 
-  const double dJdx{
+  const real_t dJdx{
     (
-      valueAtOffset(jastrow, particles, 0U, h, 0.0, 0.0) -
-      valueAtOffset(jastrow, particles, 0U, -h, 0.0, 0.0)
-    ) / (2.0 * h)
+      valueAtOffset(jastrow, particles, 0U, h, 0.0_r, 0.0_r) -
+      valueAtOffset(jastrow, particles, 0U, -h, 0.0_r, 0.0_r)
+    ) / (2.0_r * h)
   };
-  const double dJdy{
+  const real_t dJdy{
     (
-      valueAtOffset(jastrow, particles, 0U, 0.0, h, 0.0) -
-      valueAtOffset(jastrow, particles, 0U, 0.0, -h, 0.0)
-    ) / (2.0 * h)
+      valueAtOffset(jastrow, particles, 0U, 0.0_r, h, 0.0_r) -
+      valueAtOffset(jastrow, particles, 0U, 0.0_r, -h, 0.0_r)
+    ) / (2.0_r * h)
   };
-  const double dJdz{
+  const real_t dJdz{
     (
-      valueAtOffset(jastrow, particles, 0U, 0.0, 0.0, h) -
-      valueAtOffset(jastrow, particles, 0U, 0.0, 0.0, -h)
-    ) / (2.0 * h)
+      valueAtOffset(jastrow, particles, 0U, 0.0_r, 0.0_r, h) -
+      valueAtOffset(jastrow, particles, 0U, 0.0_r, 0.0_r, -h)
+    ) / (2.0_r * h)
   };
 
-  const double d2Jdx2{
+  const real_t d2Jdx2{
     (
-      valueAtOffset(jastrow, particles, 0U, h, 0.0, 0.0) - 2.0 * valueCenter +
-      valueAtOffset(jastrow, particles, 0U, -h, 0.0, 0.0)
+      valueAtOffset(jastrow, particles, 0U, h, 0.0_r, 0.0_r) - 2.0_r * valueCenter +
+      valueAtOffset(jastrow, particles, 0U, -h, 0.0_r, 0.0_r)
     ) / (h * h)
   };
-  const double d2Jdy2{
+  const real_t d2Jdy2{
     (
-      valueAtOffset(jastrow, particles, 0U, 0.0, h, 0.0) - 2.0 * valueCenter +
-      valueAtOffset(jastrow, particles, 0U, 0.0, -h, 0.0)
+      valueAtOffset(jastrow, particles, 0U, 0.0_r, h, 0.0_r) - 2.0_r * valueCenter +
+      valueAtOffset(jastrow, particles, 0U, 0.0_r, -h, 0.0_r)
     ) / (h * h)
   };
-  const double d2Jdz2{
+  const real_t d2Jdz2{
     (
-      valueAtOffset(jastrow, particles, 0U, 0.0, 0.0, h) - 2.0 * valueCenter +
-      valueAtOffset(jastrow, particles, 0U, 0.0, 0.0, -h)
+      valueAtOffset(jastrow, particles, 0U, 0.0_r, 0.0_r, h) - 2.0_r * valueCenter +
+      valueAtOffset(jastrow, particles, 0U, 0.0_r, 0.0_r, -h)
     ) / (h * h)
   };
 
-  require_near(gradX[0], dJdx, 1e-7);
-  require_near(gradY[0], dJdy, 1e-7);
-  require_near(gradZ[0], dJdz, 1e-7);
-  require_near(lap[0], d2Jdx2 + d2Jdy2 + d2Jdz2, 2e-4);
+  require_near(gradX[0], dJdx, 1e-7_r);
+  require_near(gradY[0], dJdy, 1e-7_r);
+  require_near(gradZ[0], dJdz, 1e-7_r);
+  require_near(lap[0], d2Jdx2 + d2Jdy2 + d2Jdz2, 2e-4_r);
 
-  require_near(gradX[0] + gradX[1] + gradX[2], 0.0, 1e-12);
-  require_near(gradY[0] + gradY[1] + gradY[2], 0.0, 1e-12);
-  require_near(gradZ[0] + gradZ[1] + gradZ[2], 0.0, 1e-12);
+  require_near(gradX[0] + gradX[1] + gradX[2], 0.0_r, 1e-12_r);
+  require_near(gradY[0] + gradY[1] + gradY[2], 0.0_r, 1e-12_r);
+  require_near(gradZ[0] + gradZ[1] + gradZ[2], 0.0_r, 1e-12_r);
 }

--- a/tests/test_known_energy.cpp
+++ b/tests/test_known_energy.cpp
@@ -41,44 +41,44 @@ namespace {
 ///   r_s=5:   -0.0537 Ha
 ///   r_s=10:  -0.0457 Ha
 ///   r_s=20:  -0.0279 Ha
-double published_pz_total_energy(double r_s) {
+real_t published_pz_total_energy(real_t r_s) {
   // T_HF/N = (2.21 * 2^(2/3)) / (2 * r_s^2) Ha
-  constexpr double T_COEFF{2.21 * 1.587401051968199 * 0.5};
-  const double t{T_COEFF / (r_s * r_s)};
+  constexpr real_t T_COEFF{2.21_r * 1.587401051968199_r * 0.5_r};
+  const real_t t{T_COEFF / (r_s * r_s)};
 
   // E_x/N = -(0.9163 * 2^(1/3)) / (2 * r_s) Ha
-  constexpr double EX_COEFF{0.9163 * 1.2599210498948732 * 0.5};
-  const double ex{-EX_COEFF / r_s};
+  constexpr real_t EX_COEFF{0.9163_r * 1.2599210498948732_r * 0.5_r};
+  const real_t ex{-EX_COEFF / r_s};
 
   // PZ81 correlation for ζ=1, in Ry -> Ha (divide by 2)
-  double ec_ry{};
-  if (r_s >= 1.0) {
-    constexpr double GAMMA{-0.0843};
-    constexpr double BETA1{1.0529};
-    constexpr double BETA2{0.3334};
-    ec_ry = GAMMA / (1.0 + BETA1 * std::sqrt(r_s) + BETA2 * r_s);
+  real_t ec_ry{};
+  if (r_s >= 1.0_r) {
+    constexpr real_t GAMMA{-0.0843_r};
+    constexpr real_t BETA1{1.0529_r};
+    constexpr real_t BETA2{0.3334_r};
+    ec_ry = GAMMA / (1.0_r + BETA1 * std::sqrt(r_s) + BETA2 * r_s);
   } else {
-    constexpr double A{0.01555};
-    constexpr double B{-0.0269};
-    constexpr double C{0.0007};
-    constexpr double D{-0.0048};
-    const double ln_rs{std::log(r_s)};
+    constexpr real_t A{0.01555_r};
+    constexpr real_t B{-0.0269_r};
+    constexpr real_t C{0.0007_r};
+    constexpr real_t D{-0.0048_r};
+    const real_t ln_rs{std::log(r_s)};
     ec_ry = A * ln_rs + B + C * r_s * ln_rs + D * r_s;
   }
 
-  return t + ex + 0.5 * ec_ry;
+  return t + ex + 0.5_r * ec_ry;
 }
 
 SimResult run_published_vmc(
   std::size_t N,
-  double r_s,
+  real_t r_s,
   std::size_t warmup_steps,
   std::size_t measure_steps,
-  double step_size,
+  real_t step_size,
   uint64_t seed,
   std::size_t block_size
 ) {
-  const double L{box_length_from_rs(r_s, N)};
+  const real_t L{box_length_from_rs(r_s, N)};
   Config config{make_config(N, L, warmup_steps, measure_steps, step_size, seed, block_size)};
 
   auto writer{std::make_unique<RecordingOutputWriter>()};
@@ -90,7 +90,7 @@ SimResult run_published_vmc(
   SimResult result{};
   if (sink->done.has_value()) {
     result.mean_energy = sink->done->final_mean_energy;
-    result.standard_error = sink->done->final_standard_error.value_or(0.0);
+    result.standard_error = sink->done->final_standard_error.value_or(0.0_r);
     result.acceptance_rate = sink->done->final_acceptance_rate;
   }
   return result;
@@ -111,82 +111,82 @@ SimResult run_published_vmc(
 
 TEST_CASE("Published values: E/N at r_s=5, N=19 matches PZ81 within 0.01 Ha", "[published]") {
   constexpr std::size_t N{19U};
-  constexpr double R_S{5.0};
-  const double E_PZ{published_pz_total_energy(R_S)};
+  constexpr real_t R_S{5.0_r};
+  const real_t E_PZ{published_pz_total_energy(R_S)};
 
-  const auto result{run_published_vmc(N, R_S, 5000U, 80000U, 0.6, 5019U, 2000U)};
-  const double E_VMC{result.mean_energy / static_cast<double>(N)};
+  const auto result{run_published_vmc(N, R_S, 5000U, 80000U, 0.6_r, 5019U, 2000U)};
+  const real_t E_VMC{result.mean_energy / static_cast<real_t>(N)};
 
   INFO("E_VMC/N    = " << E_VMC << " Ha");
   INFO("E_PZ/N     = " << E_PZ << " Ha (Perdew-Zunger, thermo limit)");
   INFO("Difference = " << (E_VMC - E_PZ) << " Ha");
 
   REQUIRE(std::isfinite(E_VMC));
-  REQUIRE(std::abs(E_VMC - E_PZ) < 0.01);
+  REQUIRE(std::abs(E_VMC - E_PZ) < 0.01_r);
 }
 
 TEST_CASE("Published values: E/N at r_s=10, N=19 matches PZ81 within 0.005 Ha", "[published]") {
   constexpr std::size_t N{19U};
-  constexpr double R_S{10.0};
-  const double E_PZ{published_pz_total_energy(R_S)};
+  constexpr real_t R_S{10.0_r};
+  const real_t E_PZ{published_pz_total_energy(R_S)};
 
-  const auto result{run_published_vmc(N, R_S, 5000U, 80000U, 1.0, 10019U, 2000U)};
-  const double E_VMC{result.mean_energy / static_cast<double>(N)};
+  const auto result{run_published_vmc(N, R_S, 5000U, 80000U, 1.0_r, 10019U, 2000U)};
+  const real_t E_VMC{result.mean_energy / static_cast<real_t>(N)};
 
   INFO("E_VMC/N    = " << E_VMC << " Ha");
   INFO("E_PZ/N     = " << E_PZ << " Ha (Perdew-Zunger, thermo limit)");
   INFO("Difference = " << (E_VMC - E_PZ) << " Ha");
 
   REQUIRE(std::isfinite(E_VMC));
-  REQUIRE(std::abs(E_VMC - E_PZ) < 0.005);
+  REQUIRE(std::abs(E_VMC - E_PZ) < 0.005_r);
 }
 
 TEST_CASE("Published values: E/N at r_s=10, N=7 matches PZ81 within 0.005 Ha", "[published]") {
   constexpr std::size_t N{7U};
-  constexpr double R_S{10.0};
-  const double E_PZ{published_pz_total_energy(R_S)};
+  constexpr real_t R_S{10.0_r};
+  const real_t E_PZ{published_pz_total_energy(R_S)};
 
-  const auto result{run_published_vmc(N, R_S, 5000U, 80000U, 1.2, 10007U, 2000U)};
-  const double E_VMC{result.mean_energy / static_cast<double>(N)};
+  const auto result{run_published_vmc(N, R_S, 5000U, 80000U, 1.2_r, 10007U, 2000U)};
+  const real_t E_VMC{result.mean_energy / static_cast<real_t>(N)};
 
   INFO("E_VMC/N    = " << E_VMC << " Ha");
   INFO("E_PZ/N     = " << E_PZ << " Ha (Perdew-Zunger, thermo limit)");
   INFO("Difference = " << (E_VMC - E_PZ) << " Ha");
 
   REQUIRE(std::isfinite(E_VMC));
-  REQUIRE(std::abs(E_VMC - E_PZ) < 0.005);
+  REQUIRE(std::abs(E_VMC - E_PZ) < 0.005_r);
 }
 
 // At r_s=2 finite-size effects are larger, use wider tolerance
 TEST_CASE("Published values: E/N at r_s=2, N=19 matches PZ81 within 0.07 Ha", "[published]") {
   constexpr std::size_t N{19U};
-  constexpr double R_S{2.0};
-  const double E_PZ{published_pz_total_energy(R_S)};
+  constexpr real_t R_S{2.0_r};
+  const real_t E_PZ{published_pz_total_energy(R_S)};
 
-  const auto result{run_published_vmc(N, R_S, 5000U, 80000U, 0.3, 2019U, 2000U)};
-  const double E_VMC{result.mean_energy / static_cast<double>(N)};
+  const auto result{run_published_vmc(N, R_S, 5000U, 80000U, 0.3_r, 2019U, 2000U)};
+  const real_t E_VMC{result.mean_energy / static_cast<real_t>(N)};
 
   INFO("E_VMC/N    = " << E_VMC << " Ha");
   INFO("E_PZ/N     = " << E_PZ << " Ha (Perdew-Zunger, thermo limit)");
   INFO("Difference = " << (E_VMC - E_PZ) << " Ha");
 
   REQUIRE(std::isfinite(E_VMC));
-  REQUIRE(std::abs(E_VMC - E_PZ) < 0.07);
+  REQUIRE(std::abs(E_VMC - E_PZ) < 0.07_r);
 }
 
 // Convergence toward published values with increasing N
 TEST_CASE("Published values: N=19 closer to PZ81 than N=7 at r_s=5", "[published]") {
-  constexpr double R_S{5.0};
-  const double E_PZ{published_pz_total_energy(R_S)};
+  constexpr real_t R_S{5.0_r};
+  const real_t E_PZ{published_pz_total_energy(R_S)};
 
-  const auto r7{run_published_vmc(7U, R_S, 5000U, 60000U, 0.8, 7500U, 1500U)};
-  const auto r19{run_published_vmc(19U, R_S, 5000U, 60000U, 0.6, 19500U, 1500U)};
+  const auto r7{run_published_vmc(7U, R_S, 5000U, 60000U, 0.8_r, 7500U, 1500U)};
+  const auto r19{run_published_vmc(19U, R_S, 5000U, 60000U, 0.6_r, 19500U, 1500U)};
 
-  const double E7{r7.mean_energy / 7.0};
-  const double E19{r19.mean_energy / 19.0};
+  const real_t E7{r7.mean_energy / 7.0_r};
+  const real_t E19{r19.mean_energy / 19.0_r};
 
-  const double ERR7{std::abs(E7 - E_PZ)};
-  const double ERR19{std::abs(E19 - E_PZ)};
+  const real_t ERR7{std::abs(E7 - E_PZ)};
+  const real_t ERR19{std::abs(E19 - E_PZ)};
 
   INFO("E/N (N=7)  = " << E7 << " Ha, |err| = " << ERR7);
   INFO("E/N (N=19) = " << E19 << " Ha, |err| = " << ERR19);
@@ -200,45 +200,45 @@ TEST_CASE("Published values: N=19 closer to PZ81 than N=7 at r_s=5", "[published
 TEST_CASE("Published values: correct sign at each density", "[published]") {
   // r_s=1: kinetic dominates, E/N > 0
   {
-    const auto r{run_published_vmc(19U, 1.0, 5000U, 40000U, 0.2, 1100U, 1000U)};
-    REQUIRE(r.mean_energy / 19.0 > 0.0);
+    const auto r{run_published_vmc(19U, 1.0_r, 5000U, 40000U, 0.2_r, 1100U, 1000U)};
+    REQUIRE(r.mean_energy / 19.0_r > 0.0_r);
   }
   // r_s=5: correlation dominates, E/N < 0
   {
-    const auto r{run_published_vmc(19U, 5.0, 5000U, 40000U, 0.6, 5100U, 1000U)};
-    REQUIRE(r.mean_energy / 19.0 < 0.0);
+    const auto r{run_published_vmc(19U, 5.0_r, 5000U, 40000U, 0.6_r, 5100U, 1000U)};
+    REQUIRE(r.mean_energy / 19.0_r < 0.0_r);
   }
   // r_s=10: E/N < 0
   {
-    const auto r{run_published_vmc(19U, 10.0, 5000U, 40000U, 1.0, 10100U, 1000U)};
-    REQUIRE(r.mean_energy / 19.0 < 0.0);
+    const auto r{run_published_vmc(19U, 10.0_r, 5000U, 40000U, 1.0_r, 10100U, 1000U)};
+    REQUIRE(r.mean_energy / 19.0_r < 0.0_r);
   }
 }
 
 TEST_CASE("Published values: E/N decreases from r_s=2 to r_s=5", "[published]") {
-  const auto r2{run_published_vmc(19U, 2.0, 5000U, 60000U, 0.3, 2200U, 1500U)};
-  const auto r5{run_published_vmc(19U, 5.0, 5000U, 60000U, 0.6, 5200U, 1500U)};
-  REQUIRE(r5.mean_energy / 19.0 < r2.mean_energy / 19.0);
+  const auto r2{run_published_vmc(19U, 2.0_r, 5000U, 60000U, 0.3_r, 2200U, 1500U)};
+  const auto r5{run_published_vmc(19U, 5.0_r, 5000U, 60000U, 0.6_r, 5200U, 1500U)};
+  REQUIRE(r5.mean_energy / 19.0_r < r2.mean_energy / 19.0_r);
 }
 
 TEST_CASE("Published values: deterministic reproducibility", "[published]") {
-  const auto r1{run_published_vmc(7U, 5.0, 2000U, 20000U, 0.8, 42U, 500U)};
-  const auto r2{run_published_vmc(7U, 5.0, 2000U, 20000U, 0.8, 42U, 500U)};
+  const auto r1{run_published_vmc(7U, 5.0_r, 2000U, 20000U, 0.8_r, 42U, 500U)};
+  const auto r2{run_published_vmc(7U, 5.0_r, 2000U, 20000U, 0.8_r, 42U, 500U)};
   REQUIRE(r1.mean_energy == r2.mean_energy);
 }
 
 // Print comparison table
 TEST_CASE("Published values: print comparison table", "[published][.print]") {
   struct Run {
-    double r_s;
+    real_t r_s;
     std::size_t N;
-    double step;
+    real_t step;
     uint64_t seed;
   };
   const Run runs[] = {
-      {1.0, 7U, 0.2, 1007U},   {1.0, 19U, 0.2, 1019U},   {2.0, 7U, 0.4, 2007U},
-      {2.0, 19U, 0.3, 2019U},  {5.0, 7U, 0.8, 5007U},    {5.0, 19U, 0.6, 5019U},
-      {10.0, 7U, 1.2, 10007U}, {10.0, 19U, 1.0, 10019U},
+      {1.0_r, 7U, 0.2_r, 1007U},   {1.0_r, 19U, 0.2_r, 1019U},   {2.0_r, 7U, 0.4_r, 2007U},
+      {2.0_r, 19U, 0.3_r, 2019U},  {5.0_r, 7U, 0.8_r, 5007U},    {5.0_r, 19U, 0.6_r, 5019U},
+      {10.0_r, 7U, 1.2_r, 10007U}, {10.0_r, 19U, 1.0_r, 10019U},
   };
 
   std::cout << "\n=== VMC vs Perdew-Zunger Published Values (Ha/electron) ===\n";
@@ -246,11 +246,11 @@ TEST_CASE("Published values: print comparison table", "[published][.print]") {
   std::cout << "  ----  ---  ----------   ----------   ---------   ------\n";
 
   for (const auto& run : runs) {
-    const double e_pz{published_pz_total_energy(run.r_s)};
+    const real_t e_pz{published_pz_total_energy(run.r_s)};
     const auto result{run_published_vmc(run.N, run.r_s, 5000U, 80000U, run.step, run.seed, 2000U)};
-    const double e_vmc{result.mean_energy / static_cast<double>(run.N)};
-    const double diff{e_vmc - e_pz};
-    const double pct{(std::abs(e_pz) > 1e-10) ? 100.0 * diff / e_pz : 0.0};
+    const real_t e_vmc{result.mean_energy / static_cast<real_t>(run.N)};
+    const real_t diff{e_vmc - e_pz};
+    const real_t pct{(std::abs(e_pz) > 1e-10_r) ? 100.0_r * diff / e_pz : 0.0_r};
 
     std::printf(
       "  %4.1f  %3zu  %+10.6f   %+10.6f   %+9.6f   %+6.1f%%\n",

--- a/tests/test_matrix.cpp
+++ b/tests/test_matrix.cpp
@@ -6,31 +6,37 @@
 #include <cmath>
 #include <cstddef>
 
+#ifdef FP_64
+constexpr real_t MATRIX_TOLERANCE{1e-9_r};
+#else
+constexpr real_t MATRIX_TOLERANCE{1e-4_r};
+#endif
+
 TEST_CASE("LU decomposition solves a non-singular system", "[matrix]") {
   constexpr std::size_t N{3};
-  std::array<double, N * N> A{
-      2.0, 1.0, 1.0, 4.0, 3.0, 3.0, 8.0, 7.0, 9.0,
+  std::array<real_t, N * N> A{
+      2.0_r, 1.0_r, 1.0_r, 4.0_r, 3.0_r, 3.0_r, 8.0_r, 7.0_r, 9.0_r,
   };
-  std::array<double, N> b{7.0, 19.0, 49.0};
+  std::array<real_t, N> b{7.0_r, 19.0_r, 49.0_r};
   std::array<int, N> pivot{};
-  std::array<double, N> x{};
+  std::array<real_t, N> x{};
 
   (void)lower_upper_decomp(A.data(), pivot.data(), N, N);
   solve_lower_upper(A.data(), pivot.data(), b.data(), x.data(), N, N);
 
-  REQUIRE(std::abs(x[0] - 1.0) < 1e-9);
-  REQUIRE(std::abs(x[1] - 2.0) < 1e-9);
-  REQUIRE(std::abs(x[2] - 3.0) < 1e-9);
+  REQUIRE(std::abs(x[0] - 1.0_r) < MATRIX_TOLERANCE);
+  REQUIRE(std::abs(x[1] - 2.0_r) < MATRIX_TOLERANCE);
+  REQUIRE(std::abs(x[2] - 3.0_r) < MATRIX_TOLERANCE);
 }
 
 TEST_CASE("LU back-substitution stays finite on a singular matrix", "[matrix]") {
   constexpr std::size_t N{3};
-  std::array<double, N * N> A{
-      1.0, 2.0, 3.0, 2.0, 4.0, 6.0, 1.0, 1.0, 1.0,
+  std::array<real_t, N * N> A{
+      1.0_r, 2.0_r, 3.0_r, 2.0_r, 4.0_r, 6.0_r, 1.0_r, 1.0_r, 1.0_r,
   };
-  std::array<double, N> b{1.0, 1.0, 1.0};
+  std::array<real_t, N> b{1.0_r, 1.0_r, 1.0_r};
   std::array<int, N> pivot{};
-  std::array<double, N> x{};
+  std::array<real_t, N> x{};
 
   (void)lower_upper_decomp(A.data(), pivot.data(), N, N);
   solve_lower_upper(A.data(), pivot.data(), b.data(), x.data(), N, N);

--- a/tests/test_optimizer.cpp
+++ b/tests/test_optimizer.cpp
@@ -11,9 +11,9 @@
 
 namespace {
 
-double energy_at_b(std::size_t N, double r_s, double b, uint64_t seed) {
-  const double L{box_length_from_rs(r_s, N)};
-  Config config{make_config(N, L, 3000U, 40000U, L / 10.0, seed, 1000U)};
+real_t energy_at_b(std::size_t N, real_t r_s, real_t b, uint64_t seed) {
+  const real_t L{box_length_from_rs(r_s, N)};
+  Config config{make_config(N, L, 3000U, 40000U, L / 10.0_r, seed, 1000U)};
   config.jastrow_b = b;
 
   Simulation sim{config};
@@ -26,8 +26,8 @@ double energy_at_b(std::size_t N, double r_s, double b, uint64_t seed) {
 // The optimizer should find a b value, and it should be positive and finite
 TEST_CASE("Optimizer: produces valid b parameter", "[optimizer]") {
   constexpr std::size_t N{7U};
-  constexpr double R_S{5.0};
-  const double L{box_length_from_rs(R_S, N)};
+  constexpr real_t R_S{5.0_r};
+  const real_t L{box_length_from_rs(R_S, N)};
 
   Config config{};
   config.num_particles = N;
@@ -37,7 +37,7 @@ TEST_CASE("Optimizer: produces valid b parameter", "[optimizer]") {
   config.measure_sweeps = 100U;
   config.warmup_steps = N * config.warmup_sweeps;
   config.measure_steps = N * config.measure_sweeps;
-  config.step_size = L / 10.0;
+  config.step_size = L / 10.0_r;
   config.block_size = 100U;
 
   const auto result{JastrowOptimizer::optimize(config)};
@@ -46,15 +46,15 @@ TEST_CASE("Optimizer: produces valid b parameter", "[optimizer]") {
   INFO("energy    = " << result.energy);
 
   REQUIRE(std::isfinite(result.optimal_b));
-  REQUIRE(result.optimal_b > 0.0);
+  REQUIRE(result.optimal_b > 0.0_r);
   REQUIRE(std::isfinite(result.energy));
 }
 
 // The optimized b should give lower (or equal) energy than b=1.0
 TEST_CASE("Optimizer: optimized b lowers energy vs default b=1", "[optimizer]") {
   constexpr std::size_t N{7U};
-  constexpr double R_S{5.0};
-  const double L{box_length_from_rs(R_S, N)};
+  constexpr real_t R_S{5.0_r};
+  const real_t L{box_length_from_rs(R_S, N)};
 
   Config config{};
   config.num_particles = N;
@@ -64,14 +64,14 @@ TEST_CASE("Optimizer: optimized b lowers energy vs default b=1", "[optimizer]") 
   config.measure_sweeps = 100U;
   config.warmup_steps = N * config.warmup_sweeps;
   config.measure_steps = N * config.measure_sweeps;
-  config.step_size = L / 10.0;
+  config.step_size = L / 10.0_r;
   config.block_size = 100U;
 
   const auto result{JastrowOptimizer::optimize(config)};
 
   // Run a longer simulation at the optimized b and at the default b=1
-  const double E_OPTIMIZED{energy_at_b(N, R_S, result.optimal_b, 9999U)};
-  const double E_DEFAULT{energy_at_b(N, R_S, 1.0, 9999U)};
+  const real_t E_OPTIMIZED{energy_at_b(N, R_S, result.optimal_b, 9999U)};
+  const real_t E_DEFAULT{energy_at_b(N, R_S, 1.0_r, 9999U)};
 
   INFO("E(b_opt=" << result.optimal_b << ") = " << E_OPTIMIZED);
   INFO("E(b=1.0) = " << E_DEFAULT);
@@ -82,8 +82,8 @@ TEST_CASE("Optimizer: optimized b lowers energy vs default b=1", "[optimizer]") 
 // At r_s=10 the optimizer should also work
 TEST_CASE("Optimizer: works at r_s=10", "[optimizer]") {
   constexpr std::size_t N{7U};
-  constexpr double R_S{10.0};
-  const double L{box_length_from_rs(R_S, N)};
+  constexpr real_t R_S{10.0_r};
+  const real_t L{box_length_from_rs(R_S, N)};
 
   Config config{};
   config.num_particles = N;
@@ -93,7 +93,7 @@ TEST_CASE("Optimizer: works at r_s=10", "[optimizer]") {
   config.measure_sweeps = 100U;
   config.warmup_steps = N * config.warmup_sweeps;
   config.measure_steps = N * config.measure_sweeps;
-  config.step_size = L / 10.0;
+  config.step_size = L / 10.0_r;
   config.block_size = 100U;
 
   const auto result{JastrowOptimizer::optimize(config)};
@@ -102,6 +102,6 @@ TEST_CASE("Optimizer: works at r_s=10", "[optimizer]") {
   INFO("energy = " << result.energy);
 
   REQUIRE(std::isfinite(result.optimal_b));
-  REQUIRE(result.optimal_b > 0.0);
-  REQUIRE(result.optimal_b < 20.0);
+  REQUIRE(result.optimal_b > 0.0_r);
+  REQUIRE(result.optimal_b < 20.0_r);
 }

--- a/tests/test_output_writer.cpp
+++ b/tests/test_output_writer.cpp
@@ -16,10 +16,10 @@ TEST_CASE("JsonOutputWriter writes init/frame/done records and escapes JSON stri
   const InitData init{
     .run_id = std::string{"run\"\\\b\f\n\r\t\x01"},
     .num_particles = 7U,
-    .box_length = 6.5,
+    .box_length = 6.5_r,
     .warmup_steps = 10U,
     .measure_steps = 20U,
-    .step_size = 0.2,
+    .step_size = 0.2_r,
     .seed = 42U,
     .block_size = 5U
   };
@@ -29,36 +29,36 @@ TEST_CASE("JsonOutputWriter writes init/frame/done records and escapes JSON stri
     .step = 1U,
     .accepted = 0U,
     .proposed = 1U,
-    .acceptance_rate = 0.0,
-    .local_energy = -1.25,
-    .mean_energy = -1.25,
+    .acceptance_rate = 0.0_r,
+    .local_energy = -1.25_r,
+    .mean_energy = -1.25_r,
     .standard_error = std::nullopt,
-    .positions = std::vector<double>{1.0, 2.0, 3.0}
+    .positions = std::vector<real_t>{1.0_r, 2.0_r, 3.0_r}
   });
 
   writer.write_frame(FrameData{
     .step = 2U,
     .accepted = 1U,
     .proposed = 2U,
-    .acceptance_rate = 0.5,
-    .local_energy = -1.0,
-    .mean_energy = -1.125,
-    .standard_error = 0.25,
-    .positions = std::vector<double>{4.0, 5.0, 6.0}
+    .acceptance_rate = 0.5_r,
+    .local_energy = -1.0_r,
+    .mean_energy = -1.125_r,
+    .standard_error = 0.25_r,
+    .positions = std::vector<real_t>{4.0_r, 5.0_r, 6.0_r}
   });
 
   writer.write_done(DoneData{
     .total_accepted = 1U,
     .total_proposed = 2U,
-    .final_acceptance_rate = 0.5,
-    .final_mean_energy = -1.125,
-    .final_standard_error = 0.125
+    .final_acceptance_rate = 0.5_r,
+    .final_mean_energy = -1.125_r,
+    .final_standard_error = 0.125_r
   });
   writer.write_done(DoneData{
     .total_accepted = 1U,
     .total_proposed = 2U,
-    .final_acceptance_rate = 0.5,
-    .final_mean_energy = -1.125,
+    .final_acceptance_rate = 0.5_r,
+    .final_mean_energy = -1.125_r,
     .final_standard_error = std::nullopt
   });
 
@@ -88,10 +88,10 @@ TEST_CASE("CsvOutputWriter methods throw until implemented", "[output_writer]") 
     writer.write_init(InitData{
       .run_id = "run",
       .num_particles = 1U,
-      .box_length = 1.0,
+      .box_length = 1.0_r,
       .warmup_steps = 0U,
       .measure_steps = 1U,
-      .step_size = 0.1,
+      .step_size = 0.1_r,
       .seed = 0U,
       .block_size = 1U
     }),
@@ -103,11 +103,11 @@ TEST_CASE("CsvOutputWriter methods throw until implemented", "[output_writer]") 
       .step = 1U,
       .accepted = 1U,
       .proposed = 1U,
-      .acceptance_rate = 1.0,
-      .local_energy = 0.0,
-      .mean_energy = 0.0,
+      .acceptance_rate = 1.0_r,
+      .local_energy = 0.0_r,
+      .mean_energy = 0.0_r,
       .standard_error = std::nullopt,
-      .positions = {0.0, 0.0, 0.0}
+      .positions = {0.0_r, 0.0_r, 0.0_r}
     }),
     std::logic_error
   );
@@ -116,8 +116,8 @@ TEST_CASE("CsvOutputWriter methods throw until implemented", "[output_writer]") 
     writer.write_done(DoneData{
       .total_accepted = 1U,
       .total_proposed = 1U,
-      .final_acceptance_rate = 1.0,
-      .final_mean_energy = 0.0,
+      .final_acceptance_rate = 1.0_r,
+      .final_mean_energy = 0.0_r,
       .final_standard_error = std::nullopt
     }),
     std::logic_error

--- a/tests/test_particles.cpp
+++ b/tests/test_particles.cpp
@@ -10,7 +10,7 @@ TEST_CASE("Particles allocates aligned padded blocks and zero-initializes them",
   Particles particles{numParticles};
 
   const std::size_t stride{particles.p_stride()};
-  const std::size_t doublesPerAlignment{SIMD_BYTES / sizeof(double)};
+  const std::size_t doublesPerAlignment{SIMD_BYTES / sizeof(real_t)};
 
   REQUIRE(particles.size() == numParticles);
   REQUIRE(stride >= numParticles);
@@ -20,13 +20,13 @@ TEST_CASE("Particles allocates aligned padded blocks and zero-initializes them",
   REQUIRE(baseAddress % SIMD_BYTES == 0U);
 
   for (std::size_t i = 0; i < stride; ++i) {
-    REQUIRE(particles.pos().x_[i] == 0.0);
-    REQUIRE(particles.pos().y_[i] == 0.0);
-    REQUIRE(particles.pos().z_[i] == 0.0);
-    REQUIRE(particles.grad_log_psi().x_[i] == 0.0);
-    REQUIRE(particles.grad_log_psi().y_[i] == 0.0);
-    REQUIRE(particles.grad_log_psi().z_[i] == 0.0);
-    REQUIRE(particles.lap_log_psi()[i] == 0.0);
+    REQUIRE(particles.pos().x_[i] == 0.0_r);
+    REQUIRE(particles.pos().y_[i] == 0.0_r);
+    REQUIRE(particles.pos().z_[i] == 0.0_r);
+    REQUIRE(particles.grad_log_psi().x_[i] == 0.0_r);
+    REQUIRE(particles.grad_log_psi().y_[i] == 0.0_r);
+    REQUIRE(particles.grad_log_psi().z_[i] == 0.0_r);
+    REQUIRE(particles.lap_log_psi()[i] == 0.0_r);
   }
 }
 
@@ -41,12 +41,12 @@ TEST_CASE("Particles exposes non-overlapping slices for each component", "[parti
   REQUIRE(particles.grad_log_psi().z_ - particles.grad_log_psi().y_ == stride);
   REQUIRE(particles.lap_log_psi() - particles.grad_log_psi().z_ == stride);
 
-  particles.pos().x_[0] = 1.0;
-  particles.pos().y_[0] = 2.0;
-  particles.pos().z_[0] = 3.0;
+  particles.pos().x_[0] = 1.0_r;
+  particles.pos().y_[0] = 2.0_r;
+  particles.pos().z_[0] = 3.0_r;
 
-  REQUIRE(particles.pos().x_[0] == 1.0);
-  REQUIRE(particles.pos().y_[0] == 2.0);
-  REQUIRE(particles.pos().z_[0] == 3.0);
-  REQUIRE(particles.grad_log_psi().x_[0] == 0.0);
+  REQUIRE(particles.pos().x_[0] == 1.0_r);
+  REQUIRE(particles.pos().y_[0] == 2.0_r);
+  REQUIRE(particles.pos().z_[0] == 3.0_r);
+  REQUIRE(particles.grad_log_psi().x_[0] == 0.0_r);
 }

--- a/tests/test_rigorous_physics.cpp
+++ b/tests/test_rigorous_physics.cpp
@@ -18,9 +18,15 @@
 
 namespace {
 
-constexpr double EWALD_RECIPROCAL_TOLERANCE{1.0e-6};
+#ifdef FP_64
+constexpr real_t RIGOROUS_PRECISION_SCALE{1.0_r};
+#else
+constexpr real_t RIGOROUS_PRECISION_SCALE{1e6_r};
+#endif
 
-double phy_determinant3x3(const double* matrix, std::size_t stride) {
+constexpr real_t EWALD_RECIPROCAL_TOLERANCE{1.0e-6_r};
+
+real_t phy_determinant3x3(const real_t* matrix, std::size_t stride) {
   return
     matrix[0 * stride + 0] * (
       matrix[1 * stride + 1] * matrix[2 * stride + 2] -
@@ -46,19 +52,19 @@ void phy_copy_positions(const Particles& source, Particles& dest) {
   }
 }
 
-double exact_real_potential(const Particles& particles, double box_length) {
+real_t exact_real_potential(const Particles& particles, real_t box_length) {
   const std::size_t n{particles.size()};
-  const double alpha{6.0 / box_length};
+  const real_t alpha{6.0_r / box_length};
 
-  double total{};
+  real_t total{};
 
   for (std::size_t i = 0; i < n; ++i) {
     for (std::size_t j = i + 1; j < n; ++j) {
-      const double dx{minimum_image(particles.pos().x_[i] - particles.pos().x_[j], box_length)};
-      const double dy{minimum_image(particles.pos().y_[i] - particles.pos().y_[j], box_length)};
-      const double dz{minimum_image(particles.pos().z_[i] - particles.pos().z_[j], box_length)};
+      const real_t dx{minimum_image(particles.pos().x_[i] - particles.pos().x_[j], box_length)};
+      const real_t dy{minimum_image(particles.pos().y_[i] - particles.pos().y_[j], box_length)};
+      const real_t dz{minimum_image(particles.pos().z_[i] - particles.pos().z_[j], box_length)};
 
-      const double r{std::sqrt(dx * dx + dy * dy + dz * dz)};
+      const real_t r{std::sqrt(dx * dx + dy * dy + dz * dz)};
       total += std::erfc(alpha * r) / r;
     }
   }
@@ -66,16 +72,16 @@ double exact_real_potential(const Particles& particles, double box_length) {
   return total;
 }
 
-double exact_reciprocal_potential(const Particles& particles, double box_length) {
+real_t exact_reciprocal_potential(const Particles& particles, real_t box_length) {
   const std::size_t n{particles.size()};
-  const double alpha{6.0 / box_length};
-  const double two_pi_over_l{2.0 * std::numbers::pi / box_length};
-  const double four_alpha_sq{4.0 * alpha * alpha};
-  const double cutoff_factor{-std::log(EWALD_RECIPROCAL_TOLERANCE)};
-  const double g_max_mag_sq{four_alpha_sq * cutoff_factor};
+  const real_t alpha{6.0_r / box_length};
+  const real_t two_pi_over_l{2.0_r * std::numbers::pi_v<real_t> / box_length};
+  const real_t four_alpha_sq{4.0_r * alpha * alpha};
+  const real_t cutoff_factor{-std::log(EWALD_RECIPROCAL_TOLERANCE)};
+  const real_t g_max_mag_sq{four_alpha_sq * cutoff_factor};
   const int m_max{static_cast<int>(std::ceil(std::sqrt(g_max_mag_sq) / two_pi_over_l)) + 1};
 
-  double weighted_sum{};
+  real_t weighted_sum{};
 
   for (int mx = -m_max; mx <= m_max; ++mx) {
     for (int my = -m_max; my <= m_max; ++my) {
@@ -90,25 +96,25 @@ double exact_reciprocal_potential(const Particles& particles, double box_length)
           continue;
         }
 
-        const double gx{two_pi_over_l * static_cast<double>(mx)};
-        const double gy{two_pi_over_l * static_cast<double>(my)};
-        const double gz{two_pi_over_l * static_cast<double>(mz)};
-        const double g_sq{gx * gx + gy * gy + gz * gz};
+        const real_t gx{two_pi_over_l * static_cast<real_t>(mx)};
+        const real_t gy{two_pi_over_l * static_cast<real_t>(my)};
+        const real_t gz{two_pi_over_l * static_cast<real_t>(mz)};
+        const real_t g_sq{gx * gx + gy * gy + gz * gz};
 
         if (g_sq > g_max_mag_sq) {
           continue;
         }
 
-        const double weight{
-          8.0 * std::numbers::pi * std::numbers::pi *
+        const real_t weight{
+          8.0_r * std::numbers::pi_v<real_t> * std::numbers::pi_v<real_t> *
           std::exp(-g_sq / four_alpha_sq) / g_sq
         };
 
-        double s_real{};
-        double s_imag{};
+        real_t s_real{};
+        real_t s_imag{};
 
         for (std::size_t i = 0; i < n; ++i) {
-          const double phase{
+          const real_t phase{
             gx * particles.pos().x_[i] +
             gy * particles.pos().y_[i] +
             gz * particles.pos().z_[i]
@@ -122,13 +128,13 @@ double exact_reciprocal_potential(const Particles& particles, double box_length)
     }
   }
 
-  return weighted_sum / (2.0 * std::numbers::pi * box_length * box_length * box_length);
+  return weighted_sum / (2.0_r * std::numbers::pi_v<real_t> * box_length * box_length * box_length);
 }
 
-double exact_total_potential(const Particles& particles, double box_length) {
-  const double n{static_cast<double>(particles.size())};
-  const double self_correction{-6.0 * n / (std::sqrt(std::numbers::pi) * box_length)};
-  const double background{-std::numbers::pi * n * n / (72.0 * box_length)};
+real_t exact_total_potential(const Particles& particles, real_t box_length) {
+  const real_t n{static_cast<real_t>(particles.size())};
+  const real_t self_correction{-6.0_r * n / (std::sqrt(std::numbers::pi_v<real_t>) * box_length)};
+  const real_t background{-std::numbers::pi_v<real_t> * n * n / (72.0_r * box_length)};
 
   return
     exact_real_potential(particles, box_length) +
@@ -141,49 +147,49 @@ double exact_total_potential(const Particles& particles, double box_length) {
 
 TEST_CASE("Fully polarized Jastrow cusp matches the same-spin analytical form near contact",
           "[rigorous][jastrow]") {
-  constexpr double box_length{50.0};
-  const JastrowPade jastrow{box_length, 0.25, 1.0};
+  constexpr real_t box_length{50.0_r};
+  const JastrowPade jastrow{box_length, 0.25_r, 1.0_r};
   Particles particles{2U};
 
-  particles.pos().x_[0] = 0.0;
-  particles.pos().y_[0] = 0.0;
-  particles.pos().z_[0] = 0.0;
+  particles.pos().x_[0] = 0.0_r;
+  particles.pos().y_[0] = 0.0_r;
+  particles.pos().z_[0] = 0.0_r;
 
-  for (const double r : {1.0e-5, 2.0e-5, 5.0e-5, 1.0e-4}) {
+  for (const real_t r : {1.0e-5_r, 2.0e-5_r, 5.0e-5_r, 1.0e-4_r}) {
     particles.pos().x_[1] = r;
-    particles.pos().y_[1] = 0.0;
-    particles.pos().z_[1] = 0.0;
+    particles.pos().y_[1] = 0.0_r;
+    particles.pos().z_[1] = 0.0_r;
 
-    const double expected_value{0.25 * r / (1.0 + r)};
-    const double actual_value{jastrow.value(particles)};
+    const real_t expected_value{0.25_r * r / (1.0_r + r)};
+    const real_t actual_value{jastrow.value(particles)};
 
     INFO("Checking Jastrow value against the exact same-spin Padé form near coalescence.");
     CAPTURE(r, actual_value, expected_value);
-    REQUIRE(std::abs(actual_value - expected_value) <= 1e-14);
+    REQUIRE(std::abs(actual_value - expected_value) <= (1e-14_r * RIGOROUS_PRECISION_SCALE));
 
-    std::vector<double> grad_x(particles.p_stride(), 0.0);
-    std::vector<double> grad_y(particles.p_stride(), 0.0);
-    std::vector<double> grad_z(particles.p_stride(), 0.0);
-    std::vector<double> lap(particles.p_stride(), 0.0);
+    std::vector<real_t> grad_x(particles.p_stride(), 0.0_r);
+    std::vector<real_t> grad_y(particles.p_stride(), 0.0_r);
+    std::vector<real_t> grad_z(particles.p_stride(), 0.0_r);
+    std::vector<real_t> lap(particles.p_stride(), 0.0_r);
 
     jastrow.add_derivatives(particles, grad_x.data(), grad_y.data(), grad_z.data(), lap.data());
 
-    const double first_derivative{0.25 / ((1.0 + r) * (1.0 + r))};
-    const double second_derivative{-0.5 / ((1.0 + r) * (1.0 + r) * (1.0 + r))};
-    const double expected_grad_particle_0{-first_derivative};
-    const double expected_grad_particle_1{first_derivative};
-    const double expected_laplacian{second_derivative + 2.0 * first_derivative / r};
+    const real_t first_derivative{0.25_r / ((1.0_r + r) * (1.0_r + r))};
+    const real_t second_derivative{-0.5_r / ((1.0_r + r) * (1.0_r + r) * (1.0_r + r))};
+    const real_t expected_grad_particle_0{-first_derivative};
+    const real_t expected_grad_particle_1{first_derivative};
+    const real_t expected_laplacian{second_derivative + 2.0_r * first_derivative / r};
 
     INFO("Checking same-spin Jastrow gradient and Laplacian near contact.");
     CAPTURE(r, first_derivative, second_derivative, expected_laplacian);
-    REQUIRE(std::abs(grad_x[0] - expected_grad_particle_0) <= 1e-10);
-    REQUIRE(std::abs(grad_x[1] - expected_grad_particle_1) <= 1e-10);
-    REQUIRE(std::abs(grad_y[0]) <= 1e-14);
-    REQUIRE(std::abs(grad_y[1]) <= 1e-14);
-    REQUIRE(std::abs(grad_z[0]) <= 1e-14);
-    REQUIRE(std::abs(grad_z[1]) <= 1e-14);
-    REQUIRE(std::abs(lap[0] - expected_laplacian) <= 1e-7);
-    REQUIRE(std::abs(lap[1] - expected_laplacian) <= 1e-7);
+    REQUIRE(std::abs(grad_x[0] - expected_grad_particle_0) <= (1e-10_r * RIGOROUS_PRECISION_SCALE));
+    REQUIRE(std::abs(grad_x[1] - expected_grad_particle_1) <= (1e-10_r * RIGOROUS_PRECISION_SCALE));
+    REQUIRE(std::abs(grad_y[0]) <= (1e-14_r * RIGOROUS_PRECISION_SCALE));
+    REQUIRE(std::abs(grad_y[1]) <= (1e-14_r * RIGOROUS_PRECISION_SCALE));
+    REQUIRE(std::abs(grad_z[0]) <= (1e-14_r * RIGOROUS_PRECISION_SCALE));
+    REQUIRE(std::abs(grad_z[1]) <= (1e-14_r * RIGOROUS_PRECISION_SCALE));
+    REQUIRE(std::abs(lap[0] - expected_laplacian) <= (1e-7_r * RIGOROUS_PRECISION_SCALE));
+    REQUIRE(std::abs(lap[1] - expected_laplacian) <= (1e-7_r * RIGOROUS_PRECISION_SCALE));
   }
 }
 
@@ -191,26 +197,26 @@ TEST_CASE(
     "Slater determinant changes sign under particle exchange while log_abs_det stays invariant",
     "[rigorous][slater]") {
   constexpr std::size_t n{3U};
-  constexpr double box_length{9.0};
+  constexpr real_t box_length{9.0_r};
 
   Particles original{n};
-  original.pos().x_[0] = 0.7;
-  original.pos().y_[0] = 1.4;
-  original.pos().z_[0] = 2.1;
+  original.pos().x_[0] = 0.7_r;
+  original.pos().y_[0] = 1.4_r;
+  original.pos().z_[0] = 2.1_r;
 
-  original.pos().x_[1] = 2.8;
-  original.pos().y_[1] = 0.9;
-  original.pos().z_[1] = 1.6;
+  original.pos().x_[1] = 2.8_r;
+  original.pos().y_[1] = 0.9_r;
+  original.pos().z_[1] = 1.6_r;
 
-  original.pos().x_[2] = 4.3;
-  original.pos().y_[2] = 3.2;
-  original.pos().z_[2] = 0.5;
+  original.pos().x_[2] = 4.3_r;
+  original.pos().y_[2] = 3.2_r;
+  original.pos().z_[2] = 0.5_r;
 
   SlaterPlaneWave slater_original{original, box_length};
-  const double log_original{slater_original.log_abs_det(original)};
+  const real_t log_original{slater_original.log_abs_det(original)};
   REQUIRE(std::isfinite(log_original));
 
-  const double det_original{
+  const real_t det_original{
     phy_determinant3x3(
       slater_original.determinant(),
       slater_original.matrix_row_stride()
@@ -224,10 +230,10 @@ TEST_CASE(
   std::swap(swapped.pos().z_[0], swapped.pos().z_[1]);
 
   SlaterPlaneWave slater_swapped{swapped, box_length};
-  const double log_swapped{slater_swapped.log_abs_det(swapped)};
+  const real_t log_swapped{slater_swapped.log_abs_det(swapped)};
   REQUIRE(std::isfinite(log_swapped));
 
-  const double det_swapped{
+  const real_t det_swapped{
     phy_determinant3x3(
       slater_swapped.determinant(),
       slater_swapped.matrix_row_stride()
@@ -236,52 +242,52 @@ TEST_CASE(
 
   INFO("Swapping two particles must negate the Slater determinant but preserve log|det|.");
   CAPTURE(det_original, det_swapped, log_original, log_swapped);
-  REQUIRE(std::abs(det_swapped + det_original) <= 1e-10);
-  REQUIRE(std::abs(log_swapped - log_original) <= 1e-12);
+  REQUIRE(std::abs(det_swapped + det_original) <= (1e-10_r * RIGOROUS_PRECISION_SCALE));
+  REQUIRE(std::abs(log_swapped - log_original) <= (1e-12_r * RIGOROUS_PRECISION_SCALE));
 }
 
 TEST_CASE("SlaterPlaneWave is periodic under box translations of a single particle",
           "[rigorous][slater]") {
   constexpr std::size_t n{3U};
-  constexpr double box_length{10.0};
+  constexpr real_t box_length{10.0_r};
 
   Particles particles{n};
-  particles.pos().x_[0] = 1.1;
-  particles.pos().y_[0] = 2.2;
-  particles.pos().z_[0] = 3.3;
+  particles.pos().x_[0] = 1.1_r;
+  particles.pos().y_[0] = 2.2_r;
+  particles.pos().z_[0] = 3.3_r;
 
-  particles.pos().x_[1] = 4.4;
-  particles.pos().y_[1] = 5.5;
-  particles.pos().z_[1] = 6.6;
+  particles.pos().x_[1] = 4.4_r;
+  particles.pos().y_[1] = 5.5_r;
+  particles.pos().z_[1] = 6.6_r;
 
-  particles.pos().x_[2] = 7.7;
-  particles.pos().y_[2] = 1.8;
-  particles.pos().z_[2] = 2.9;
+  particles.pos().x_[2] = 7.7_r;
+  particles.pos().y_[2] = 1.8_r;
+  particles.pos().z_[2] = 2.9_r;
 
   SlaterPlaneWave baseline{particles, box_length};
-  const double baseline_log_det{baseline.log_abs_det(particles)};
+  const real_t baseline_log_det{baseline.log_abs_det(particles)};
   REQUIRE(std::isfinite(baseline_log_det));
 
   Particles shifted{n};
   phy_copy_positions(particles, shifted);
   shifted.pos().x_[1] += box_length;
   shifted.pos().y_[1] -= box_length;
-  shifted.pos().z_[1] += 2.0 * box_length;
+  shifted.pos().z_[1] += 2.0_r * box_length;
 
   SlaterPlaneWave translated{shifted, box_length};
-  const double translated_log_det{translated.log_abs_det(shifted)};
+  const real_t translated_log_det{translated.log_abs_det(shifted)};
   REQUIRE(std::isfinite(translated_log_det));
 
   INFO("Plane-wave Slater determinant must be invariant under integer box translations.");
   CAPTURE(baseline_log_det, translated_log_det);
-  REQUIRE(std::abs(translated_log_det - baseline_log_det) <= 1e-12);
+  REQUIRE(std::abs(translated_log_det - baseline_log_det) <= (1e-12_r * RIGOROUS_PRECISION_SCALE));
 
   const std::size_t S{baseline.matrix_row_stride()};
   for (std::size_t row = 0; row < n; ++row) {
     for (std::size_t col = 0; col < n; ++col) {
       const std::size_t idx{row * S + col};
       CAPTURE(row, col);
-      REQUIRE(std::abs(baseline.determinant()[idx] - translated.determinant()[idx]) <= 1e-12);
+      REQUIRE(std::abs(baseline.determinant()[idx] - translated.determinant()[idx]) <= (1e-12_r * RIGOROUS_PRECISION_SCALE));
     }
   }
 }
@@ -289,12 +295,12 @@ TEST_CASE("SlaterPlaneWave is periodic under box translations of a single partic
 TEST_CASE("Randomized determinant_ratio matches exact determinant ratio over many configurations",
           "[rigorous][slater]") {
   constexpr std::size_t n{3U};
-  constexpr double box_length{11.0};
+  constexpr real_t box_length{11.0_r};
   constexpr std::size_t samples{40U};
 
   std::mt19937_64 rng{123456789ULL};
-  std::uniform_real_distribution<double> position_dist{0.0, box_length};
-  std::uniform_real_distribution<double> move_dist{-0.20, 0.20};
+  std::uniform_real_distribution<real_t> position_dist{0.0_r, box_length};
+  std::uniform_real_distribution<real_t> move_dist{-0.20_r, 0.20_r};
 
   for (std::size_t sample = 0; sample < samples; ++sample) {
     Particles particles{n};
@@ -306,19 +312,19 @@ TEST_CASE("Randomized determinant_ratio matches exact determinant ratio over man
     }
 
     SlaterPlaneWave slater{particles, box_length};
-    const double baseline_log_det{slater.log_abs_det(particles)};
+    const real_t baseline_log_det{slater.log_abs_det(particles)};
 
     INFO("Baseline Slater rebuild must be finite for randomized determinant-ratio testing.");
     CAPTURE(sample, baseline_log_det);
     REQUIRE(std::isfinite(baseline_log_det));
 
-    const double det_old{
+    const real_t det_old{
       phy_determinant3x3(
         slater.determinant(),
         slater.matrix_row_stride()
       )
     };
-    REQUIRE(std::abs(det_old) > 1e-12);
+    REQUIRE(std::abs(det_old) > (1e-12_r * RIGOROUS_PRECISION_SCALE));
 
     const std::size_t moved{sample % n};
     particles.pos().x_[moved] =
@@ -329,71 +335,71 @@ TEST_CASE("Randomized determinant_ratio matches exact determinant ratio over man
         wrap_coordinate(particles.pos().z_[moved] + move_dist(rng), box_length);
 
     slater.update_trig_cache(moved, particles);
-    const double* const new_row{slater.build_row(moved)};
-    const double ratio{slater.determinant_ratio(moved, new_row)};
+    const real_t* const new_row{slater.build_row(moved)};
+    const real_t ratio{slater.determinant_ratio(moved, new_row)};
 
     SlaterPlaneWave rebuilt{particles, box_length};
-    const double rebuilt_log_det{rebuilt.log_abs_det(particles)};
+    const real_t rebuilt_log_det{rebuilt.log_abs_det(particles)};
 
     INFO("Fresh rebuild must be finite for randomized determinant-ratio testing.");
     CAPTURE(sample, moved, rebuilt_log_det);
     REQUIRE(std::isfinite(rebuilt_log_det));
 
-    const double det_new{
+    const real_t det_new{
       phy_determinant3x3(
         rebuilt.determinant(),
         rebuilt.matrix_row_stride()
       )
     };
-    const double exact_ratio{det_new / det_old};
+    const real_t exact_ratio{det_new / det_old};
 
     INFO("Fast determinant ratio must agree with exact determinant ratio over many random "
          "configurations.");
     CAPTURE(sample, moved, ratio, exact_ratio, det_old, det_new);
-    REQUIRE(std::abs(ratio - exact_ratio) <= 1e-9);
+    REQUIRE(std::abs(ratio - exact_ratio) <= (1e-9_r * RIGOROUS_PRECISION_SCALE));
   }
 }
 
 TEST_CASE("SlaterPlaneWave reports a singular determinant for duplicate particle rows",
           "[rigorous][slater]") {
   constexpr std::size_t n{3U};
-  constexpr double box_length{10.0};
+  constexpr real_t box_length{10.0_r};
 
   Particles particles{n};
-  particles.pos().x_[0] = 1.25;
-  particles.pos().y_[0] = 2.50;
-  particles.pos().z_[0] = 3.75;
+  particles.pos().x_[0] = 1.25_r;
+  particles.pos().y_[0] = 2.50_r;
+  particles.pos().z_[0] = 3.75_r;
 
   particles.pos().x_[1] = particles.pos().x_[0];
   particles.pos().y_[1] = particles.pos().y_[0];
   particles.pos().z_[1] = particles.pos().z_[0];
 
-  particles.pos().x_[2] = 4.10;
-  particles.pos().y_[2] = 0.90;
-  particles.pos().z_[2] = 1.70;
+  particles.pos().x_[2] = 4.10_r;
+  particles.pos().y_[2] = 0.90_r;
+  particles.pos().z_[2] = 1.70_r;
 
   SlaterPlaneWave slater{particles, box_length};
-  const double log_abs_det{slater.log_abs_det(particles)};
-  const double det{phy_determinant3x3(slater.determinant(), slater.matrix_row_stride())};
+  const real_t log_abs_det{slater.log_abs_det(particles)};
+  const real_t det{phy_determinant3x3(slater.determinant(), slater.matrix_row_stride())};
 
   INFO("Duplicate particle positions should create duplicate Slater rows and a singular matrix.");
   CAPTURE(log_abs_det, det);
   REQUIRE_FALSE(std::isfinite(log_abs_det));
-  REQUIRE(std::abs(det) <= 1e-12);
+  REQUIRE(std::abs(det) <= (1e-12_r * RIGOROUS_PRECISION_SCALE));
 }
 
 TEST_CASE("Repeated accepted Slater updates preserve predictive determinant ratios against fresh "
           "rebuilds",
           "[rigorous][slater]") {
   constexpr std::size_t n{7U};
-  constexpr double box_length{10.0};
+  constexpr real_t box_length{10.0_r};
   constexpr std::size_t steps{64U};
 
   Particles particles{n};
   set_stable_closed_shell_positions(particles);
 
   SlaterPlaneWave maintained{particles, box_length};
-  const double initial_log_det{maintained.log_abs_det(particles)};
+  const real_t initial_log_det{maintained.log_abs_det(particles)};
 
   INFO("Initial Slater matrix for the multi-step drift test must be well-defined.");
   CAPTURE(initial_log_det);
@@ -402,48 +408,48 @@ TEST_CASE("Repeated accepted Slater updates preserve predictive determinant rati
   for (std::size_t step = 0; step < steps; ++step) {
     const std::size_t moved{step % n};
 
-    const double dx{0.003 * static_cast<double>((step % 5U) + 1U)};
-    const double dy{-0.0025 * static_cast<double>((step % 7U) + 1U)};
-    const double dz{0.002 * static_cast<double>((step % 3U) + 1U)};
+    const real_t dx{0.003_r * static_cast<real_t>((step % 5U) + 1U)};
+    const real_t dy{-0.0025_r * static_cast<real_t>((step % 7U) + 1U)};
+    const real_t dz{0.002_r * static_cast<real_t>((step % 3U) + 1U)};
 
     particles.pos().x_[moved] = wrap_coordinate(particles.pos().x_[moved] + dx, box_length);
     particles.pos().y_[moved] = wrap_coordinate(particles.pos().y_[moved] + dy, box_length);
     particles.pos().z_[moved] = wrap_coordinate(particles.pos().z_[moved] + dz, box_length);
 
     maintained.update_trig_cache(moved, particles);
-    const double* const accepted_row{maintained.build_row(moved)};
-    const double accepted_ratio{maintained.determinant_ratio(moved, accepted_row)};
+    const real_t* const accepted_row{maintained.build_row(moved)};
+    const real_t accepted_ratio{maintained.determinant_ratio(moved, accepted_row)};
 
     INFO("Accepted-step determinant ratio became non-finite or too close to singular.");
     CAPTURE(step, moved, accepted_ratio);
     REQUIRE(std::isfinite(accepted_ratio));
-    REQUIRE(std::abs(accepted_ratio) > 1e-10);
+    REQUIRE(std::abs(accepted_ratio) > (1e-10_r * RIGOROUS_PRECISION_SCALE));
 
     maintained.accept_move(moved, accepted_row, accepted_ratio);
 
     SlaterPlaneWave rebuilt{particles, box_length};
-    const double rebuilt_log_det{rebuilt.log_abs_det(particles)};
+    const real_t rebuilt_log_det{rebuilt.log_abs_det(particles)};
 
     INFO("Fresh rebuild produced a non-finite log determinant during the multi-step "
          "predictive-consistency test.");
     CAPTURE(step, moved, rebuilt_log_det);
     REQUIRE(std::isfinite(rebuilt_log_det));
 
-    const double maintained_residual{slater_identity_residual(maintained)};
-    const double rebuilt_residual{slater_identity_residual(rebuilt)};
+    const real_t maintained_residual{slater_identity_residual(maintained)};
+    const real_t rebuilt_residual{slater_identity_residual(rebuilt)};
 
     INFO("Both maintained and rebuilt Slater states must remain valid inverses of their "
          "determinant matrices.");
     CAPTURE(step, moved, maintained_residual, rebuilt_residual);
-    REQUIRE(maintained_residual <= 1e-8);
-    REQUIRE(rebuilt_residual <= 1e-10);
+    REQUIRE(maintained_residual <= (1e-8_r * RIGOROUS_PRECISION_SCALE));
+    REQUIRE(rebuilt_residual <= (1e-10_r * RIGOROUS_PRECISION_SCALE));
 
-    double max_det_diff{};
+    real_t max_det_diff{};
     const std::size_t S_MAT{maintained.matrix_row_stride()};
     for (std::size_t row = 0; row < n; ++row) {
       for (std::size_t col = 0; col < n; ++col) {
         const std::size_t idx{row * S_MAT + col};
-        const double det_diff{
+        const real_t det_diff{
           std::abs(maintained.determinant()[idx] - rebuilt.determinant()[idx])
         };
         max_det_diff = std::max(max_det_diff, det_diff);
@@ -452,15 +458,15 @@ TEST_CASE("Repeated accepted Slater updates preserve predictive determinant rati
 
     INFO("Maintained and rebuilt determinant matrices should match after each accepted update.");
     CAPTURE(step, moved, max_det_diff);
-    REQUIRE(max_det_diff <= 1e-11);
+    REQUIRE(max_det_diff <= (1e-11_r * RIGOROUS_PRECISION_SCALE));
 
     const std::size_t probe{(moved + 1U) % n};
     Particles probe_particles{n};
     phy_copy_positions(particles, probe_particles);
 
-    const double probe_dx{0.0017 * static_cast<double>((step % 4U) + 1U)};
-    const double probe_dy{-0.0011 * static_cast<double>((step % 6U) + 1U)};
-    const double probe_dz{0.0013 * static_cast<double>((step % 5U) + 1U)};
+    const real_t probe_dx{0.0017_r * static_cast<real_t>((step % 4U) + 1U)};
+    const real_t probe_dy{-0.0011_r * static_cast<real_t>((step % 6U) + 1U)};
+    const real_t probe_dz{0.0013_r * static_cast<real_t>((step % 5U) + 1U)};
 
     probe_particles.pos().x_[probe] =
         wrap_coordinate(probe_particles.pos().x_[probe] + probe_dx, box_length);
@@ -475,11 +481,11 @@ TEST_CASE("Repeated accepted Slater updates preserve predictive determinant rati
     maintained.update_trig_cache(probe, probe_particles);
     rebuilt.update_trig_cache(probe, probe_particles);
 
-    const double* const maintained_probe_row{maintained.build_row(probe)};
-    const double* const rebuilt_probe_row{rebuilt.build_row(probe)};
+    const real_t* const maintained_probe_row{maintained.build_row(probe)};
+    const real_t* const rebuilt_probe_row{rebuilt.build_row(probe)};
 
-    const double maintained_probe_ratio{maintained.determinant_ratio(probe, maintained_probe_row)};
-    const double rebuilt_probe_ratio{rebuilt.determinant_ratio(probe, rebuilt_probe_row)};
+    const real_t maintained_probe_ratio{maintained.determinant_ratio(probe, maintained_probe_row)};
+    const real_t rebuilt_probe_ratio{rebuilt.determinant_ratio(probe, rebuilt_probe_row)};
 
     maintained.restore_trig_row(probe);
     rebuilt.restore_trig_row(probe);
@@ -488,26 +494,26 @@ TEST_CASE("Repeated accepted Slater updates preserve predictive determinant rati
     CAPTURE(step, moved, probe, maintained_probe_ratio, rebuilt_probe_ratio);
     REQUIRE(std::isfinite(maintained_probe_ratio));
     REQUIRE(std::isfinite(rebuilt_probe_ratio));
-    REQUIRE(std::abs(maintained_probe_ratio - rebuilt_probe_ratio) <= 1e-8);
+    REQUIRE(std::abs(maintained_probe_ratio - rebuilt_probe_ratio) <= (1e-8_r * RIGOROUS_PRECISION_SCALE));
   }
 }
 
 TEST_CASE("WaveFunction log_psi and derivatives are invariant under integer box translations",
           "[rigorous][wavefunction]") {
   constexpr std::size_t n{7U};
-  constexpr double box_length{9.5};
+  constexpr real_t box_length{9.5_r};
 
   Particles particles{n};
   set_stable_closed_shell_positions(particles);
 
   WaveFunction baseline{particles, box_length};
-  const double baseline_log_psi{baseline.evaluate_log_psi(particles)};
+  const real_t baseline_log_psi{baseline.evaluate_log_psi(particles)};
   baseline.evaluate_derivatives(particles);
 
-  std::vector<double> baseline_grad_x(n);
-  std::vector<double> baseline_grad_y(n);
-  std::vector<double> baseline_grad_z(n);
-  std::vector<double> baseline_lap(n);
+  std::vector<real_t> baseline_grad_x(n);
+  std::vector<real_t> baseline_grad_y(n);
+  std::vector<real_t> baseline_grad_z(n);
+  std::vector<real_t> baseline_lap(n);
 
   for (std::size_t i = 0; i < n; ++i) {
     baseline_grad_x[i] = particles.grad_log_psi().x_[i];
@@ -520,8 +526,8 @@ TEST_CASE("WaveFunction log_psi and derivatives are invariant under integer box 
   phy_copy_positions(particles, shifted);
 
   shifted.pos().x_[3] += box_length;
-  shifted.pos().y_[3] -= 2.0 * box_length;
-  shifted.pos().z_[3] += 3.0 * box_length;
+  shifted.pos().y_[3] -= 2.0_r * box_length;
+  shifted.pos().z_[3] += 3.0_r * box_length;
 
   // After shifting:
   for (std::size_t i = 0; i < n; ++i) {
@@ -531,30 +537,30 @@ TEST_CASE("WaveFunction log_psi and derivatives are invariant under integer box 
   }
 
   WaveFunction translated{shifted, box_length};
-  const double translated_log_psi{translated.evaluate_log_psi(shifted)};
+  const real_t translated_log_psi{translated.evaluate_log_psi(shifted)};
   translated.evaluate_derivatives(shifted);
 
   INFO("WaveFunction must be periodic under integer box translations.");
   CAPTURE(baseline_log_psi, translated_log_psi);
-  REQUIRE(std::abs(baseline_log_psi - translated_log_psi) <= 1e-12);
+  REQUIRE(std::abs(baseline_log_psi - translated_log_psi) <= (1e-12_r * RIGOROUS_PRECISION_SCALE));
 
   for (std::size_t i = 0; i < n; ++i) {
     CAPTURE(i);
-    REQUIRE(std::abs(baseline_grad_x[i] - shifted.grad_log_psi().x_[i]) <= 1e-10);
-    REQUIRE(std::abs(baseline_grad_y[i] - shifted.grad_log_psi().y_[i]) <= 1e-10);
-    REQUIRE(std::abs(baseline_grad_z[i] - shifted.grad_log_psi().z_[i]) <= 1e-10);
-    REQUIRE(std::abs(baseline_lap[i] - shifted.lap_log_psi()[i]) <= 1e-7);
+    REQUIRE(std::abs(baseline_grad_x[i] - shifted.grad_log_psi().x_[i]) <= (1e-10_r * RIGOROUS_PRECISION_SCALE));
+    REQUIRE(std::abs(baseline_grad_y[i] - shifted.grad_log_psi().y_[i]) <= (1e-10_r * RIGOROUS_PRECISION_SCALE));
+    REQUIRE(std::abs(baseline_grad_z[i] - shifted.grad_log_psi().z_[i]) <= (1e-10_r * RIGOROUS_PRECISION_SCALE));
+    REQUIRE(std::abs(baseline_lap[i] - shifted.lap_log_psi()[i]) <= (1e-7_r * RIGOROUS_PRECISION_SCALE));
   }
 }
 
 TEST_CASE("EnergyTracker matches an exact Ewald reference on many random small configurations",
           "[rigorous][energy]") {
   constexpr std::size_t n{3U};
-  constexpr double box_length{8.25};
+  constexpr real_t box_length{8.25_r};
   constexpr std::size_t samples{25U};
 
   std::mt19937_64 rng{987654321ULL};
-  std::uniform_real_distribution<double> dist{0.0, box_length};
+  std::uniform_real_distribution<real_t> dist{0.0_r, box_length};
 
   for (std::size_t sample = 0; sample < samples; ++sample) {
     Particles particles{n};
@@ -565,41 +571,41 @@ TEST_CASE("EnergyTracker matches an exact Ewald reference on many random small c
       particles.pos().z_[i] = dist(rng);
     }
 
-    EnergyTracker tracker{box_length, static_cast<double>(n)};
+    EnergyTracker tracker{box_length, static_cast<real_t>(n)};
     tracker.initialize_structure_factors(particles);
     tracker.initialize_reciprocal_energy();
     tracker.initialize_real_energy(particles);
 
-    const double tracker_total{tracker.eval_total_energy(particles)};
-    const double exact_total{exact_total_potential(particles, box_length)};
+    const real_t tracker_total{tracker.eval_total_energy(particles)};
+    const real_t exact_total{exact_total_potential(particles, box_length)};
 
     INFO("EnergyTracker total potential should match the exact Ewald reference on many random "
          "small configurations.");
     CAPTURE(sample, tracker_total, exact_total);
-    REQUIRE(std::abs(tracker_total - exact_total) <= 8e-6);
+    REQUIRE(std::abs(tracker_total - exact_total) <= (8e-6_r * RIGOROUS_PRECISION_SCALE));
   }
 }
 
 TEST_CASE("EnergyTracker remains close to the exact Ewald reference across many cached updates",
           "[rigorous][energy]") {
   constexpr std::size_t n{3U};
-  constexpr double box_length{8.75};
+  constexpr real_t box_length{8.75_r};
   constexpr std::size_t steps{48U};
 
   Particles particles{n};
-  particles.pos().x_[0] = 0.55;
-  particles.pos().y_[0] = 1.20;
-  particles.pos().z_[0] = 2.10;
+  particles.pos().x_[0] = 0.55_r;
+  particles.pos().y_[0] = 1.20_r;
+  particles.pos().z_[0] = 2.10_r;
 
-  particles.pos().x_[1] = 3.15;
-  particles.pos().y_[1] = 2.45;
-  particles.pos().z_[1] = 1.05;
+  particles.pos().x_[1] = 3.15_r;
+  particles.pos().y_[1] = 2.45_r;
+  particles.pos().z_[1] = 1.05_r;
 
-  particles.pos().x_[2] = 5.60;
-  particles.pos().y_[2] = 0.85;
-  particles.pos().z_[2] = 4.45;
+  particles.pos().x_[2] = 5.60_r;
+  particles.pos().y_[2] = 0.85_r;
+  particles.pos().z_[2] = 4.45_r;
 
-  EnergyTracker tracker{box_length, static_cast<double>(n)};
+  EnergyTracker tracker{box_length, static_cast<real_t>(n)};
   tracker.initialize_structure_factors(particles);
   tracker.initialize_reciprocal_energy();
   tracker.initialize_real_energy(particles);
@@ -607,13 +613,13 @@ TEST_CASE("EnergyTracker remains close to the exact Ewald reference across many 
   for (std::size_t step = 0; step < steps; ++step) {
     const std::size_t moved{step % n};
 
-    const double old_x{particles.pos().x_[moved]};
-    const double old_y{particles.pos().y_[moved]};
-    const double old_z{particles.pos().z_[moved]};
+    const real_t old_x{particles.pos().x_[moved]};
+    const real_t old_y{particles.pos().y_[moved]};
+    const real_t old_z{particles.pos().z_[moved]};
 
-    const double dx{0.017 * static_cast<double>((step % 4U) + 1U)};
-    const double dy{-0.012 * static_cast<double>((step % 5U) + 1U)};
-    const double dz{0.010 * static_cast<double>((step % 3U) + 1U)};
+    const real_t dx{0.017_r * static_cast<real_t>((step % 4U) + 1U)};
+    const real_t dy{-0.012_r * static_cast<real_t>((step % 5U) + 1U)};
+    const real_t dz{0.010_r * static_cast<real_t>((step % 3U) + 1U)};
 
     particles.pos().x_[moved] = wrap_coordinate(old_x + dx, box_length);
     particles.pos().y_[moved] = wrap_coordinate(old_y + dy, box_length);
@@ -625,11 +631,11 @@ TEST_CASE("EnergyTracker remains close to the exact Ewald reference across many 
     );
     tracker.update_real_energy(moved, old_x, old_y, old_z, particles);
 
-    const double tracker_total{tracker.eval_total_energy(particles)};
-    const double exact_total{exact_total_potential(particles, box_length)};
+    const real_t tracker_total{tracker.eval_total_energy(particles)};
+    const real_t exact_total{exact_total_potential(particles, box_length)};
 
     INFO("Cached Ewald updates drifted too far from an exact recomputation.");
     CAPTURE(step, moved, tracker_total, exact_total);
-    REQUIRE(std::abs(tracker_total - exact_total) <= 8e-6);
+    REQUIRE(std::abs(tracker_total - exact_total) <= (8e-6_r * RIGOROUS_PRECISION_SCALE));
   }
 }

--- a/tests/test_simulation.cpp
+++ b/tests/test_simulation.cpp
@@ -17,7 +17,7 @@ TEST_CASE("Simulation API is present", "[simulation]") {
 
 TEST_CASE("Simulation emits consistent init/frame/done records through OutputWriter",
           "[simulation]") {
-  const Config config{make_config(7U, 6.0, 0U, 4U, 0.35, 12345U, 2U)};
+  const Config config{make_config(7U, 6.0_r, 0U, 4U, 0.35_r, 12345U, 2U)};
 
   auto writer{std::make_unique<RecordingOutputWriter>()};
   RecordingOutputWriter* const sink{writer.get()};
@@ -50,7 +50,7 @@ TEST_CASE("Simulation emits consistent init/frame/done records through OutputWri
     REQUIRE(frame.accepted <= frame.proposed);
     require_near(
       frame.acceptance_rate,
-      static_cast<double>(frame.accepted) / static_cast<double>(frame.proposed)
+      static_cast<real_t>(frame.accepted) / static_cast<real_t>(frame.proposed)
     );
     REQUIRE(frame.positions.size() == 3U * config.num_particles);
   }
@@ -63,13 +63,13 @@ TEST_CASE("Simulation emits consistent init/frame/done records through OutputWri
   REQUIRE(done.total_accepted == sink->frames.back().accepted);
   require_near(
     done.final_acceptance_rate,
-    static_cast<double>(done.total_accepted) / static_cast<double>(done.total_proposed)
+    static_cast<real_t>(done.total_accepted) / static_cast<real_t>(done.total_proposed)
   );
   REQUIRE(done.final_standard_error.has_value());
 }
 
 TEST_CASE("Simulation produces blocked energy summary when no writer is attached", "[simulation]") {
-  const Config config{make_config(1U, 5.0, 0U, 4U, 0.1, 7U, 2U)};
+  const Config config{make_config(1U, 5.0_r, 0U, 4U, 0.1_r, 7U, 2U)};
 
   Simulation simulation{config};
   const auto summary{simulation.run()};
@@ -77,13 +77,13 @@ TEST_CASE("Simulation produces blocked energy summary when no writer is attached
   // 4 measure steps, block_size=2 -> 2 complete blocks -> blocking is ready
   REQUIRE(summary.standard_error.has_value());
   REQUIRE(std::isfinite(summary.mean_energy));
-  REQUIRE(summary.acceptance_rate >= 0.0);
-  REQUIRE(summary.acceptance_rate <= 1.0);
+  REQUIRE(summary.acceptance_rate >= 0.0_r);
+  REQUIRE(summary.acceptance_rate <= 1.0_r);
 }
 
 TEST_CASE("Simulation skips blocked energy summary when insufficient blocks are available",
           "[simulation]") {
-  const Config config{make_config(1U, 5.0, 0U, 3U, 0.1, 9U, 10U)};
+  const Config config{make_config(1U, 5.0_r, 0U, 3U, 0.1_r, 9U, 10U)};
 
   Simulation simulation{config};
   const auto summary{simulation.run()};
@@ -91,13 +91,13 @@ TEST_CASE("Simulation skips blocked energy summary when insufficient blocks are 
   // 3 measure steps, block_size=10 -> 0 complete blocks -> no SE available
   REQUIRE_FALSE(summary.standard_error.has_value());
   REQUIRE(std::isfinite(summary.mean_energy));
-  REQUIRE(summary.acceptance_rate >= 0.0);
-  REQUIRE(summary.acceptance_rate <= 1.0);
+  REQUIRE(summary.acceptance_rate >= 0.0_r);
+  REQUIRE(summary.acceptance_rate <= 1.0_r);
 }
 
 TEST_CASE("Simulation accepts zero-step proposals and preserves local energy across frames",
           "[simulation]") {
-  const Config config{make_config(7U, 6.0, 0U, 6U, 0.0, 314159U, 3U)};
+  const Config config{make_config(7U, 6.0_r, 0U, 6U, 0.0_r, 314159U, 3U)};
 
   auto writer{std::make_unique<RecordingOutputWriter>()};
   RecordingOutputWriter* const sink{writer.get()};
@@ -106,7 +106,7 @@ TEST_CASE("Simulation accepts zero-step proposals and preserves local energy acr
   simulation.run();
 
   REQUIRE(sink->frames.size() == config.measure_steps);
-  const double first_energy{sink->frames.front().local_energy};
+  const real_t first_energy{sink->frames.front().local_energy};
 
   for (std::size_t i = 0; i < sink->frames.size(); ++i) {
     const FrameData& frame{sink->frames[i]};
@@ -117,7 +117,7 @@ TEST_CASE("Simulation accepts zero-step proposals and preserves local energy acr
 }
 
 TEST_CASE("Simulation performs rejected moves for a large proposal step size", "[simulation]") {
-  const Config config{make_config(7U, 6.0, 0U, 100U, 2.0, 20250308U, 10U)};
+  const Config config{make_config(7U, 6.0_r, 0U, 100U, 2.0_r, 20250308U, 10U)};
 
   auto writer{std::make_unique<RecordingOutputWriter>()};
   RecordingOutputWriter* const sink{writer.get()};
@@ -131,7 +131,7 @@ TEST_CASE("Simulation performs rejected moves for a large proposal step size", "
 }
 
 TEST_CASE("Simulation warmup path executes with adaptive proposal updates", "[simulation]") {
-  const Config config{make_config(1U, 4.0, 5U, 1U, 0.2, 42U, 1U)};
+  const Config config{make_config(1U, 4.0_r, 5U, 1U, 0.2_r, 42U, 1U)};
 
   auto writer{std::make_unique<RecordingOutputWriter>()};
   RecordingOutputWriter* const sink{writer.get()};

--- a/tests/test_slater_plane_wave.cpp
+++ b/tests/test_slater_plane_wave.cpp
@@ -9,13 +9,21 @@
 #include <tuple>
 #include <vector>
 
+namespace {
+#ifdef FP_64
+constexpr real_t SLATER_PRECISION_SCALE{1.0_r};
+#else
+constexpr real_t SLATER_PRECISION_SCALE{1e6_r};
+#endif
+} // namespace
+
 TEST_CASE("SlaterPlaneWave constructor initializes correctly", "[slater]") {
   constexpr std::size_t N{3U};
   Particles particles{N};
-  SlaterPlaneWave slater{particles, 5.0};
+  SlaterPlaneWave slater{particles, 5.0_r};
 
   REQUIRE(slater.num_orbitals() == N);
-  REQUIRE(slater.box_length() == 5.0);
+  REQUIRE(slater.box_length() == 5.0_r);
   REQUIRE(slater.matrix_row_stride() >= N);
   REQUIRE(slater.matrix_size() == slater.matrix_row_stride() * N);
 }
@@ -23,50 +31,50 @@ TEST_CASE("SlaterPlaneWave constructor initializes correctly", "[slater]") {
 TEST_CASE("log_abs_det handles the N=1 constant orbital case", "[slater]") {
   // N=1: orbital 0 is k=0, cos → D = cos(0) = 1
   Particles particles{1U};
-  SlaterPlaneWave slater{particles, 10.0};
+  SlaterPlaneWave slater{particles, 10.0_r};
 
-  particles.pos().x_[0] = 3.25;
-  particles.pos().y_[0] = 1.50;
-  particles.pos().z_[0] = 7.75;
+  particles.pos().x_[0] = 3.25_r;
+  particles.pos().y_[0] = 1.50_r;
+  particles.pos().z_[0] = 7.75_r;
 
-  const double logDet{slater.log_abs_det(particles)};
+  const real_t logDet{slater.log_abs_det(particles)};
 
-  require_near(logDet, 0.0);
-  require_near(slater.determinant()[0], 1.0);
-  require_near(slater.inv_determinant()[0], 1.0);
+  require_near(logDet, 0.0_r);
+  require_near(slater.determinant()[0], 1.0_r);
+  require_near(slater.inv_determinant()[0], 1.0_r);
 }
 
 TEST_CASE("log_abs_det computes an inverse satisfying D*invD = I", "[slater]") {
   // N=3: orbital 0 = cos(0)=1, orbital 1 = cos(k1·r), orbital 2 = sin(k1·r)
   constexpr std::size_t N{3U};
   Particles particles{N};
-  SlaterPlaneWave slater{particles, 11.0};
+  SlaterPlaneWave slater{particles, 11.0_r};
 
-  particles.pos().x_[0] = 0.3;
-  particles.pos().y_[0] = 0.4;
-  particles.pos().z_[0] = 0.5;
+  particles.pos().x_[0] = 0.3_r;
+  particles.pos().y_[0] = 0.4_r;
+  particles.pos().z_[0] = 0.5_r;
 
-  particles.pos().x_[1] = 1.7;
-  particles.pos().y_[1] = 0.2;
-  particles.pos().z_[1] = 2.1;
+  particles.pos().x_[1] = 1.7_r;
+  particles.pos().y_[1] = 0.2_r;
+  particles.pos().z_[1] = 2.1_r;
 
-  particles.pos().x_[2] = 2.2;
-  particles.pos().y_[2] = 1.8;
-  particles.pos().z_[2] = 0.9;
+  particles.pos().x_[2] = 2.2_r;
+  particles.pos().y_[2] = 1.8_r;
+  particles.pos().z_[2] = 0.9_r;
 
-  const double logDet{slater.log_abs_det(particles)};
+  const real_t logDet{slater.log_abs_det(particles)};
   REQUIRE(std::isfinite(logDet));
 
   for (std::size_t row = 0; row < N; ++row) {
     for (std::size_t col = 0; col < N; ++col) {
-      double value{};
+      real_t value{};
       for (std::size_t k = 0; k < N; ++k) {
         value +=
           slater.determinant()[matrix_index(row, k, slater.matrix_row_stride())] *
           slater.inv_determinant()[matrix_index(col, k, slater.matrix_row_stride())];
       }
-      const double expected{row == col ? 1.0 : 0.0};
-      require_near(value, expected, 1e-9);
+      const real_t expected{row == col ? 1.0_r : 0.0_r};
+      require_near(value, expected, 1e-9_r * SLATER_PRECISION_SCALE);
     }
   }
 }
@@ -74,7 +82,7 @@ TEST_CASE("log_abs_det computes an inverse satisfying D*invD = I", "[slater]") {
 TEST_CASE("SlaterPlaneWave zero-initializes the full trig cache span", "[slater]") {
   constexpr std::size_t N{7U};
   Particles particles{N};
-  SlaterPlaneWave slater{particles, 9.0};
+  SlaterPlaneWave slater{particles, 9.0_r};
 
   const std::size_t numK{slater.num_unique_k()};
   const std::size_t ROW_STRIDE{slater.trig_row_stride()};
@@ -86,101 +94,101 @@ TEST_CASE("SlaterPlaneWave zero-initializes the full trig cache span", "[slater]
     for (std::size_t k = 0; k < numK; ++k) {
       const std::size_t idx{p * ROW_STRIDE + k};
       CAPTURE(p, k, idx);
-      REQUIRE(slater.sin_cache()[idx] == 0.0);
-      REQUIRE(slater.cos_cache()[idx] == 0.0);
+      REQUIRE(slater.sin_cache()[idx] == 0.0_r);
+      REQUIRE(slater.cos_cache()[idx] == 0.0_r);
     }
   }
 }
 
 TEST_CASE("determinant_ratio matches exact determinant ratio for a moved row", "[slater]") {
   constexpr std::size_t N{3U};
-  constexpr double L{12.0};
+  constexpr real_t L{12.0_r};
   Particles particles{N};
 
-  particles.pos().x_[0] = 0.8;
-  particles.pos().y_[0] = 1.1;
-  particles.pos().z_[0] = 0.3;
+  particles.pos().x_[0] = 0.8_r;
+  particles.pos().y_[0] = 1.1_r;
+  particles.pos().z_[0] = 0.3_r;
 
-  particles.pos().x_[1] = 2.7;
-  particles.pos().y_[1] = 0.4;
-  particles.pos().z_[1] = 1.9;
+  particles.pos().x_[1] = 2.7_r;
+  particles.pos().y_[1] = 0.4_r;
+  particles.pos().z_[1] = 1.9_r;
 
-  particles.pos().x_[2] = 4.2;
-  particles.pos().y_[2] = 3.5;
-  particles.pos().z_[2] = 2.6;
+  particles.pos().x_[2] = 4.2_r;
+  particles.pos().y_[2] = 3.5_r;
+  particles.pos().z_[2] = 2.6_r;
 
   SlaterPlaneWave slater{particles, L};
-  const double logDetOld{slater.log_abs_det(particles)};
+  const real_t logDetOld{slater.log_abs_det(particles)};
   REQUIRE(std::isfinite(logDetOld));
 
-  const double detOld{determinant_3x3(slater.determinant(), slater.matrix_row_stride())};
-  REQUIRE(std::abs(detOld) > 1e-12);
+  const real_t detOld{determinant_3x3(slater.determinant(), slater.matrix_row_stride())};
+  REQUIRE(std::abs(detOld) > (1e-12_r * SLATER_PRECISION_SCALE));
 
   constexpr std::size_t moved{1U};
-  particles.pos().x_[moved] += 0.35;
-  particles.pos().y_[moved] -= 0.20;
-  particles.pos().z_[moved] += 0.15;
+  particles.pos().x_[moved] += 0.35_r;
+  particles.pos().y_[moved] -= 0.20_r;
+  particles.pos().z_[moved] += 0.15_r;
 
   slater.update_trig_cache(moved, particles);
-  const double* const newRow{slater.build_row(moved)};
-  const double ratio{slater.determinant_ratio(moved, newRow)};
+  const real_t* const newRow{slater.build_row(moved)};
+  const real_t ratio{slater.determinant_ratio(moved, newRow)};
 
   SlaterPlaneWave exactSlater{particles, L};
-  const double logDetNew{exactSlater.log_abs_det(particles)};
+  const real_t logDetNew{exactSlater.log_abs_det(particles)};
   REQUIRE(std::isfinite(logDetNew));
 
-  const double detNew{
+  const real_t detNew{
     determinant_3x3(
       exactSlater.determinant(),
       exactSlater.matrix_row_stride()
     )
   };
-  const double exactRatio{detNew / detOld};
+  const real_t exactRatio{detNew / detOld};
 
   INFO("Trial-move determinant ratio should equal det(D_new) / det(D_old).");
   CAPTURE(detOld, detNew, ratio, exactRatio, moved);
-  require_near(ratio, exactRatio, 1e-10);
+  require_near(ratio, exactRatio, 1e-10_r * SLATER_PRECISION_SCALE);
 }
 
 TEST_CASE("accept_move matches a fresh full rebuild after an accepted row update", "[slater]") {
   constexpr std::size_t N{3U};
-  constexpr double L{10.5};
+  constexpr real_t L{10.5_r};
   Particles particles{N};
 
-  particles.pos().x_[0] = 0.4;
-  particles.pos().y_[0] = 1.5;
-  particles.pos().z_[0] = 2.7;
+  particles.pos().x_[0] = 0.4_r;
+  particles.pos().y_[0] = 1.5_r;
+  particles.pos().z_[0] = 2.7_r;
 
-  particles.pos().x_[1] = 3.1;
-  particles.pos().y_[1] = 2.2;
-  particles.pos().z_[1] = 0.9;
+  particles.pos().x_[1] = 3.1_r;
+  particles.pos().y_[1] = 2.2_r;
+  particles.pos().z_[1] = 0.9_r;
 
-  particles.pos().x_[2] = 4.8;
-  particles.pos().y_[2] = 0.7;
-  particles.pos().z_[2] = 3.3;
+  particles.pos().x_[2] = 4.8_r;
+  particles.pos().y_[2] = 0.7_r;
+  particles.pos().z_[2] = 3.3_r;
 
   SlaterPlaneWave updated{particles, L};
-  const double logDetInitial{updated.log_abs_det(particles)};
+  const real_t logDetInitial{updated.log_abs_det(particles)};
   REQUIRE(std::isfinite(logDetInitial));
 
   constexpr std::size_t moved{2U};
-  particles.pos().x_[moved] -= 0.28;
-  particles.pos().y_[moved] += 0.19;
-  particles.pos().z_[moved] += 0.41;
+  particles.pos().x_[moved] -= 0.28_r;
+  particles.pos().y_[moved] += 0.19_r;
+  particles.pos().z_[moved] += 0.41_r;
 
   updated.update_trig_cache(moved, particles);
-  const double* const newRow{updated.build_row(moved)};
-  const double ratio{updated.determinant_ratio(moved, newRow)};
+  const real_t* const newRow{updated.build_row(moved)};
+  const real_t ratio{updated.determinant_ratio(moved, newRow)};
 
   INFO("Accepted-move update should preserve determinant/inverse consistency.");
   CAPTURE(moved, ratio);
   REQUIRE(std::isfinite(ratio));
-  REQUIRE(std::abs(ratio) > 1e-10);
+  REQUIRE(std::abs(ratio) > (1e-10_r * SLATER_PRECISION_SCALE));
 
   updated.accept_move(moved, newRow, ratio);
 
   SlaterPlaneWave rebuilt{particles, L};
-  const double logDetRebuilt{rebuilt.log_abs_det(particles)};
+  const real_t logDetRebuilt{rebuilt.log_abs_det(particles)};
   REQUIRE(std::isfinite(logDetRebuilt));
 
   const std::size_t S{updated.matrix_row_stride()};
@@ -188,8 +196,8 @@ TEST_CASE("accept_move matches a fresh full rebuild after an accepted row update
     for (std::size_t col = 0; col < N; ++col) {
       const std::size_t idx{row * S + col};
       CAPTURE(row, col);
-      require_near(updated.determinant()[idx], rebuilt.determinant()[idx], 1e-12);
-      require_near(updated.inv_determinant()[idx], rebuilt.inv_determinant()[idx], 1e-9);
+      require_near(updated.determinant()[idx], rebuilt.determinant()[idx], 1e-12_r * SLATER_PRECISION_SCALE);
+      require_near(updated.inv_determinant()[idx], rebuilt.inv_determinant()[idx], 1e-9_r * SLATER_PRECISION_SCALE);
     }
   }
 }
@@ -198,21 +206,21 @@ TEST_CASE("N=3 determinant matrix uses cos/sin basis correctly", "[slater]") {
   // N=3: orbital 0 = cos(0)=1, orbital 1 = cos(k1·r), orbital 2 = sin(k1·r)
   // k1 is the first nonzero canonical k-vector
   constexpr std::size_t N{3U};
-  constexpr double L{10.0};
+  constexpr real_t L{10.0_r};
   Particles particles{N};
   SlaterPlaneWave slater{particles, L};
 
-  particles.pos().x_[0] = 1.0;
-  particles.pos().y_[0] = 2.0;
-  particles.pos().z_[0] = 3.0;
+  particles.pos().x_[0] = 1.0_r;
+  particles.pos().y_[0] = 2.0_r;
+  particles.pos().z_[0] = 3.0_r;
 
-  particles.pos().x_[1] = 4.0;
-  particles.pos().y_[1] = 5.0;
-  particles.pos().z_[1] = 6.0;
+  particles.pos().x_[1] = 4.0_r;
+  particles.pos().y_[1] = 5.0_r;
+  particles.pos().z_[1] = 6.0_r;
 
-  particles.pos().x_[2] = 7.0;
-  particles.pos().y_[2] = 8.0;
-  particles.pos().z_[2] = 9.0;
+  particles.pos().x_[2] = 7.0_r;
+  particles.pos().y_[2] = 8.0_r;
+  particles.pos().z_[2] = 9.0_r;
 
   slater.log_abs_det(particles);
 
@@ -221,13 +229,13 @@ TEST_CASE("N=3 determinant matrix uses cos/sin basis correctly", "[slater]") {
 
   // Orbital 0 should be cos type with k=0
   REQUIRE(o_type[0] == 0);
-  require_near(slater.k_vector().x_[k_index[0]], 0.0);
-  require_near(slater.k_vector().y_[k_index[0]], 0.0);
-  require_near(slater.k_vector().z_[k_index[0]], 0.0);
+  require_near(slater.k_vector().x_[k_index[0]], 0.0_r);
+  require_near(slater.k_vector().y_[k_index[0]], 0.0_r);
+  require_near(slater.k_vector().z_[k_index[0]], 0.0_r);
 
   // First column should all be 1.0 (cos(0))
   for (std::size_t i = 0; i < N; ++i) {
-    require_near(slater.determinant()[matrix_index(i, 0, slater.matrix_row_stride())], 1.0);
+    require_near(slater.determinant()[matrix_index(i, 0, slater.matrix_row_stride())], 1.0_r);
   }
 
   // Orbital 1 should be cos, orbital 2 should be sin, same k-vector
@@ -237,12 +245,12 @@ TEST_CASE("N=3 determinant matrix uses cos/sin basis correctly", "[slater]") {
 
   // Verify D entries for orbitals 1 and 2
   const std::size_t ki{k_index[1]};
-  const double kx{slater.k_vector().x_[ki]};
-  const double ky{slater.k_vector().y_[ki]};
-  const double kz{slater.k_vector().z_[ki]};
+  const real_t kx{slater.k_vector().x_[ki]};
+  const real_t ky{slater.k_vector().y_[ki]};
+  const real_t kz{slater.k_vector().z_[ki]};
 
   for (std::size_t i = 0; i < N; ++i) {
-    const double k_dot_r{
+    const real_t k_dot_r{
       kx * particles.pos().x_[i] +
       ky * particles.pos().y_[i] +
       kz * particles.pos().z_[i]
@@ -262,65 +270,69 @@ TEST_CASE("N=7 determinant is nonzero with cos/sin basis", "[slater]") {
   // N=7 is a closed shell: 1 (k=0) + 3 pairs × 2 = 7
   constexpr std::size_t N{7U};
   Particles particles{N};
-  SlaterPlaneWave slater{particles, 10.0};
+  SlaterPlaneWave slater{particles, 10.0_r};
 
   // Spread particles around the box
   for (std::size_t i = 0; i < N; ++i) {
-    particles.pos().x_[i] = 1.0 + static_cast<double>(i) * 1.1;
-    particles.pos().y_[i] = 0.5 + static_cast<double>(i) * 0.7;
-    particles.pos().z_[i] = 0.3 + static_cast<double>(i) * 1.3;
+    particles.pos().x_[i] = 1.0_r + static_cast<real_t>(i) * 1.1_r;
+    particles.pos().y_[i] = 0.5_r + static_cast<real_t>(i) * 0.7_r;
+    particles.pos().z_[i] = 0.3_r + static_cast<real_t>(i) * 1.3_r;
   }
 
-  const double logDet{slater.log_abs_det(particles)};
+  const real_t logDet{slater.log_abs_det(particles)};
   REQUIRE(std::isfinite(logDet));
 
   // Verify D * D^{-1} = I
   for (std::size_t row = 0; row < N; ++row) {
     for (std::size_t col = 0; col < N; ++col) {
-      double value{};
+      real_t value{};
       for (std::size_t k = 0; k < N; ++k) {
         value +=
           slater.determinant()[matrix_index(row, k, slater.matrix_row_stride())] *
           slater.inv_determinant()[matrix_index(col, k, slater.matrix_row_stride())];
       }
-      const double expected{row == col ? 1.0 : 0.0};
-      require_near(value, expected, 1e-9);
+      const real_t expected{row == col ? 1.0_r : 0.0_r};
+      require_near(value, expected, 1e-9_r * SLATER_PRECISION_SCALE);
     }
   }
 }
 
 TEST_CASE("Slater derivatives match finite-difference for N=3 cos/sin basis", "[slater]") {
   constexpr std::size_t N{3U};
-  constexpr double L{10.0};
+  constexpr real_t L{10.0_r};
   Particles particles{N};
   SlaterPlaneWave slater{particles, L};
 
-  particles.pos().x_[0] = 1.1;
-  particles.pos().y_[0] = 2.3;
-  particles.pos().z_[0] = 0.7;
+  particles.pos().x_[0] = 1.1_r;
+  particles.pos().y_[0] = 2.3_r;
+  particles.pos().z_[0] = 0.7_r;
 
-  particles.pos().x_[1] = 4.2;
-  particles.pos().y_[1] = 1.8;
-  particles.pos().z_[1] = 3.5;
+  particles.pos().x_[1] = 4.2_r;
+  particles.pos().y_[1] = 1.8_r;
+  particles.pos().z_[1] = 3.5_r;
 
-  particles.pos().x_[2] = 7.6;
-  particles.pos().y_[2] = 5.1;
-  particles.pos().z_[2] = 8.9;
+  particles.pos().x_[2] = 7.6_r;
+  particles.pos().y_[2] = 5.1_r;
+  particles.pos().z_[2] = 8.9_r;
 
   // Compute analytic derivatives
   slater.log_abs_det(particles);
   const std::size_t stride{particles.p_stride()};
-  std::vector<double> gradX(stride, 0.0);
-  std::vector<double> gradY(stride, 0.0);
-  std::vector<double> gradZ(stride, 0.0);
-  std::vector<double> lap(stride, 0.0);
+  std::vector<real_t> gradX(stride, 0.0_r);
+  std::vector<real_t> gradY(stride, 0.0_r);
+  std::vector<real_t> gradZ(stride, 0.0_r);
+  std::vector<real_t> lap(stride, 0.0_r);
   slater.add_derivatives(gradX.data(), gradY.data(), gradZ.data(), lap.data());
 
   // Finite-difference check for particle 0
-  const double h{1e-5};
-  const double center{slater.log_abs_det(particles)};
+#ifdef FP_64
+  const real_t h{1e-5_r};
+#else
+  const real_t h{1e-3_r};
+#endif
+  const real_t center{slater.log_abs_det(particles)};
 
-  auto shift_and_eval = [&](std::size_t p, double dx, double dy, double dz) {
+  auto shift_and_eval = [&](std::size_t p, real_t dx, real_t dy, real_t dz) {
     Particles shifted{N};
     for (std::size_t i = 0; i < N; ++i) {
       shifted.pos().x_[i] = particles.pos().x_[i];
@@ -334,54 +346,54 @@ TEST_CASE("Slater derivatives match finite-difference for N=3 cos/sin basis", "[
   };
 
   for (std::size_t p = 0; p < N; ++p) {
-    const double fd_gx{
+    const real_t fd_gx{
       (
-        shift_and_eval(p, h, 0.0, 0.0) -
-        shift_and_eval(p, -h, 0.0, 0.0)
-      ) / (2.0 * h)
+        shift_and_eval(p, h, 0.0_r, 0.0_r) -
+        shift_and_eval(p, -h, 0.0_r, 0.0_r)
+      ) / (2.0_r * h)
     };
-    const double fd_gy{
+    const real_t fd_gy{
       (
-        shift_and_eval(p, 0.0, h, 0.0) -
-        shift_and_eval(p, 0.0, -h, 0.0)
-      ) / (2.0 * h)
+        shift_and_eval(p, 0.0_r, h, 0.0_r) -
+        shift_and_eval(p, 0.0_r, -h, 0.0_r)
+      ) / (2.0_r * h)
     };
-    const double fd_gz{
+    const real_t fd_gz{
       (
-        shift_and_eval(p, 0.0, 0.0, h) -
-        shift_and_eval(p, 0.0, 0.0, -h)
-      ) / (2.0 * h)
-    };
-
-    const double fd_lx{
-      (
-        shift_and_eval(p, h, 0.0, 0.0) - 2.0 * center +
-        shift_and_eval(p, -h, 0.0, 0.0)
-      ) / (h * h)
-    };
-    const double fd_ly{
-      (
-        shift_and_eval(p, 0.0, h, 0.0) - 2.0 * center +
-        shift_and_eval(p, 0.0, -h, 0.0)
-      ) / (h * h)
-    };
-    const double fd_lz{
-      (
-        shift_and_eval(p, 0.0, 0.0, h) - 2.0 * center +
-        shift_and_eval(p, 0.0, 0.0, -h)
-      ) / (h * h)
+        shift_and_eval(p, 0.0_r, 0.0_r, h) -
+        shift_and_eval(p, 0.0_r, 0.0_r, -h)
+      ) / (2.0_r * h)
     };
 
-    require_near(gradX[p], fd_gx, 1e-6);
-    require_near(gradY[p], fd_gy, 1e-6);
-    require_near(gradZ[p], fd_gz, 1e-6);
-    require_near(lap[p], fd_lx + fd_ly + fd_lz, 5e-4);
+    const real_t fd_lx{
+      (
+        shift_and_eval(p, h, 0.0_r, 0.0_r) - 2.0_r * center +
+        shift_and_eval(p, -h, 0.0_r, 0.0_r)
+      ) / (h * h)
+    };
+    const real_t fd_ly{
+      (
+        shift_and_eval(p, 0.0_r, h, 0.0_r) - 2.0_r * center +
+        shift_and_eval(p, 0.0_r, -h, 0.0_r)
+      ) / (h * h)
+    };
+    const real_t fd_lz{
+      (
+        shift_and_eval(p, 0.0_r, 0.0_r, h) - 2.0_r * center +
+        shift_and_eval(p, 0.0_r, 0.0_r, -h)
+      ) / (h * h)
+    };
+
+    require_near(gradX[p], fd_gx, 1e-6_r * SLATER_PRECISION_SCALE);
+    require_near(gradY[p], fd_gy, 1e-6_r * SLATER_PRECISION_SCALE);
+    require_near(gradZ[p], fd_gz, 1e-6_r * SLATER_PRECISION_SCALE);
+    require_near(lap[p], fd_lx + fd_ly + fd_lz, 5e-4_r * SLATER_PRECISION_SCALE);
   }
 }
 
 TEST_CASE("Shell filling produces (0,0,0) as the first n-vector", "[slater]") {
   Particles p{1U};
-  SlaterPlaneWave slater{p, 5.0};
+  SlaterPlaneWave slater{p, 5.0_r};
 
   REQUIRE(slater.n_vector().x_[0] == 0);
   REQUIRE(slater.n_vector().y_[0] == 0);
@@ -391,7 +403,7 @@ TEST_CASE("Shell filling produces (0,0,0) as the first n-vector", "[slater]") {
 TEST_CASE("Shell filling for N=7 uses canonical n-vectors with 4 unique k-vectors", "[slater]") {
   // N=7: 1 (k=0) + 3 nonzero k-vectors × 2 (cos,sin) = 7
   Particles p{7U};
-  SlaterPlaneWave slater{p, 10.0};
+  SlaterPlaneWave slater{p, 10.0_r};
 
   REQUIRE(slater.num_unique_k() == 4U);
 
@@ -422,7 +434,7 @@ TEST_CASE("Shell filling for N=7 uses canonical n-vectors with 4 unique k-vector
 
 TEST_CASE("Shell filling orbital types alternate cos/sin for nonzero k", "[slater]") {
   Particles p{7U};
-  SlaterPlaneWave slater{p, 10.0};
+  SlaterPlaneWave slater{p, 10.0_r};
 
   const auto& o_type{slater.orbital_type()};
   const auto& k_index{slater.orbital_k_index()};
@@ -440,7 +452,7 @@ TEST_CASE("Shell filling orbital types alternate cos/sin for nonzero k", "[slate
 
 TEST_CASE("Shell filling n-vectors are sorted by magnitude then lexicographically", "[slater]") {
   Particles p{7U};
-  SlaterPlaneWave slater{p, 10.0};
+  SlaterPlaneWave slater{p, 10.0_r};
 
   const std::size_t num_k{slater.num_unique_k()};
   const int* n_x{slater.n_vector().x_};
@@ -466,25 +478,25 @@ TEST_CASE("Shell filling n-vectors are sorted by magnitude then lexicographicall
 
 TEST_CASE("Shell filling k-vectors match 2pi/L times n-vectors", "[slater]") {
   constexpr std::size_t N{7U};
-  constexpr double L{8.0};
+  constexpr real_t L{8.0_r};
   Particles p{N};
   SlaterPlaneWave slater{p, L};
 
-  const double TWO_PI_OVER_L{2.0 * std::numbers::pi / L};
+  const real_t TWO_PI_OVER_L{2.0_r * std::numbers::pi_v<real_t> / L};
   const std::size_t num_k{slater.num_unique_k()};
 
   for (std::size_t i = 0; i < num_k; ++i) {
     require_near(
       slater.k_vector().x_[i],
-      TWO_PI_OVER_L * static_cast<double>(slater.n_vector().x_[i])
+      TWO_PI_OVER_L * static_cast<real_t>(slater.n_vector().x_[i])
     );
     require_near(
       slater.k_vector().y_[i],
-      TWO_PI_OVER_L * static_cast<double>(slater.n_vector().y_[i])
+      TWO_PI_OVER_L * static_cast<real_t>(slater.n_vector().y_[i])
     );
     require_near(
       slater.k_vector().z_[i],
-      TWO_PI_OVER_L * static_cast<double>(slater.n_vector().z_[i])
+      TWO_PI_OVER_L * static_cast<real_t>(slater.n_vector().z_[i])
     );
   }
 }

--- a/tests/test_utilities.hpp
+++ b/tests/test_utilities.hpp
@@ -19,7 +19,13 @@
 #include <utility>
 #include <vector>
 
-inline void require_near(double actual, double expected, double tolerance = 1e-12) {
+#ifdef FP_64
+constexpr real_t DEFAULT_TOLERANCE{1e-12_r};
+#else
+constexpr real_t DEFAULT_TOLERANCE{1e-5_r};
+#endif
+
+inline void require_near(real_t actual, real_t expected, real_t tolerance = DEFAULT_TOLERANCE) {
   REQUIRE(std::abs(actual - expected) <= tolerance);
 }
 
@@ -48,7 +54,7 @@ inline std::size_t matrix_index(std::size_t row, std::size_t col, std::size_t n)
   return row * n + col;
 }
 
-inline double determinant_3x3(const double* matrix, std::size_t stride) {
+inline real_t determinant_3x3(const real_t* matrix, std::size_t stride) {
   return
     matrix[0 * stride + 0] * (
       matrix[1 * stride + 1] * matrix[2 * stride + 2] -
@@ -64,21 +70,21 @@ inline double determinant_3x3(const double* matrix, std::size_t stride) {
     );
 }
 
-inline double slater_identity_residual(const SlaterPlaneWave& slater) {
+inline real_t slater_identity_residual(const SlaterPlaneWave& slater) {
   const std::size_t N{slater.num_orbitals()};
   const std::size_t S{slater.matrix_row_stride()};
-  double max_residual{};
+  real_t max_residual{};
 
   for (std::size_t row = 0; row < N; ++row) {
     for (std::size_t col = 0; col < N; ++col) {
-      double value{};
+      real_t value{};
 
       for (std::size_t k = 0; k < N; ++k) {
         value += slater.determinant()[row * S + k] * slater.inv_determinant()[col * S + k];
       }
 
-      const double expected{row == col ? 1.0 : 0.0};
-      const double residual{std::abs(value - expected)};
+      const real_t expected{row == col ? 1.0_r : 0.0_r};
+      const real_t residual{std::abs(value - expected)};
       max_residual = std::max(max_residual, residual);
     }
   }
@@ -86,12 +92,12 @@ inline double slater_identity_residual(const SlaterPlaneWave& slater) {
   return max_residual;
 }
 
-inline double wrap_coordinate(double value, double box_length) {
+inline real_t wrap_coordinate(real_t value, real_t box_length) {
   return value - box_length * std::floor(value / box_length);
 }
 
-inline double minimum_image(double dx, double box_length) {
-  const double HALF_LENGTH{0.5 * box_length};
+inline real_t minimum_image(real_t dx, real_t box_length) {
+  const real_t HALF_LENGTH{0.5_r * box_length};
 
   if (dx <= -HALF_LENGTH) {
     dx += box_length;
@@ -102,45 +108,45 @@ inline double minimum_image(double dx, double box_length) {
   return dx;
 }
 
-inline double exact_kinetic_energy(const SlaterPlaneWave& slater) {
+inline real_t exact_kinetic_energy(const SlaterPlaneWave& slater) {
   const std::size_t N{slater.num_orbitals()};
-  const double* k_x{slater.k_vector().x_};
-  const double* k_y{slater.k_vector().y_};
-  const double* k_z{slater.k_vector().z_};
+  const real_t* k_x{slater.k_vector().x_};
+  const real_t* k_y{slater.k_vector().y_};
+  const real_t* k_z{slater.k_vector().z_};
   const auto& K_INDEX{slater.orbital_k_index()};
 
-  double T_exact{};
+  real_t T_exact{};
   for (std::size_t j = 0; j < N; ++j) {
     const std::size_t IDX{K_INDEX[j]};
-    T_exact += 0.5 * (k_x[IDX] * k_x[IDX] + k_y[IDX] * k_y[IDX] + k_z[IDX] * k_z[IDX]);
+    T_exact += 0.5_r * (k_x[IDX] * k_x[IDX] + k_y[IDX] * k_y[IDX] + k_z[IDX] * k_z[IDX]);
   }
   return T_exact;
 }
 
-inline double local_kinetic_energy(const Particles& particles) {
+inline real_t local_kinetic_energy(const Particles& particles) {
   const std::size_t N{particles.size()};
-  double T_local{};
+  real_t T_local{};
   for (std::size_t i = 0; i < N; ++i) {
-    const double GX{particles.grad_log_psi().x_[i]};
-    const double GY{particles.grad_log_psi().y_[i]};
-    const double GZ{particles.grad_log_psi().z_[i]};
-    const double LAP{particles.lap_log_psi()[i]};
-    T_local += -0.5 * (LAP + GX * GX + GY * GY + GZ * GZ);
+    const real_t GX{particles.grad_log_psi().x_[i]};
+    const real_t GY{particles.grad_log_psi().y_[i]};
+    const real_t GZ{particles.grad_log_psi().z_[i]};
+    const real_t LAP{particles.lap_log_psi()[i]};
+    T_local += -0.5_r * (LAP + GX * GX + GY * GY + GZ * GZ);
   }
   return T_local;
 }
 
-inline double box_length_from_rs(double r_s, std::size_t N) {
-  return std::cbrt(4.0 * std::numbers::pi * static_cast<double>(N) / 3.0) * r_s;
+inline real_t box_length_from_rs(real_t r_s, std::size_t N) {
+  return std::cbrt(4.0_r * std::numbers::pi_v<real_t> * static_cast<real_t>(N) / 3.0_r) * r_s;
 }
 
 inline void set_stable_closed_shell_positions(Particles& particles) {
   const std::size_t N{particles.size()};
 
   for (std::size_t i = 0; i < N; ++i) {
-    particles.pos().x_[i] = 1.0 + static_cast<double>(i) * 1.1;
-    particles.pos().y_[i] = 0.5 + static_cast<double>(i) * 0.7;
-    particles.pos().z_[i] = 0.3 + static_cast<double>(i) * 1.3;
+    particles.pos().x_[i] = 1.0_r + static_cast<real_t>(i) * 1.1_r;
+    particles.pos().y_[i] = 0.5_r + static_cast<real_t>(i) * 0.7_r;
+    particles.pos().z_[i] = 0.3_r + static_cast<real_t>(i) * 1.3_r;
   }
 }
 
@@ -162,10 +168,10 @@ template <typename Fn> std::string capture_stdout(Fn&& fn) {
 /// step_size overrides the default box_length/10 derivation.
 inline Config make_config(
   std::size_t num_particles,
-  double box_length,
+  real_t box_length,
   std::size_t warmup_steps,
   std::size_t measure_steps,
-  double step_size,
+  real_t step_size,
   uint64_t master_seed,
   std::size_t block_size,
   std::size_t num_threads = 1U,
@@ -210,7 +216,7 @@ public:
 };
 
 struct SimResult {
-  double mean_energy;
-  double standard_error;
-  double acceptance_rate;
+  real_t mean_energy;
+  real_t standard_error;
+  real_t acceptance_rate;
 };

--- a/tests/test_validation_free_gas.cpp
+++ b/tests/test_validation_free_gas.cpp
@@ -7,20 +7,28 @@
 #include <numbers>
 #include <random>
 
+namespace {
+#ifdef FP_64
+constexpr real_t FREE_GAS_PRECISION_SCALE{1.0_r};
+#else
+constexpr real_t FREE_GAS_PRECISION_SCALE{1e6_r};
+#endif
+} // namespace
+
 // N=1: only k=0 orbital, T_exact = 0, uniform wavefunction
 TEST_CASE("Free gas N=1: kinetic energy is exactly zero", "[validation]") {
   constexpr std::size_t N{1U};
-  constexpr double L{5.0};
+  constexpr real_t L{5.0_r};
 
   Particles particles{N};
   SlaterPlaneWave slater{particles, L};
-  const double T_EXACT{exact_kinetic_energy(slater)};
-  require_near(T_EXACT, 0.0);
+  const real_t T_EXACT{exact_kinetic_energy(slater)};
+  require_near(T_EXACT, 0.0_r);
 
-  WaveFunction wf{particles, L, 0.0, 1.0}; // a = 0 -> Jastrow off
+  WaveFunction wf{particles, L, 0.0_r, 1.0_r}; // a = 0 -> Jastrow off
 
   std::mt19937_64 rng{42};
-  std::uniform_real_distribution<double> uniform{0.0, L};
+  std::uniform_real_distribution<real_t> uniform{0.0_r, L};
 
   for (int sample = 0; sample < 5; ++sample) {
     particles.pos().x_[0] = uniform(rng);
@@ -30,9 +38,9 @@ TEST_CASE("Free gas N=1: kinetic energy is exactly zero", "[validation]") {
     wf.evaluate_log_psi(particles);
     wf.evaluate_derivatives(particles);
 
-    const double T_local{local_kinetic_energy(particles)};
+    const real_t T_local{local_kinetic_energy(particles)};
 
-    require_near(T_local, 0.0);
+    require_near(T_local, 0.0_r);
   }
 }
 
@@ -40,20 +48,20 @@ TEST_CASE("Free gas N=1: kinetic energy is exactly zero", "[validation]") {
 TEST_CASE("Free gas N=7: local kinetic energy matches exact value at every sample",
           "[validation]") {
   constexpr std::size_t N{7U};
-  constexpr double L{6.0};
+  constexpr real_t L{6.0_r};
 
   Particles particles{N};
   SlaterPlaneWave slater{particles, L};
-  const double T_EXACT{exact_kinetic_energy(slater)};
+  const real_t T_EXACT{exact_kinetic_energy(slater)};
 
-  const double TWO_PI_OVER_L{2.0 * std::numbers::pi / L};
-  const double T_ANALYTICAL{3.0 * TWO_PI_OVER_L * TWO_PI_OVER_L};
+  const real_t TWO_PI_OVER_L{2.0_r * std::numbers::pi_v<real_t> / L};
+  const real_t T_ANALYTICAL{3.0_r * TWO_PI_OVER_L * TWO_PI_OVER_L};
   require_near(T_EXACT, T_ANALYTICAL);
 
-  WaveFunction wf{particles, L, 0.0, 1.0};
+  WaveFunction wf{particles, L, 0.0_r, 1.0_r};
 
   std::mt19937_64 rng{314159};
-  std::uniform_real_distribution<double> uniform{0.0, L};
+  std::uniform_real_distribution<real_t> uniform{0.0_r, L};
 
   for (int sample = 0; sample < 10; ++sample) {
     for (std::size_t i = 0; i < N; ++i) {
@@ -65,9 +73,9 @@ TEST_CASE("Free gas N=7: local kinetic energy matches exact value at every sampl
     wf.evaluate_log_psi(particles);
     wf.evaluate_derivatives(particles);
 
-    const double T_local{local_kinetic_energy(particles)};
+    const real_t T_local{local_kinetic_energy(particles)};
 
-    require_near(T_local, T_EXACT, 1e-8);
+    require_near(T_local, T_EXACT, 1e-8_r * FREE_GAS_PRECISION_SCALE);
   }
 }
 
@@ -75,20 +83,20 @@ TEST_CASE("Free gas N=7: local kinetic energy matches exact value at every sampl
 TEST_CASE("Free gas N=19: local kinetic energy matches exact value at every sample",
           "[validation]") {
   constexpr std::size_t N{19U};
-  constexpr double L{7.0};
+  constexpr real_t L{7.0_r};
 
   Particles particles{N};
   SlaterPlaneWave slater{particles, L};
-  const double T_EXACT{exact_kinetic_energy(slater)};
+  const real_t T_EXACT{exact_kinetic_energy(slater)};
 
-  const double K_SQ{(2.0 * std::numbers::pi / L) * (2.0 * std::numbers::pi / L)};
-  const double T_ANALYTICAL{15.0 * K_SQ};
+  const real_t K_SQ{(2.0_r * std::numbers::pi_v<real_t> / L) * (2.0_r * std::numbers::pi_v<real_t> / L)};
+  const real_t T_ANALYTICAL{15.0_r * K_SQ};
   require_near(T_EXACT, T_ANALYTICAL);
 
-  WaveFunction wf{particles, L, 0.0, 1.0};
+  WaveFunction wf{particles, L, 0.0_r, 1.0_r};
 
   std::mt19937_64 rng{271828};
-  std::uniform_real_distribution<double> uniform{0.0, L};
+  std::uniform_real_distribution<real_t> uniform{0.0_r, L};
 
   for (int sample = 0; sample < 10; ++sample) {
     for (std::size_t i = 0; i < N; ++i) {
@@ -100,9 +108,9 @@ TEST_CASE("Free gas N=19: local kinetic energy matches exact value at every samp
     wf.evaluate_log_psi(particles);
     wf.evaluate_derivatives(particles);
 
-    const double T_local{local_kinetic_energy(particles)};
+    const real_t T_local{local_kinetic_energy(particles)};
 
-    require_near(T_local, T_EXACT, 1e-7);
+    require_near(T_local, T_EXACT, 1e-7_r * FREE_GAS_PRECISION_SCALE);
   }
 }
 
@@ -110,16 +118,16 @@ TEST_CASE("Free gas N=19: local kinetic energy matches exact value at every samp
 TEST_CASE("Free gas zero-variance: local kinetic energy is configuration-independent",
           "[validation]") {
   constexpr std::size_t N{7U};
-  constexpr double L{5.5};
+  constexpr real_t L{5.5_r};
 
   Particles particles{N};
-  WaveFunction wf{particles, L, 0.0, 1.0};
+  WaveFunction wf{particles, L, 0.0_r, 1.0_r};
 
   std::mt19937_64 rng{999};
-  std::uniform_real_distribution<double> uniform{0.0, L};
+  std::uniform_real_distribution<real_t> uniform{0.0_r, L};
 
   constexpr int NUM_SAMPLES{50};
-  double first_T{};
+  real_t first_T{};
 
   for (int sample = 0; sample < NUM_SAMPLES; ++sample) {
     for (std::size_t i = 0; i < N; ++i) {
@@ -131,12 +139,12 @@ TEST_CASE("Free gas zero-variance: local kinetic energy is configuration-indepen
     wf.evaluate_log_psi(particles);
     wf.evaluate_derivatives(particles);
 
-    const double T_local{local_kinetic_energy(particles)};
+    const real_t T_local{local_kinetic_energy(particles)};
 
     if (sample == 0) {
       first_T = T_local;
     } else {
-      require_near(T_local, first_T, 1e-8);
+      require_near(T_local, first_T, 1e-8_r * FREE_GAS_PRECISION_SCALE);
     }
   }
 }
@@ -144,14 +152,14 @@ TEST_CASE("Free gas zero-variance: local kinetic energy is configuration-indepen
 // EnergyTracker kinetic term should match local_kinetic_energy with Jastrow off
 TEST_CASE("Free gas: EnergyTracker kinetic term matches manual computation", "[validation]") {
   constexpr std::size_t N{7U};
-  constexpr double L{6.0};
+  constexpr real_t L{6.0_r};
 
   Particles particles{N};
-  WaveFunction wf{particles, L, 0.0, 1.0};
-  EnergyTracker tracker{L, static_cast<double>(N)};
+  WaveFunction wf{particles, L, 0.0_r, 1.0_r};
+  EnergyTracker tracker{L, static_cast<real_t>(N)};
 
   std::mt19937_64 rng{65537};
-  std::uniform_real_distribution<double> uniform{0.0, L};
+  std::uniform_real_distribution<real_t> uniform{0.0_r, L};
 
   for (std::size_t i = 0; i < N; ++i) {
     particles.pos().x_[i] = uniform(rng);
@@ -164,16 +172,16 @@ TEST_CASE("Free gas: EnergyTracker kinetic term matches manual computation", "[v
 
   tracker.initialize_structure_factors(particles);
 
-  const double T_manual{local_kinetic_energy(particles)};
+  const real_t T_manual{local_kinetic_energy(particles)};
   const SlaterPlaneWave& slater{wf.slater_plane_wave()};
-  const double T_EXACT{exact_kinetic_energy(slater)};
+  const real_t T_EXACT{exact_kinetic_energy(slater)};
 
-  require_near(T_manual, T_EXACT, 1e-8);
+  require_near(T_manual, T_EXACT, 1e-8_r * FREE_GAS_PRECISION_SCALE);
 }
 
 // Verify closed-shell orbital counts: N = 1, 7, 19, 27
 TEST_CASE("Shell filling produces correct closed-shell orbital counts", "[validation]") {
-  constexpr double L{10.0};
+  constexpr real_t L{10.0_r};
 
   SECTION("N = 1") {
     Particles p{1U};
@@ -207,15 +215,15 @@ TEST_CASE("Shell filling produces correct closed-shell orbital counts", "[valida
 // N=16 partial shell: zero-variance property still holds
 TEST_CASE("Free gas partial shell N=16: zero-variance property still holds", "[validation]") {
   constexpr std::size_t N{16U};
-  constexpr double L{6.5};
+  constexpr real_t L{6.5_r};
 
   Particles particles{N};
-  WaveFunction wf{particles, L, 0.0, 1.0};
+  WaveFunction wf{particles, L, 0.0_r, 1.0_r};
   const SlaterPlaneWave& slater{wf.slater_plane_wave()};
-  const double T_EXACT{exact_kinetic_energy(slater)};
+  const real_t T_EXACT{exact_kinetic_energy(slater)};
 
   std::mt19937_64 rng{1337};
-  std::uniform_real_distribution<double> uniform{0.0, L};
+  std::uniform_real_distribution<real_t> uniform{0.0_r, L};
 
   constexpr int NUM_SAMPLES{20};
 
@@ -229,8 +237,8 @@ TEST_CASE("Free gas partial shell N=16: zero-variance property still holds", "[v
     wf.evaluate_log_psi(particles);
     wf.evaluate_derivatives(particles);
 
-    const double T_local{local_kinetic_energy(particles)};
+    const real_t T_local{local_kinetic_energy(particles)};
 
-    require_near(T_local, T_EXACT, 1e-7);
+    require_near(T_local, T_EXACT, 1e-7_r * FREE_GAS_PRECISION_SCALE);
   }
 }

--- a/tests/test_validation_interacting.cpp
+++ b/tests/test_validation_interacting.cpp
@@ -11,10 +11,10 @@ namespace {
 
 SimResult run_vmc(
   std::size_t N,
-  double L,
+  real_t L,
   std::size_t warmup,
   std::size_t measure,
-  double step_size,
+  real_t step_size,
   uint64_t seed,
   std::size_t block_size
 ) {
@@ -29,7 +29,7 @@ SimResult run_vmc(
   SimResult result{};
   if (sink->done.has_value()) {
     result.mean_energy = sink->done->final_mean_energy;
-    result.standard_error = sink->done->final_standard_error.value_or(0.0);
+    result.standard_error = sink->done->final_standard_error.value_or(0.0_r);
     result.acceptance_rate = sink->done->final_acceptance_rate;
   }
   return result;
@@ -40,14 +40,14 @@ SimResult run_vmc(
 // At r_s=5 the interaction energy is strongly negative, VMC total must be below non-interacting KE
 TEST_CASE("Interacting VMC energy is below non-interacting KE at r_s=5", "[interacting]") {
   constexpr std::size_t N{19U};
-  constexpr double R_S{5.0};
-  const double L{box_length_from_rs(R_S, N)};
+  constexpr real_t R_S{5.0_r};
+  const real_t L{box_length_from_rs(R_S, N)};
 
   Particles p{N};
   const SlaterPlaneWave slater{p, L};
-  const double T_EXACT{exact_kinetic_energy(slater)};
+  const real_t T_EXACT{exact_kinetic_energy(slater)};
 
-  const auto result{run_vmc(N, L, 5000U, 40000U, 0.6, 2048U, 1000U)};
+  const auto result{run_vmc(N, L, 5000U, 40000U, 0.6_r, 2048U, 1000U)};
 
   REQUIRE(std::isfinite(result.mean_energy));
   REQUIRE(result.mean_energy < T_EXACT);
@@ -56,111 +56,111 @@ TEST_CASE("Interacting VMC energy is below non-interacting KE at r_s=5", "[inter
 // At r_s=5, exchange-correlation dominates -> E/N must be negative
 TEST_CASE("Energy per particle is negative at r_s=5", "[interacting]") {
   constexpr std::size_t N{19U};
-  constexpr double R_S{5.0};
-  const double L{box_length_from_rs(R_S, N)};
+  constexpr real_t R_S{5.0_r};
+  const real_t L{box_length_from_rs(R_S, N)};
 
-  const auto result{run_vmc(N, L, 5000U, 40000U, 0.6, 4096U, 1000U)};
-  const double E_PER_N{result.mean_energy / static_cast<double>(N)};
+  const auto result{run_vmc(N, L, 5000U, 40000U, 0.6_r, 4096U, 1000U)};
+  const real_t E_PER_N{result.mean_energy / static_cast<real_t>(N)};
 
-  REQUIRE(E_PER_N < 0.0);
+  REQUIRE(E_PER_N < 0.0_r);
 }
 
 // E/N at r_s=5 should be more negative than at r_s=2 (approaching energy minimum)
 TEST_CASE("Energy per particle decreases from r_s=2 to r_s=5", "[interacting]") {
   constexpr std::size_t N{19U};
 
-  const double L_2{box_length_from_rs(2.0, N)};
-  const double L_5{box_length_from_rs(5.0, N)};
+  const real_t L_2{box_length_from_rs(2.0_r, N)};
+  const real_t L_5{box_length_from_rs(5.0_r, N)};
 
-  const auto result_2{run_vmc(N, L_2, 5000U, 40000U, 0.3, 1024U, 1000U)};
-  const auto result_5{run_vmc(N, L_5, 5000U, 40000U, 0.6, 2048U, 1000U)};
+  const auto result_2{run_vmc(N, L_2, 5000U, 40000U, 0.3_r, 1024U, 1000U)};
+  const auto result_5{run_vmc(N, L_5, 5000U, 40000U, 0.6_r, 2048U, 1000U)};
 
-  const double E_PER_N_2{result_2.mean_energy / static_cast<double>(N)};
-  const double E_PER_N_5{result_5.mean_energy / static_cast<double>(N)};
+  const real_t E_PER_N_2{result_2.mean_energy / static_cast<real_t>(N)};
+  const real_t E_PER_N_5{result_5.mean_energy / static_cast<real_t>(N)};
 
   REQUIRE(E_PER_N_5 < E_PER_N_2);
 }
 
 // E/N for N=7 and N=19 should agree within ~0.01 Ha/electron at r_s=5
 TEST_CASE("Finite-size convergence: N=7 and N=19 agree at r_s=5", "[interacting]") {
-  constexpr double R_S{5.0};
+  constexpr real_t R_S{5.0_r};
 
-  const double L_7{box_length_from_rs(R_S, 7U)};
-  const double L_19{box_length_from_rs(R_S, 19U)};
+  const real_t L_7{box_length_from_rs(R_S, 7U)};
+  const real_t L_19{box_length_from_rs(R_S, 19U)};
 
-  const auto result_7{run_vmc(7U, L_7, 5000U, 40000U, 0.8, 456U, 1000U)};
-  const auto result_19{run_vmc(19U, L_19, 5000U, 40000U, 0.6, 2048U, 1000U)};
+  const auto result_7{run_vmc(7U, L_7, 5000U, 40000U, 0.8_r, 456U, 1000U)};
+  const auto result_19{run_vmc(19U, L_19, 5000U, 40000U, 0.6_r, 2048U, 1000U)};
 
-  const double E_PER_N_7{result_7.mean_energy / 7.0};
-  const double E_PER_N_19{result_19.mean_energy / 19.0};
+  const real_t E_PER_N_7{result_7.mean_energy / 7.0_r};
+  const real_t E_PER_N_19{result_19.mean_energy / 19.0_r};
 
-  const double DELTA{std::abs(E_PER_N_7 - E_PER_N_19)};
-  REQUIRE(DELTA < 0.01);
+  const real_t DELTA{std::abs(E_PER_N_7 - E_PER_N_19)};
+  REQUIRE(DELTA < 0.01_r);
 }
 
 // 40k measure steps with block_size=1000 -> 40 blocks, should produce reliable SE
 TEST_CASE("Blocking analysis produces finite standard error", "[interacting]") {
   constexpr std::size_t N{7U};
-  constexpr double R_S{2.0};
-  const double L{box_length_from_rs(R_S, N)};
+  constexpr real_t R_S{2.0_r};
+  const real_t L{box_length_from_rs(R_S, N)};
 
-  const auto result{run_vmc(N, L, 2000U, 40000U, 0.4, 123U, 1000U)};
+  const auto result{run_vmc(N, L, 2000U, 40000U, 0.4_r, 123U, 1000U)};
 
-  REQUIRE(result.standard_error > 0.0);
+  REQUIRE(result.standard_error > 0.0_r);
   REQUIRE(std::isfinite(result.standard_error));
 
-  const double SE_PER_N{result.standard_error / static_cast<double>(N)};
-  REQUIRE(SE_PER_N < 0.01);
+  const real_t SE_PER_N{result.standard_error / static_cast<real_t>(N)};
+  REQUIRE(SE_PER_N < 0.01_r);
 }
 
 // Warmup targets ~50% acceptance, measurement should land between 30-70%
 TEST_CASE("Warmup produces reasonable acceptance rate", "[interacting]") {
   constexpr std::size_t N{19U};
-  constexpr double R_S{2.0};
-  const double L{box_length_from_rs(R_S, N)};
+  constexpr real_t R_S{2.0_r};
+  const real_t L{box_length_from_rs(R_S, N)};
 
-  const auto result{run_vmc(N, L, 5000U, 20000U, 0.3, 7777U, 1000U)};
+  const auto result{run_vmc(N, L, 5000U, 20000U, 0.3_r, 7777U, 1000U)};
 
-  REQUIRE(result.acceptance_rate > 0.30);
-  REQUIRE(result.acceptance_rate < 0.70);
+  REQUIRE(result.acceptance_rate > 0.30_r);
+  REQUIRE(result.acceptance_rate < 0.70_r);
 }
 
 // At r_s=1 (high density), KE dominates -> E/N positive, bounded [0.3, 2.0] Ha
 TEST_CASE("Energy per particle at r_s=1 is positive and bounded", "[interacting]") {
   constexpr std::size_t N{19U};
-  constexpr double R_S{1.0};
-  const double L{box_length_from_rs(R_S, N)};
+  constexpr real_t R_S{1.0_r};
+  const real_t L{box_length_from_rs(R_S, N)};
 
-  const auto result{run_vmc(N, L, 5000U, 40000U, 0.2, 789U, 1000U)};
-  const double E_PER_N{result.mean_energy / static_cast<double>(N)};
+  const auto result{run_vmc(N, L, 5000U, 40000U, 0.2_r, 789U, 1000U)};
+  const real_t E_PER_N{result.mean_energy / static_cast<real_t>(N)};
 
-  REQUIRE(E_PER_N > 0.0);
-  REQUIRE(E_PER_N > 0.3);
-  REQUIRE(E_PER_N < 2.0);
+  REQUIRE(E_PER_N > 0.0_r);
+  REQUIRE(E_PER_N > 0.3_r);
+  REQUIRE(E_PER_N < 2.0_r);
 }
 
 // SE per particle should be small fraction of |E/N|
 TEST_CASE("Standard error is small relative to energy scale", "[interacting]") {
   constexpr std::size_t N{19U};
-  constexpr double R_S{5.0};
-  const double L{box_length_from_rs(R_S, N)};
+  constexpr real_t R_S{5.0_r};
+  const real_t L{box_length_from_rs(R_S, N)};
 
-  const auto result{run_vmc(N, L, 5000U, 40000U, 0.6, 31415U, 1000U)};
+  const auto result{run_vmc(N, L, 5000U, 40000U, 0.6_r, 31415U, 1000U)};
 
-  const double SE_PER_N{result.standard_error / static_cast<double>(N)};
-  const double ABS_E_PER_N{std::abs(result.mean_energy / static_cast<double>(N))};
+  const real_t SE_PER_N{result.standard_error / static_cast<real_t>(N)};
+  const real_t ABS_E_PER_N{std::abs(result.mean_energy / static_cast<real_t>(N))};
 
-  REQUIRE(SE_PER_N < 0.1 * ABS_E_PER_N);
+  REQUIRE(SE_PER_N < 0.1_r * ABS_E_PER_N);
 }
 
 // Deterministic RNG seeding must produce identical results
 TEST_CASE("Same seed produces identical energy", "[interacting]") {
   constexpr std::size_t N{7U};
-  constexpr double R_S{2.0};
-  const double L{box_length_from_rs(R_S, N)};
+  constexpr real_t R_S{2.0_r};
+  const real_t L{box_length_from_rs(R_S, N)};
 
-  const auto r1{run_vmc(N, L, 1000U, 10000U, 0.4, 42U, 500U)};
-  const auto r2{run_vmc(N, L, 1000U, 10000U, 0.4, 42U, 500U)};
+  const auto r1{run_vmc(N, L, 1000U, 10000U, 0.4_r, 42U, 500U)};
+  const auto r2{run_vmc(N, L, 1000U, 10000U, 0.4_r, 42U, 500U)};
 
   REQUIRE(r1.mean_energy == r2.mean_energy);
 }
@@ -168,16 +168,16 @@ TEST_CASE("Same seed produces identical energy", "[interacting]") {
 // Different seeds should agree within 3 combined standard errors
 TEST_CASE("Independent seeds produce consistent energies", "[interacting]") {
   constexpr std::size_t N{7U};
-  constexpr double R_S{5.0};
-  const double L{box_length_from_rs(R_S, N)};
+  constexpr real_t R_S{5.0_r};
+  const real_t L{box_length_from_rs(R_S, N)};
 
-  const auto r1{run_vmc(N, L, 3000U, 40000U, 0.8, 111U, 1000U)};
-  const auto r2{run_vmc(N, L, 3000U, 40000U, 0.8, 222U, 1000U)};
+  const auto r1{run_vmc(N, L, 3000U, 40000U, 0.8_r, 111U, 1000U)};
+  const auto r2{run_vmc(N, L, 3000U, 40000U, 0.8_r, 222U, 1000U)};
 
-  const double COMBINED_SE{
+  const real_t COMBINED_SE{
     std::sqrt(r1.standard_error * r1.standard_error + r2.standard_error * r2.standard_error)
   };
-  const double DELTA{std::abs(r1.mean_energy - r2.mean_energy)};
+  const real_t DELTA{std::abs(r1.mean_energy - r2.mean_energy)};
 
-  REQUIRE(DELTA < 3.0 * COMBINED_SE);
+  REQUIRE(DELTA < 3.0_r * COMBINED_SE);
 }

--- a/tests/test_wavefunction.cpp
+++ b/tests/test_wavefunction.cpp
@@ -10,29 +10,29 @@ TEST_CASE("WaveFunction evaluateDerivatives clears buffers and delegates to Jast
           "[wavefunction]") {
   Particles particles{2U};
 
-  particles.pos().x_[0] = 0.0;
-  particles.pos().y_[0] = 0.0;
-  particles.pos().z_[0] = 0.0;
+  particles.pos().x_[0] = 0.0_r;
+  particles.pos().y_[0] = 0.0_r;
+  particles.pos().z_[0] = 0.0_r;
 
-  particles.pos().x_[1] = 1.0;
-  particles.pos().y_[1] = 0.0;
-  particles.pos().z_[1] = 0.0;
+  particles.pos().x_[1] = 1.0_r;
+  particles.pos().y_[1] = 0.0_r;
+  particles.pos().z_[1] = 0.0_r;
 
   const std::size_t stride{particles.p_stride()};
   for (std::size_t i = 0; i < stride; ++i) {
-    particles.grad_log_psi().x_[i] = 999.0;
-    particles.grad_log_psi().y_[i] = 999.0;
-    particles.grad_log_psi().z_[i] = 999.0;
-    particles.lap_log_psi()[i] = 999.0;
+    particles.grad_log_psi().x_[i] = 999.0_r;
+    particles.grad_log_psi().y_[i] = 999.0_r;
+    particles.grad_log_psi().z_[i] = 999.0_r;
+    particles.lap_log_psi()[i] = 999.0_r;
   }
 
-  WaveFunction waveFunction{particles, 10.0, 0.5, 1.0};
+  WaveFunction waveFunction{particles, 10.0_r, 0.5_r, 1.0_r};
 
   // Compute expected: zero-init then add both Slater and Jastrow
-  std::vector<double> expectedX(stride, 0.0);
-  std::vector<double> expectedY(stride, 0.0);
-  std::vector<double> expectedZ(stride, 0.0);
-  std::vector<double> expectedLap(stride, 0.0);
+  std::vector<real_t> expectedX(stride, 0.0_r);
+  std::vector<real_t> expectedY(stride, 0.0_r);
+  std::vector<real_t> expectedZ(stride, 0.0_r);
+  std::vector<real_t> expectedLap(stride, 0.0_r);
 
   // Need to call log_abs_det first to populate the inverse
   waveFunction.slater_plane_wave().log_abs_det(particles);
@@ -62,26 +62,26 @@ TEST_CASE("WaveFunction evaluate_log_psi returns finite for N=1", "[wavefunction
   // Total log_psi = 0
   Particles particles{1U};
 
-  particles.pos().x_[0] = 0.4;
-  particles.pos().y_[0] = 0.7;
-  particles.pos().z_[0] = 0.9;
+  particles.pos().x_[0] = 0.4_r;
+  particles.pos().y_[0] = 0.7_r;
+  particles.pos().z_[0] = 0.9_r;
 
-  WaveFunction waveFunction{particles, 10.0, 0.5, 1.0};
+  WaveFunction waveFunction{particles, 10.0_r, 0.5_r, 1.0_r};
 
-  const double logPsi{waveFunction.evaluate_log_psi(particles)};
-  require_near(logPsi, 0.0);
+  const real_t logPsi{waveFunction.evaluate_log_psi(particles)};
+  require_near(logPsi, 0.0_r);
 }
 
 TEST_CASE("WaveFunction default Jastrow parameter matches fully polarized cusp choice",
           "[wavefunction]") {
   Particles particles{2U};
-  WaveFunction waveFunction{particles, 9.0};
+  WaveFunction waveFunction{particles, 9.0_r};
 
-  const double actualA{waveFunction.jastrow_pade().a()};
-  const double actualB{waveFunction.jastrow_pade().b()};
+  const real_t actualA{waveFunction.jastrow_pade().a()};
+  const real_t actualB{waveFunction.jastrow_pade().b()};
 
   INFO("Default WaveFunction Jastrow parameters should match the fully polarized HEG choice.");
   CAPTURE(actualA, actualB);
-  require_near(actualA, 0.25);
-  require_near(actualB, 1.0);
+  require_near(actualA, 0.25_r);
+  require_near(actualB, 1.0_r);
 }


### PR DESCRIPTION
## Summary

Fixes: https://github.com/UWHPC/Variational-Monte-Carlo/issues/23

Replaces hardcoded `double`/`float` throughout the codebase with a `real_t` typedef, controlled by a new `FP_64` CMake option (on by default). Also adds `complex_t` for future use.

- `real_t` = `double` when `FP_64` is on, `float` otherwise
- Added a `1.0_r` literal suffix so float literals cast correctly without noisy narrowing warnings (and without silently blocking SIMD vectorization)
- Converted every source and test file, including tolerance constants in tests, which now scale by precision mode instead of using one hardcoded value that would fail spuriously in float mode

## Testing

Full test suite passes. Verified locally with `g++ -fsyntax-only` per file in both `FP_64` on and off before that, then ran the actual build and test suite, which confirmed everything works end to end.

## Notes

- `AlignedSoA<double>` in `test_aligned_soa.cpp` is untouched on purpose. It's testing the generic container itself, not simulation numerics.
- The wall-clock timer in `main.cpp` stays `double` since it's unrelated to `real_t`.