### PR TITLE
Implement --fp32 / -Fp32 argument for build scripts

### DIFF
--- a/scripts/build-fast.sh
+++ b/scripts/build-fast.sh
@@ -1,14 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+FP32=0
+for arg in "$@"; do
+  case "$arg" in
+    --fp32)
+      FP32=1
+      ;;
+  esac
+done
+
+if [ "$FP32" -eq 1 ]; then
+  FP64_FLAG="OFF"
+else
+  FP64_FLAG="ON"
+fi
+
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*)
     echo "MSVC builds on Windows must run from PowerShell (sourcing vcvars64.bat from Git Bash hangs)." >&2
-    echo "Run instead: .\\scripts\\build.ps1" >&2
+    echo "Run instead: .\\scripts\\build.ps1 $([ "$FP32" -eq 1 ] && echo "-Fp32 ")" >&2
     exit 1
     ;;
   *)
-    cmake -S . -B build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
+    cmake -S . -B build -DFP_64=$FP64_FLAG -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
     cmake --build build --target vmc
     ;;
 esac

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,6 +1,7 @@
 param(
     [string]$BuildType = "Release",
-    [switch]$Cuda
+    [switch]$Cuda,
+    [switch]$Fp32
 )
 
 $vcvars = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat'
@@ -11,6 +12,7 @@ if (-not (Test-Path $vcvars)) {
 
 $buildDir = if ($Cuda) { "build-cuda" } else { "build" }
 $cudaFlag = if ($Cuda) { "ON" } else { "OFF" }
+$fp64Flag = if ($Fp32) { "OFF" } else { "ON" }
 
-cmd /c "`"$vcvars`" && cmake -S . -B $buildDir -G Ninja -DVMC_ENABLE_CUDA=$cudaFlag -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=$BuildType && cmake --build $buildDir --target vmc"
+cmd /c "`"$vcvars`" && cmake -S . -B $buildDir -G Ninja -DVMC_ENABLE_CUDA=$cudaFlag -DFP_64=$fp64Flag -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=$BuildType && cmake --build $buildDir --target vmc"
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,11 +3,15 @@ set -euo pipefail
 
 BUILD_TYPE="Release"
 CUDA=0
+FP32=0
 
 for arg in "$@"; do
   case "$arg" in
     --cuda)
       CUDA=1
+      ;;
+    --fp32)
+      FP32=1
       ;;
     *)
       BUILD_TYPE="$arg"
@@ -23,14 +27,20 @@ else
   CUDA_FLAG="OFF"
 fi
 
+if [ "$FP32" -eq 1 ]; then
+  FP64_FLAG="OFF"
+else
+  FP64_FLAG="ON"
+fi
+
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*)
     echo "CUDA/MSVC builds on Windows must run from PowerShell (sourcing vcvars64.bat from Git Bash hangs)." >&2
-    echo "Run instead: .\\scripts\\build.ps1 $([ "$CUDA" -eq 1 ] && echo "-Cuda ")-BuildType $BUILD_TYPE" >&2
+    echo "Run instead: .\\scripts\\build.ps1 $([ "$CUDA" -eq 1 ] && echo "-Cuda ")$([ "$FP32" -eq 1 ] && echo "-Fp32 ")-BuildType $BUILD_TYPE" >&2
     exit 1
     ;;
   *)
-    cmake -S . -B "$BUILD_DIR" -DVMC_ENABLE_CUDA=$CUDA_FLAG -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+    cmake -S . -B "$BUILD_DIR" -DVMC_ENABLE_CUDA=$CUDA_FLAG -DFP_64=$FP64_FLAG -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
     cmake --build "$BUILD_DIR" --target vmc
     ;;
 esac

--- a/scripts/profile.ps1
+++ b/scripts/profile.ps1
@@ -1,6 +1,7 @@
 param(
     [string]$BuildDir = "",
-    [switch]$Cuda
+    [switch]$Cuda,
+    [switch]$Fp32
 )
 
 $vcvars = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat'
@@ -13,7 +14,8 @@ if ($BuildDir -eq "") {
     $BuildDir = if ($Cuda) { "build-prof-cuda" } else { "build-prof" }
 }
 $cudaFlag = if ($Cuda) { "ON" } else { "OFF" }
+$fp64Flag = if ($Fp32) { "OFF" } else { "ON" }
 
-cmd /c "`"$vcvars`" && cmake -S . -B $BuildDir -G Ninja -DVMC_ENABLE_CUDA=$cudaFlag -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo && cmake --build $BuildDir --target vmc"
+cmd /c "`"$vcvars`" && cmake -S . -B $BuildDir -G Ninja -DVMC_ENABLE_CUDA=$cudaFlag -DFP_64=$fp64Flag -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo && cmake --build $BuildDir --target vmc"
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 Write-Host "Profiler build ready: ./$BuildDir/vmc"

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -3,11 +3,15 @@ set -euo pipefail
 
 BUILD_DIR=""
 CUDA=0
+FP32=0
 
 for arg in "$@"; do
   case "$arg" in
     --cuda)
       CUDA=1
+      ;;
+    --fp32)
+      FP32=1
       ;;
     *)
       BUILD_DIR="$arg"
@@ -24,14 +28,20 @@ else
 fi
 BUILD_DIR="${BUILD_DIR:-$DEFAULT_DIR}"
 
+if [ "$FP32" -eq 1 ]; then
+  FP64_FLAG="OFF"
+else
+  FP64_FLAG="ON"
+fi
+
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*)
     echo "CUDA/MSVC builds on Windows must run from PowerShell (sourcing vcvars64.bat from Git Bash hangs)." >&2
-    echo "Run instead: .\\scripts\\profile.ps1 $([ "$CUDA" -eq 1 ] && echo "-Cuda ")-BuildDir $BUILD_DIR" >&2
+    echo "Run instead: .\\scripts\\profile.ps1 $([ "$CUDA" -eq 1 ] && echo "-Cuda ")$([ "$FP32" -eq 1 ] && echo "-Fp32 ")-BuildDir $BUILD_DIR" >&2
     exit 1
     ;;
   *)
-    cmake -S . -B "$BUILD_DIR" -DVMC_ENABLE_CUDA=$CUDA_FLAG -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    cmake -S . -B "$BUILD_DIR" -DVMC_ENABLE_CUDA=$CUDA_FLAG -DFP_64=$FP64_FLAG -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
     cmake --build "$BUILD_DIR" --target vmc
     ;;
 esac

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -1,4 +1,7 @@
-param([string]$BuildType = "Debug")
+param(
+    [string]$BuildType = "Debug",
+    [switch]$Fp32
+)
 
 $vcvars = 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat'
 if (-not (Test-Path $vcvars)) {
@@ -6,5 +9,7 @@ if (-not (Test-Path $vcvars)) {
     exit 1
 }
 
-cmd /c "`"$vcvars`" && cmake -S . -B build-tests -G Ninja -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=$BuildType -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && cmake --build build-tests --target vmc_tests && ctest --test-dir build-tests --output-on-failure"
+$fp64Flag = if ($Fp32) { "OFF" } else { "ON" }
+
+cmd /c "`"$vcvars`" && cmake -S . -B build-tests -G Ninja -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=$BuildType -DFP_64=$fp64Flag -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && cmake --build build-tests --target vmc_tests && ctest --test-dir build-tests --output-on-failure"
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,17 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BUILD_TYPE="${1:-Debug}"
+BUILD_TYPE="Debug"
+FP32=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --fp32)
+      FP32=1
+      ;;
+    *)
+      BUILD_TYPE="$arg"
+      ;;
+  esac
+done
+
+if [ "$FP32" -eq 1 ]; then
+  FP64_FLAG="OFF"
+else
+  FP64_FLAG="ON"
+fi
 
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*)
     echo "MSVC builds on Windows must run from PowerShell (sourcing vcvars64.bat from Git Bash hangs)." >&2
-    echo "Run instead: .\\scripts\\test.ps1 $BUILD_TYPE" >&2
+    echo "Run instead: .\\scripts\\test.ps1 $([ "$FP32" -eq 1 ] && echo "-Fp32 ")-BuildType $BUILD_TYPE" >&2
     exit 1
     ;;
   *)
     cmake -S . -B build-tests -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
-          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          -DFP_64=$FP64_FLAG -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     cmake --build build-tests --target vmc_tests
     ctest --test-dir build-tests --output-on-failure
     ;;


### PR DESCRIPTION
## Summary

Fixes: #59

Adds a `--fp32` (bash) / `-Fp32` (PowerShell) flag to the build, test, and profile scripts, so single precision (`real_t = float`) can be selected from the CLI instead of calling `cmake -DFP_64=OFF` by hand.

## Changes

- `scripts/build.sh` / `scripts/build.ps1`
- `scripts/build-fast.sh`
- `scripts/test.sh` / `scripts/test.ps1`
- `scripts/profile.sh` / `scripts/profile.ps1`

Each script now parses the new flag and passes `-DFP_64=OFF` through to its `cmake -S ... -B ...` configure call. No flag means no behavior change: FP64 stays the default, matching the existing CMake default in `CMakeLists.txt`. The flag composes with the existing `--cuda` / `-Cuda` flag.

## Testing

- `.\scripts\build.ps1 -Fp32`: builds clean, `CMakeCache.txt` confirms `FP_64:BOOL=OFF`
- `.\scripts\profile.ps1 -Fp32` and `.\scripts\profile.ps1` (default): both ran end-to-end, binary correctly reports `FP32` / `FP64` at the end matching the requested precision, energy values differ as expected from precision