### PR TITLE
Implement cudaLogAbsDet CUDA kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ endif()
 set(VMC_CUDA_SOURCES
   src/jastrow_pade/jastrow_pade.cu
   src/wavefunction/wavefunction.cu
+  src/slater_plane_wave/slater_kernels.cu
   src/slater_plane_wave/slater_plane_wave.cu
   src/simulation/simulation.cu
   src/energy_tracking/energy_tracking.cu
@@ -168,8 +169,16 @@ target_compile_options(vmc_lib PRIVATE
 )
 
 if(VMC_CUDA)
+  find_package(CUDAToolkit REQUIRED)
+
   set_target_properties(vmc_lib PROPERTIES
     CUDA_SEPARABLE_COMPILATION ON
+  )
+
+  target_link_libraries(vmc_lib PUBLIC
+    CUDA::cudart
+    CUDA::cusolver
+    CUDA::cublas
   )
 endif()
 

--- a/src/slater_plane_wave/slater_kernels.cu
+++ b/src/slater_plane_wave/slater_kernels.cu
@@ -1,0 +1,284 @@
+#include "slater_plane_wave.cuh"
+
+#if defined(__CUDACC__)
+#include <cublas_v2.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+
+namespace {
+
+inline void cuSolverGetrfBufferSize(
+  cusolverDnHandle_t handle,
+  int rows,
+  int cols,
+  real_t* matrix,
+  int leading_dim,
+  int* work_size
+) {
+#ifdef FP_64
+  CUSOLVER_CHECK(cusolverDnDgetrf_bufferSize(
+    handle, rows, cols, matrix, leading_dim, work_size
+  ));
+#else
+  CUSOLVER_CHECK(cusolverDnSgetrf_bufferSize(
+    handle, rows, cols, matrix, leading_dim, work_size
+  ));
+#endif
+}
+
+inline void cusolverGetrf(
+  cusolverDnHandle_t handle,
+  int rows,
+  int cols,
+  real_t* matrix,
+  int leading_dim,
+  real_t* work,
+  int* pivot,
+  int* info
+) {
+#ifdef FP_64
+  CUSOLVER_CHECK(cusolverDnDgetrf(
+    handle, rows, cols, matrix, leading_dim, work, pivot, info
+  ));
+#else
+  CUSOLVER_CHECK(cusolverDnSgetrf(
+    handle, rows, cols, matrix, leading_dim, work, pivot, info
+  ));
+#endif
+}
+
+inline void cusolverGetrs(
+  cusolverDnHandle_t handle,
+  cublasOperation_t transpose,
+  int n,
+  int num_rhs,
+  const real_t* lower_upper,
+  int leading_dim,
+  const int* pivot,
+  real_t* rhs,
+  int rhs_leading_dim,
+  int* info
+) {
+#ifdef FP_64
+  CUSOLVER_CHECK(cusolverDnDgetrs(
+    handle, transpose, n, num_rhs, lower_upper, leading_dim,
+    pivot, rhs, rhs_leading_dim, info
+  ));
+#else
+  CUSOLVER_CHECK(cusolverDnSgetrs(
+    handle, transpose, n, num_rhs, lower_upper, leading_dim,
+    pivot, rhs, rhs_leading_dim, info
+  ));
+#endif
+}
+
+void checkCusolverInfo(int info, const char* name) {
+  if (info < 0) {
+    std::fprintf(stderr, "cuSOLVER %s invalid argument: %d\n", name, -info);
+    std::abort();
+  }
+}
+
+__global__
+void cudaBuildTrigCache(
+  std::size_t N, std::size_t trig_S, std::size_t num_unique_k,
+  const real_t* RESTRICT p_x, const real_t* RESTRICT p_y, const real_t* RESTRICT p_z,
+  const real_t* RESTRICT k_x, const real_t* RESTRICT k_y, const real_t* RESTRICT k_z,
+  real_t* RESTRICT s_cache, real_t* RESTRICT c_cache
+) {
+  const std::size_t j{blockIdx.x * blockDim.x + threadIdx.x};
+  if (j >= num_unique_k) { return; }
+
+  const std::size_t i{blockIdx.y * blockDim.y + threadIdx.y};
+  if (i >= N) { return; }
+
+  const real_t dot{
+    k_x[j] * p_x[i] +
+    k_y[j] * p_y[i] +
+    k_z[j] * p_z[i]
+  };
+
+  const std::size_t offset{i * trig_S};
+  const std::size_t sc_idx{offset + j};
+
+  vmc::sincos(dot, &s_cache[sc_idx], &c_cache[sc_idx]);
+}
+
+__global__
+void cudaBuildDetFromCache(
+  std::size_t N, std::size_t trig_S, std::size_t mat_S,
+  const real_t* RESTRICT s_cache, const real_t* RESTRICT c_cache,
+  const std::size_t* RESTRICT k_idx, const std::uint8_t* RESTRICT orb_t,
+  real_t* RESTRICT det_mat
+) {
+  const std::size_t j{blockIdx.x * blockDim.x + threadIdx.x};
+  if (j >= N) { return; }
+
+  const std::size_t i{blockIdx.y * blockDim.y + threadIdx.y};
+  if (i >= N) { return; }
+
+  const std::size_t offset{i * trig_S};
+  const std::size_t trig_idx{offset + k_idx[j]};
+  const std::size_t mat_idx{i * mat_S + j};
+
+  const real_t type{static_cast<real_t>(orb_t[j])};
+  const real_t cos_term{c_cache[trig_idx]};
+  const real_t sin_term{s_cache[trig_idx]};
+
+  det_mat[mat_idx] = cos_term + type * (sin_term - cos_term);
+}
+
+__global__
+void cudaComputeLogAbsDet(
+  std::size_t N, std::size_t mat_S,
+  const real_t* lower_upper,
+  real_t* log_abs_det
+) {
+  const std::size_t i{blockIdx.x * blockDim.x + threadIdx.x};
+  if (i >= N) { return; }
+
+  const real_t U_diag{lower_upper[i * mat_S + i]};
+
+  atomicAdd(log_abs_det, vmc::log(vmc::abs(U_diag)));
+}
+
+__global__
+void cudaBuildIdentity(
+  std::size_t N,
+  std::size_t mat_S,
+  real_t* matrix
+) {
+  const std::size_t i{blockIdx.x * blockDim.x + threadIdx.x};
+  const std::size_t size{N * mat_S};
+  if (i >= size) { return; }
+
+  const std::size_t row{i / mat_S};
+  const std::size_t col{i - row * mat_S};
+
+  matrix[i] = (row == col) ? static_cast<real_t>(1) : static_cast<real_t>(0);
+}
+
+} // namespace
+
+real_t SlaterPlaneWave::cudaLogAbsDet(const Particles& particles) {
+  AlignedSoA<real_t> log_abs_det{1, 1};
+
+  const int N{static_cast<int>(particles.size())};
+  const int mat_S{static_cast<int>(this->matrix_row_stride())};
+
+  cusolverDnHandle_t cusolver_handle{};
+  CUSOLVER_CHECK(cusolverDnCreate(&cusolver_handle));
+
+  int work_size{};
+  cuSolverGetrfBufferSize(
+    cusolver_handle,
+    N, N,
+    this->lower_upper(), mat_S,
+    &work_size
+  );
+
+  AlignedSoA<real_t> work{static_cast<std::size_t>(work_size), 1};
+  AlignedSoA<int> info{1, 1};
+
+  dim3 buildTrigCacheThreads(16, 16);
+  dim3 buildTrigCacheBlocks(
+    vmc::cudaNumBlocks(num_unique_k(), buildTrigCacheThreads.x),
+    vmc::cudaNumBlocks(particles.size(), buildTrigCacheThreads.y)
+  );
+  cudaBuildTrigCache<<<buildTrigCacheBlocks, buildTrigCacheThreads>>>(
+    particles.size(), this->trig_row_stride(), this->num_unique_k(),
+    particles.pos().x_, particles.pos().y_, particles.pos().z_,
+    this->k_vector().x_, this->k_vector().y_, this->k_vector().z_,
+    this->sin_cache(), this->cos_cache()
+  );
+  CUDA_CHECK(cudaGetLastError());
+
+  dim3 buildDetFromCacheThreads(16, 16);
+  dim3 buildDetFromCacheBlocks(
+    vmc::cudaNumBlocks(particles.size(), buildDetFromCacheThreads.x),
+    vmc::cudaNumBlocks(particles.size(), buildDetFromCacheThreads.y)
+  );
+  cudaBuildDetFromCache<<<buildDetFromCacheBlocks, buildDetFromCacheThreads>>>(
+    particles.size(),
+    this->trig_row_stride(), this->matrix_row_stride(),
+    this->sin_cache(), this->cos_cache(),
+    this->orbital_k_index(), this->orbital_type(),
+    this->determinant()
+  );
+  CUDA_CHECK(cudaGetLastError());
+
+  CUDA_CHECK(cudaMemcpyAsync(
+    this->lower_upper(),
+    this->determinant(),
+    this->matrix_row_stride() *
+    particles.size()          *
+    sizeof(real_t),
+    cudaMemcpyDeviceToDevice
+  ));
+
+  cusolverGetrf(
+    cusolver_handle,
+    N, N,
+    this->lower_upper(), mat_S,
+    work[0], this->pivot(), info[0]
+  );
+
+  CUDA_CHECK(cudaDeviceSynchronize());
+  checkCusolverInfo(*info[0], "getrf");
+  if (*info[0] > 0) {
+    CUSOLVER_CHECK(cusolverDnDestroy(cusolver_handle));
+    return -std::numeric_limits<real_t>::infinity();
+  }
+
+  dim3 computeLogAbsDetThreads(256);
+  dim3 computeLogAbsDetBlocks(
+    vmc::cudaNumBlocks(particles.size(), computeLogAbsDetThreads.x)
+  );
+  cudaComputeLogAbsDet<<<computeLogAbsDetBlocks, computeLogAbsDetThreads>>>(
+    particles.size(), this->matrix_row_stride(),
+    this->lower_upper(),
+    log_abs_det[0]
+  );
+  CUDA_CHECK(cudaGetLastError());
+
+  dim3 buildIdentityThreads(256);
+  dim3 buildIdentityBlocks(
+    vmc::cudaNumBlocks(
+      particles.size() * this->matrix_row_stride(),
+      buildIdentityThreads.x
+    )
+  );
+  cudaBuildIdentity<<<buildIdentityBlocks, buildIdentityThreads>>>(
+    particles.size(),
+    this->matrix_row_stride(),
+    this->inv_determinant()
+  );
+  CUDA_CHECK(cudaGetLastError());
+
+  cusolverGetrs(
+    cusolver_handle,
+    CUBLAS_OP_T,
+    N, N,
+    this->lower_upper(), mat_S,
+    this->pivot(),
+    this->inv_determinant(), mat_S,
+    info[0]
+  );
+
+  CUDA_CHECK(cudaDeviceSynchronize());
+  checkCusolverInfo(*info[0], "getrs");
+  CUSOLVER_CHECK(cusolverDnDestroy(cusolver_handle));
+
+  if (!std::isfinite(*log_abs_det[0])) {
+    return -std::numeric_limits<real_t>::infinity();
+  }
+
+  return *log_abs_det[0];
+}
+
+#endif

--- a/src/slater_plane_wave/slater_plane_wave.cu
+++ b/src/slater_plane_wave/slater_plane_wave.cu
@@ -54,7 +54,7 @@ SlaterPlaneWave::SlaterPlaneWave(const Particles& particles, real_t box_lengthL)
   };
 
   // Increase vector size to be safe
-  const int N_MAX{static_cast<int>(std::ceil(std::cbrt(static_cast<real_t>(N)))) + 2};
+  const int N_MAX{static_cast<int>(vmc::ceil(vmc::cbrt(static_cast<real_t>(N)))) + 2};
   const std::size_t side{static_cast<std::size_t>((2 * N_MAX + 1))};
 
   // Vector for all possible n-vector candidates
@@ -189,7 +189,7 @@ void SlaterPlaneWave::update_trig_cache(std::size_t particle, const Particles& p
   }
 }
 
-real_t SlaterPlaneWave::log_abs_det(const Particles& particles) {
+real_t SlaterPlaneWave::cpu_log_abs_det(const Particles& particles) {
   const std::size_t N{num_orbitals()};
   const std::size_t S{matrix_row_stride()};
   const std::size_t padded_N{particles.p_stride()};

--- a/src/slater_plane_wave/slater_plane_wave.cuh
+++ b/src/slater_plane_wave/slater_plane_wave.cuh
@@ -105,7 +105,15 @@ public:
   #if defined(__CUDACC__)
   real_t cudaLogAbsDet(const Particles& particles);
   #endif
-  real_t log_abs_det(const Particles& particles);
+  real_t cpu_log_abs_det(const Particles& particles);
+
+  real_t log_abs_det(const Particles& particles) {
+  #if defined(__CUDACC__)
+    return cudaLogAbsDet(particles);
+  #else
+    return cpu_log_abs_det(particles);
+  #endif
+  }
 
   real_t* build_row(std::size_t particle) noexcept;
 

--- a/src/utilities/aligned_soa.cuh
+++ b/src/utilities/aligned_soa.cuh
@@ -8,11 +8,7 @@
 #include <memory>
 #include <new>
 
-#if defined(_WIN32)
-#include <malloc.h>
-#endif
-
-inline void* aligned_alloc_backend(std::size_t alignment, std::size_t size) {
+inline void* backend_alloc(std::size_t alignment, std::size_t size) {
 #if defined(__CUDACC__)
   static_cast<void>(alignment);
 
@@ -20,7 +16,7 @@ inline void* aligned_alloc_backend(std::size_t alignment, std::size_t size) {
   CUDA_CHECK(cudaMallocManaged(&ptr, size));
 
   return ptr;
-#elif defined(_WIN32)
+#elif defined(_MSC_VER)
   return _aligned_malloc(size, alignment);
 #elif defined(__APPLE__) || defined(__GNUC__) || defined(__clang__)
   void* ptr{};
@@ -34,62 +30,81 @@ inline void* aligned_alloc_backend(std::size_t alignment, std::size_t size) {
 #endif
 }
 
-inline void aligned_free_backend(void* ptr) {
+inline void backend_free(void* ptr) {
 #if defined(__CUDACC__)
   cudaFree(ptr);
-#elif defined(_WIN32)
+#elif defined(_MSC_VER)
   _aligned_free(ptr);
 #else
   std::free(ptr);
 #endif
 }
 
-struct AlignedDeleter {
+struct SoADeleter {
   template <typename T>
   void operator()(T* ptr) const {
-    aligned_free_backend(ptr);
+    backend_free(ptr);
   }
 };
 
-template <arithmetic T> class AlignedSoA {
+template <arithmetic T>
+class AlignedSoA {
 private:
   static constexpr std::size_t elements_per_align_{SIMD_BYTES / sizeof(T)};
-  std::size_t num_elements_{};
-  std::size_t stride_length_{};
-  std::unique_ptr<T[], AlignedDeleter> memory_block_;
+  std::size_t num_elements_;
+  std::size_t stride_length_;
+  std::unique_ptr<T[], SoADeleter> data_;
 
 public:
-  AlignedSoA() = default;
+  AlignedSoA() : num_elements_{}, stride_length_{}, data_{} {}
   AlignedSoA(AlignedSoA&&) noexcept = default;
   AlignedSoA& operator=(AlignedSoA&&) noexcept = default;
 
   AlignedSoA(std::size_t num_elements, std::size_t num_arrays)
   : num_elements_{num_elements}
-  , stride_length_{round_up(num_elements)}
-  {
+  , stride_length_{round_up(num_elements)} {
+    #if defined(__CUDACC__)
+      stride_length_ = num_elements;
+    #endif
     const std::size_t total_elements{num_arrays * stride_length_};
     const std::size_t total_bytes{total_elements * sizeof(T)};
 
-    T* ptr{static_cast<T*>(aligned_alloc_backend(SIMD_BYTES, total_bytes))};
-    if (!ptr) {
-      throw std::bad_alloc();
-    }
+    T* ptr{static_cast<T*>(backend_alloc(SIMD_BYTES, total_bytes))};
+    if (!ptr) { throw std::bad_alloc(); }
+
+    // For once cudaMalloc is used:
+    // #if defined(__CUDACC__)
+    //   CUDA_CHECK(cudaMemset(ptr, 0, total_bytes));
+    // #else
+    //   std::fill_n(ptr, total_elements, T{});
+    // #endif
 
     std::fill_n(ptr, total_elements, T{});
-    memory_block_.reset(ptr);
+    data_.reset(ptr);
   }
 
-  [[nodiscard]] std::size_t stride() const { return stride_length_; }
-  [[nodiscard]] std::size_t num_elements() const { return num_elements_; }
-
-  [[nodiscard]] T* operator[](std::size_t array_index) {
-    return memory_block_.get() + array_index * stride();
-  }
-  [[nodiscard]] const T* operator[](std::size_t array_index) const {
-    return memory_block_.get() + array_index * stride();
+  [[nodiscard]] std::size_t num_elements() const {
+    return num_elements_;
   }
 
-  [[nodiscard]] static constexpr std::size_t round_up(std::size_t unpadded) {
-    return (unpadded + elements_per_align_ - 1) & ~(elements_per_align_ - 1);
+  [[nodiscard]]
+  std::size_t stride() const {
+    return stride_length_;
+  }
+
+  [[nodiscard]]
+  T* operator[](std::size_t array_index) {
+    return data_.get() + array_index * stride();
+  }
+
+  [[nodiscard]]
+  const T* operator[](std::size_t array_index) const {
+    return data_.get() + array_index * stride();
+  }
+
+  [[nodiscard]]
+  static constexpr std::size_t round_up(std::size_t unpadded) {
+    return (unpadded + elements_per_align_ - 1) & 
+          ~(elements_per_align_ - 1);
   }
 };

--- a/src/utilities/macros.cuh
+++ b/src/utilities/macros.cuh
@@ -32,6 +32,8 @@ using complex_t = std::complex<real_t>;
 #include <cstdio>
 #include <cstdlib>
 #include <cuda_runtime.h>
+#include <cusolverDn.h>
+
 #define CUDA_CHECK(call) \
   do { \
     cudaError_t cuda_check_result_{(call)}; \
@@ -42,6 +44,21 @@ using complex_t = std::complex<real_t>;
         __FILE__, \
         __LINE__, \
         cudaGetErrorString(cuda_check_result_) \
+      ); \
+      std::abort(); \
+    } \
+  } while (0)
+
+#define CUSOLVER_CHECK(call) \
+  do { \
+    cusolverStatus_t cusolver_check_result_{(call)}; \
+    if (cusolver_check_result_ != CUSOLVER_STATUS_SUCCESS) { \
+      std::fprintf( \
+        stderr, \
+        "cuSOLVER error at %s:%d: %d\n", \
+        __FILE__, \
+        __LINE__, \
+        static_cast<int>(cusolver_check_result_) \
       ); \
       std::abort(); \
     } \

--- a/src/utilities/math.cuh
+++ b/src/utilities/math.cuh
@@ -9,7 +9,7 @@
 namespace vmc {
 
 CUDA_CALLABLE
-inline void sincos(real_t theta, real_t* s, real_t* c) {
+inline void sincos(real_t theta, real_t* s, real_t* c) noexcept {
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     ::sincos(theta, s, c);
@@ -37,7 +37,7 @@ inline void sincos(real_t theta, real_t* s, real_t* c) {
 }
 
 CUDA_CALLABLE [[nodiscard]]
-inline real_t sqrt(real_t arg) {
+inline real_t sqrt(real_t arg) noexcept {
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::sqrt(arg);
@@ -52,7 +52,7 @@ inline real_t sqrt(real_t arg) {
 }
 
 CUDA_CALLABLE [[nodiscard]]
-inline real_t exp(real_t arg) {
+inline real_t exp(real_t arg) noexcept {
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::exp(arg);
@@ -67,7 +67,7 @@ inline real_t exp(real_t arg) {
 }
 
 CUDA_CALLABLE [[nodiscard]]
-inline real_t pow(real_t arg, real_t power) {
+inline real_t pow(real_t arg, real_t power) noexcept {
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::pow(arg, power);
@@ -82,7 +82,7 @@ inline real_t pow(real_t arg, real_t power) {
 }
 
 CUDA_CALLABLE [[nodiscard]]
-inline real_t cbrt(real_t arg) {
+inline real_t cbrt(real_t arg) noexcept {
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::cbrt(arg);
@@ -97,7 +97,7 @@ inline real_t cbrt(real_t arg) {
 }
 
 CUDA_CALLABLE [[nodiscard]]
-inline real_t log(real_t arg) {
+inline real_t log(real_t arg) noexcept {
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::log(arg);
@@ -112,7 +112,7 @@ inline real_t log(real_t arg) {
 }
 
 CUDA_CALLABLE [[nodiscard]]
-inline real_t abs(real_t arg) {
+inline real_t abs(real_t arg) noexcept {
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return fabs(arg);
@@ -125,7 +125,7 @@ inline real_t abs(real_t arg) {
 }
 
 CUDA_CALLABLE [[nodiscard]]
-inline real_t floor(real_t arg) {
+inline real_t floor(real_t arg) noexcept {
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::floor(arg);
@@ -138,7 +138,7 @@ inline real_t floor(real_t arg) {
 }
 
 CUDA_CALLABLE [[nodiscard]]
-inline real_t ceil(real_t arg) {
+inline real_t ceil(real_t arg) noexcept {
 #if defined(__CUDACC__) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::ceil(arg);
@@ -148,6 +148,11 @@ inline real_t ceil(real_t arg) {
 #else
   return std::ceil(arg);
 #endif
+}
+
+CUDA_CALLABLE [[nodiscard]]
+inline unsigned int cudaNumBlocks(std::size_t size, unsigned int threads) noexcept {
+  return static_cast<unsigned int>((size + threads - 1)) / threads;
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Fixes: #46

Adds the CUDA backend for `log_abs_det`: the determinant matrix is built, factorized (cuSOLVER getrf), and inverted (getrs) entirely on device. `log_abs_det` picks the backend at compile time via `__CUDACC__`; the CPU version is now `cpu_log_abs_det`.

## Changes

- `slater_kernels.cu` (new): build/log-det/identity kernels plus `cudaLogAbsDet`, with fp64/fp32 cuSOLVER wrappers
- `slater_plane_wave.cuh/.cu`: backend dispatch, CPU path renamed
- `aligned_soa.cuh`: CUDA path drops SIMD stride padding, it's wasted memory on GPU
- `macros.cuh` / `math.cuh`: `CUSOLVER_CHECK`, `cudaNumBlocks`, `noexcept` on math wrappers
- `CMakeLists.txt`: adds the new file, links cudart/cusolver/cublas

## Notes

- Buffers are row-major and cuSOLVER is column-major, so we factor D^T and solve with `CUBLAS_OP_T`. The inverse lands in the same transposed layout the CPU backend stores.
- All managed allocations happen before the first kernel launch. Windows kills the process if the host touches managed memory while a kernel is running.

## Testing

- Standalone parity harness vs CPU backend: fp64 agrees to ~1e-15, fp32 to ~1 ULP
- Full suite: 95/95 in both fp64 and fp32 (CUDA-enabled build)
- N=512 rebuild is ~9-13x faster on GPU; ~3.8 ms/call is handle create/destroy overhead

## Follow-ups

- Cache the cuSOLVER handle and scratch buffers across calls
- In-repo CUDA parity test once CUDA test builds are decided
