### PR TITLE
Port CMake for CUDA acceleration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,38 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.24)
 
 if(
-    NOT DEFINED CMAKE_EXPORT_COMPILE_COMMANDS
-    OR CMAKE_EXPORT_COMPILE_COMMANDS STREQUAL ""
+  NOT DEFINED CMAKE_EXPORT_COMPILE_COMMANDS
+  OR CMAKE_EXPORT_COMPILE_COMMANDS STREQUAL ""
 )
-    set(
-        CMAKE_EXPORT_COMPILE_COMMANDS
-        ON
-        CACHE BOOL "Generate compile_commands.json for tooling" FORCE
-    )
+  set(
+    CMAKE_EXPORT_COMPILE_COMMANDS
+    ON
+    CACHE BOOL "Generate compile_commands.json for tooling" FORCE
+  )
 endif()
 
 project(Variational-Monte-Carlo LANGUAGES CXX)
 
+option(VMC_ENABLE_CUDA "Enable CUDA acceleration if a CUDA compiler is available" ON)
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# --- CUDA detection ---
+set(VMC_CUDA OFF)
+if(VMC_ENABLE_CUDA)
+  include(CheckLanguage)
+  check_language(CUDA)
+  if(CMAKE_CUDA_COMPILER)
+    enable_language(CUDA)
+    set(CMAKE_CUDA_STANDARD 23)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+      set(CMAKE_CUDA_ARCHITECTURES native)
+    endif()
+    set(VMC_CUDA ON)
+  endif()
+endif()
 
 # --- Floating point precision ---
 option(FP_64 "Use double precision (real_t = double) instead of single precision (real_t = float)" ON)
@@ -23,88 +41,139 @@ option(FP_64 "Use double precision (real_t = double) instead of single precision
 find_package(OpenMP QUIET COMPONENTS CXX)
 
 if(OpenMP_CXX_FOUND)
-    message(STATUS "OpenMP found (CXX ${OpenMP_CXX_VERSION}); using it for '#pragma omp simd'.")
+  message(STATUS "OpenMP found (CXX ${OpenMP_CXX_VERSION}); using it for '#pragma omp simd'.")
 else()
-    message(STATUS "OpenMP not found; building without it (we only use '#pragma omp simd').")
-    include(CheckCXXCompilerFlag)
-    check_cxx_compiler_flag("-fopenmp-simd" VMC_HAS_FOPENMP_SIMD)
+  message(STATUS "OpenMP not found; building without it (we only use '#pragma omp simd').")
+  include(CheckCXXCompilerFlag)
+  check_cxx_compiler_flag("-fopenmp-simd" VMC_HAS_FOPENMP_SIMD)
 endif()
 
 # --- Build type default (Release unless overridden) ---
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+if(NOT CMAKE_CONFIGURATION_TYPES)
+  if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+  endif()
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release RelWithDebInfo MinSizeRel)
 endif()
-set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release RelWithDebInfo MinSizeRel)
 
 # --- Compiler warnings and optimizations ---
 if(MSVC)
-    set(VMC_WARNING_OPTIONS /W4 /permissive- /arch:AVX2)
-    set(VMC_RELEASE_OPTIONS /O2)
-    set(VMC_DEBUG_OPTIONS   /Od /Zi)
-    set(VMC_RELWITHDEBINFO_OPT_1 /O2)
-    set(VMC_RELWITHDEBINFO_OPT_2 /Oy-)
-    set(VMC_RELWITHDEBINFO_OPT_3 "")
+  set(VMC_WARNING_OPTIONS /W4 /permissive- /arch:AVX2)
+  set(VMC_RELEASE_OPTIONS /O2)
+  set(VMC_DEBUG_OPTIONS   /Od /Zi)
+  set(VMC_RELWITHDEBINFO_OPT_1 /O2)
+  set(VMC_RELWITHDEBINFO_OPT_2 /Oy-)
+  set(VMC_RELWITHDEBINFO_OPT_3 "")
 else()
-    set(VMC_WARNING_OPTIONS
-        -Wall
-        -Wextra
-        -Wpedantic
-        -Wshadow
-        -Wconversion
-        -Wsign-conversion
-    )
-    set(VMC_RELEASE_OPTIONS -O3 -march=native)
-    set(VMC_DEBUG_OPTIONS   -g -O0)
-    set(VMC_RELWITHDEBINFO_OPT_1 -O3)
-    set(VMC_RELWITHDEBINFO_OPT_2 -march=native)
-    set(VMC_RELWITHDEBINFO_OPT_3 -fno-omit-frame-pointer)
+  set(VMC_WARNING_OPTIONS
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wshadow
+    -Wconversion
+    -Wsign-conversion
+  )
+  set(VMC_RELEASE_OPTIONS -O3 -march=native)
+  set(VMC_DEBUG_OPTIONS   -g -O0)
+  set(VMC_RELWITHDEBINFO_OPT_1 -O3)
+  set(VMC_RELWITHDEBINFO_OPT_2 -march=native)
+  set(VMC_RELWITHDEBINFO_OPT_3 -fno-omit-frame-pointer)
 endif()
+
+if(VMC_CUDA)
+  if(MSVC)
+    set(VMC_CUDA_XCOMPILE "-Xcompiler=/W4,/permissive-")
+    set(VMC_CUDA_RELEASE_OPTIONS -Xcompiler=/O2)
+    set(VMC_CUDA_DEBUG_OPTIONS   -Xcompiler=/Od,/Zi -G)
+  else()
+    set(VMC_CUDA_XCOMPILE "-Xcompiler=-Wall,-Wextra,-march=native")
+    set(VMC_CUDA_RELEASE_OPTIONS -O3 -Xcompiler=-O3)
+    set(VMC_CUDA_DEBUG_OPTIONS   -g -G -O0 -Xcompiler=-O0)
+  endif()
+endif()
+
+# --- Source lists ---
+set(VMC_CUDA_SOURCES
+  # src/simulation/simulation.cu
+)
+
+set(VMC_CXX_SOURCES
+  src/jastrow_pade/jastrow_pade.cpp
+  src/wavefunction/wavefunction.cpp
+  src/slater_plane_wave/slater_plane_wave.cpp
+  src/simulation/simulation.cpp
+  src/blocking_analysis/blocking_analysis.cpp
+  src/output_writer/output_writer.cpp
+  src/energy_tracking/energy_tracking.cpp
+  src/optimizer/jastrow_optimizer.cpp
+)
+
+set(VMC_CUDA_EXTENSION_SOURCES
+  ${VMC_CUDA_SOURCES}
+)
 
 # --- Library target for all source files ---
 add_library(vmc_lib STATIC
-    src/jastrow_pade/jastrow_pade.cpp
-    src/wavefunction/wavefunction.cpp
-    src/slater_plane_wave/slater_plane_wave.cpp
-    src/simulation/simulation.cpp
-    src/blocking_analysis/blocking_analysis.cpp
-    src/output_writer/output_writer.cpp
-    src/energy_tracking/energy_tracking.cpp
-    src/optimizer/jastrow_optimizer.cpp
+  ${VMC_CXX_SOURCES}
+  ${VMC_CUDA_SOURCES}
 )
 
 target_include_directories(vmc_lib PUBLIC src)
 
+if(NOT VMC_CUDA AND VMC_CUDA_EXTENSION_SOURCES)
+  set_source_files_properties(
+    ${VMC_CUDA_EXTENSION_SOURCES}
+    PROPERTIES LANGUAGE CXX
+  )
+
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    set_source_files_properties(
+      ${VMC_CUDA_EXTENSION_SOURCES}
+      PROPERTIES COMPILE_OPTIONS "-x;c++"
+    )
+  endif()
+endif()
+
 if(FP_64)
-    target_compile_definitions(vmc_lib PUBLIC FP_64)
+  target_compile_definitions(vmc_lib PUBLIC FP_64)
 endif()
 
 if(OpenMP_CXX_FOUND)
-    target_link_libraries(vmc_lib PUBLIC OpenMP::OpenMP_CXX)
+  target_link_libraries(vmc_lib PUBLIC OpenMP::OpenMP_CXX)
 elseif(VMC_HAS_FOPENMP_SIMD)
-    target_compile_options(vmc_lib PUBLIC -fopenmp-simd)
+  target_compile_options(vmc_lib PUBLIC -fopenmp-simd)
 endif()
 target_compile_options(vmc_lib PRIVATE
-    ${VMC_WARNING_OPTIONS}
-    $<$<CONFIG:Release>:${VMC_RELEASE_OPTIONS}>
-    $<$<CONFIG:Debug>:${VMC_DEBUG_OPTIONS}>
-    $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_1}>
-    $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_2}>
-    $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_3}>
+  $<$<COMPILE_LANGUAGE:CXX>:${VMC_WARNING_OPTIONS}>
+  $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Release>>:${VMC_RELEASE_OPTIONS}>
+  $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:Debug>>:${VMC_DEBUG_OPTIONS}>
+  $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:RelWithDebInfo>>:${VMC_RELWITHDEBINFO_OPT_1}>
+  $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:RelWithDebInfo>>:${VMC_RELWITHDEBINFO_OPT_2}>
+  $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:RelWithDebInfo>>:${VMC_RELWITHDEBINFO_OPT_3}>
+  $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<BOOL:${VMC_CUDA}>>:${VMC_CUDA_XCOMPILE}>
+  $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<BOOL:${VMC_CUDA}>,$<CONFIG:Release>>:${VMC_CUDA_RELEASE_OPTIONS}>
+  $<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<BOOL:${VMC_CUDA}>,$<CONFIG:Debug>>:${VMC_CUDA_DEBUG_OPTIONS}>
 )
+
+if(VMC_CUDA)
+  set_target_properties(vmc_lib PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON
+  )
+endif()
 
 # --- Main executable ---
 add_executable(vmc
-    src/main.cpp
+  src/main.cpp
 )
 
 target_link_libraries(vmc PRIVATE vmc_lib)
 target_compile_options(vmc PRIVATE
-    ${VMC_WARNING_OPTIONS}
-    $<$<CONFIG:Release>:${VMC_RELEASE_OPTIONS}>
-    $<$<CONFIG:Debug>:${VMC_DEBUG_OPTIONS}>
-    $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_1}>
-    $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_2}>
-    $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_3}>
+  ${VMC_WARNING_OPTIONS}
+  $<$<CONFIG:Release>:${VMC_RELEASE_OPTIONS}>
+  $<$<CONFIG:Debug>:${VMC_DEBUG_OPTIONS}>
+  $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_1}>
+  $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_2}>
+  $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_3}>
 )
 
 # --- Testing (opt-in via BUILD_TESTING argument) ---
@@ -112,35 +181,35 @@ include(CTest)
 
 if(BUILD_TESTING)
 
-    include(FetchContent)
+  include(FetchContent)
 
-    fetchcontent_declare(
-        Catch2
-        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG v3.8.1
-    )
+  fetchcontent_declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.8.1
+  )
 
-    fetchcontent_makeavailable(Catch2)
+  fetchcontent_makeavailable(Catch2)
 
-    add_executable(vmc_tests
-        tests/test_tests.cpp
-    )
+  add_executable(vmc_tests
+    tests/test_tests.cpp
+  )
 
-    target_link_libraries(vmc_tests PRIVATE
-        Catch2::Catch2WithMain
-        vmc_lib
-    )
-    target_compile_options(vmc_tests PRIVATE
-        ${VMC_WARNING_OPTIONS}
-        $<$<CONFIG:Release>:${VMC_RELEASE_OPTIONS}>
-        $<$<CONFIG:Debug>:${VMC_DEBUG_OPTIONS}>
-        $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_1}>
-        $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_2}>
-        $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_3}>
-    )
+  target_link_libraries(vmc_tests PRIVATE
+    Catch2::Catch2WithMain
+    vmc_lib
+  )
+  target_compile_options(vmc_tests PRIVATE
+    ${VMC_WARNING_OPTIONS}
+    $<$<CONFIG:Release>:${VMC_RELEASE_OPTIONS}>
+    $<$<CONFIG:Debug>:${VMC_DEBUG_OPTIONS}>
+    $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_1}>
+    $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_2}>
+    $<$<CONFIG:RelWithDebInfo>:${VMC_RELWITHDEBINFO_OPT_3}>
+  )
 
-    list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
-    include(Catch)
-    catch_discover_tests(vmc_tests)
+  list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
+  include(Catch)
+  catch_discover_tests(vmc_tests)
 
 endif()


### PR DESCRIPTION
## Summary

Fixes: https://github.com/UWHPC/Variational-Monte-Carlo/issues/34

Ports the CUDA detection/toggle pattern from the heat-solver project into `CMakeLists.txt`, so we can add CUDA kernels later without needing CUDA to build today. `FP_64`, OpenMP, and Catch2 are untouched.

## Changes

- Adds `VMC_ENABLE_CUDA` (on by default), detected via `check_language(CUDA)`
- Adds empty `VMC_CUDA_SOURCES` / `VMC_CXX_SOURCES` lists as a place for future `.cu` files (no kernels yet, so no behavior change)
- Guards existing warning/opt flags with `$<COMPILE_LANGUAGE:CXX>` so they don't leak into `nvcc`, with a smaller matching set for CUDA
- Sets `CUDA_SEPARABLE_COMPILATION` when CUDA is on
- Bumps `cmake_minimum_required` to 3.24 (needed for `CMAKE_CUDA_ARCHITECTURES native`)
- Fixes a pre-existing bug where `set_property(CACHE CMAKE_BUILD_TYPE ...)` crashed configure under the Visual Studio multi-config generator
- Reformats the file to 2-space indentation (whitespace only, checked with `git diff -w`)

## Testing

Configured and built `vmc_lib` on both the default VS generator and Ninja with no CUDA compiler present, confirming the fallback path works.

## Notes

Not tested with CUDA actually enabled. `complex_t` (`std::complex<real_t>`) also won't work in device code yet, that's a follow-up for whenever kernels get ported.