### PR TITLE
Refactor CUDA architecture and control flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ endif()
 set(VMC_CUDA_SOURCES
   src/jastrow_pade/jastrow_pade.cu
   src/wavefunction/wavefunction.cu
-  src/slater_plane_wave/slater_kernels.cu
+  src/slater_plane_wave/log_abs_det.cu
   src/slater_plane_wave/slater_plane_wave.cu
   src/simulation/simulation.cu
   src/energy_tracking/energy_tracking.cu

--- a/scripts/build-fast.sh
+++ b/scripts/build-fast.sh
@@ -33,7 +33,7 @@ case "$(uname -s)" in
     exit 1
     ;;
   *)
-    cmake -S . -B build -DFP_64=$FP64_FLAG -DVMC_FAST_MATH=$FAST_MATH_FLAG -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
+    cmake -S . -B build -DVMC_ENABLE_CUDA=OFF -DFP_64=$FP64_FLAG -DVMC_FAST_MATH=$FAST_MATH_FLAG -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release
     cmake --build build --target vmc
     ;;
 esac

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -13,5 +13,5 @@ if (-not (Test-Path $vcvars)) {
 $fp64Flag = if ($Fp32 -or ${Vmc-fast-math}) { "OFF" } else { "ON" }
 $fastMathFlag = if (${Vmc-fast-math}) { "ON" } else { "OFF" }
 
-cmd /c "`"$vcvars`" && cmake -S . -B build-tests -G Ninja -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=$BuildType -DFP_64=$fp64Flag -DVMC_FAST_MATH=$fastMathFlag -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && cmake --build build-tests --target vmc_tests && ctest --test-dir build-tests --output-on-failure"
+cmd /c "`"$vcvars`" && cmake -S . -B build-tests -G Ninja -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=$BuildType -DVMC_ENABLE_CUDA=OFF -DFP_64=$fp64Flag -DVMC_FAST_MATH=$fastMathFlag -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && cmake --build build-tests --target vmc_tests && ctest --test-dir build-tests --output-on-failure"
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -39,7 +39,7 @@ case "$(uname -s)" in
     ;;
   *)
     cmake -S . -B build-tests -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE="$BUILD_TYPE" \
-          -DFP_64=$FP64_FLAG -DVMC_FAST_MATH=$FAST_MATH_FLAG -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          -DVMC_ENABLE_CUDA=OFF -DFP_64=$FP64_FLAG -DVMC_FAST_MATH=$FAST_MATH_FLAG -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     cmake --build build-tests --target vmc_tests
     ctest --test-dir build-tests --output-on-failure
     ;;

--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -101,20 +101,13 @@ void EnergyTracker::initialize_real_energy(const Particles& particles) noexcept 
   const real_t neg_half_L{-1.0_r * half_L};
   const real_t alpha{ewald_alpha_};
 
-  // Fast erfc constants
-  const real_t p{0.3275911_r};
-  const real_t a1{0.254829592_r};
-  const real_t a2{-0.284496736_r};
-  const real_t a3{1.421413741_r};
-  const real_t a4{-1.453152027_r};
-  const real_t a5{1.061405429_r};
-
   const auto pos{particles.pos().align()};
 
   real_t sum{};
   for (std::size_t i = 0; i < N; ++i) {
     real_t local_sum{};
 
+    // Not vectorzied: loop contains a mathematical function
     #pragma omp simd reduction(+ : local_sum)
     for (std::size_t j = i + 1; j < N; ++j) {
       real_t dx{pos.x_[i] - pos.x_[j]};
@@ -133,23 +126,7 @@ void EnergyTracker::initialize_real_energy(const Particles& particles) noexcept 
         )
       };
       const real_t inv_r{(r < 1e-12_r) ? 1.0_r : 1.0_r / r};
-
-      // Abramowitz & Stegun formula for fast std::erfc approx.
-      const real_t erfc_arg{alpha * r};
-      const real_t t{1.0_r / (1.0_r + p * erfc_arg)};
-      const real_t tau{
-        t * (
-          a1 + t * (
-            a2 + t * (
-              a3 + t * (
-                a4 + t * a5
-              )
-            )
-          )
-        )
-      };
-
-      local_sum += tau * vmc::exp(-erfc_arg * erfc_arg) * inv_r;
+      local_sum += vmc::erfc(alpha * r) * inv_r;
     }
     sum += local_sum;
   }
@@ -173,6 +150,7 @@ void EnergyTracker::initialize_structure_factors(const Particles& particles) noe
     real_t cos_sum{};
     real_t sin_sum{};
 
+    // Not vectorzied: loop contains a mathematical function
     #pragma omp simd reduction(+ : cos_sum, sin_sum)
     for (std::size_t j = 0; j < N; ++j) {
       const real_t G_dot_r{
@@ -224,6 +202,7 @@ void EnergyTracker::update_structure_factors(
 
   real_t delta{};
 
+  // Not vectorzied: loop contains a mathematical function
   #pragma omp simd
   for (std::size_t g = 0; g < num_G; ++g) {
     const real_t old_dot{
@@ -300,16 +279,7 @@ void EnergyTracker::update_real_energy(
   const real_t neg_L{-1.0_r * L};
   const real_t half_L{0.5_r * L};
   const real_t neg_half_L{-1.0_r * half_L};
-
   const real_t alpha{ewald_alpha_};
-
-  // Fast erfc constants
-  const real_t p{0.3275911_r};
-  const real_t a1{0.254829592_r};
-  const real_t a2{-0.284496736_r};
-  const real_t a3{1.421413741_r};
-  const real_t a4{-1.453152027_r};
-  const real_t a5{1.061405429_r};
 
   const auto pos{particles.pos().align()};
 
@@ -319,6 +289,7 @@ void EnergyTracker::update_real_energy(
 
   real_t delta{};
 
+  // Not vectorzied: loop contains a mathematical function
   #pragma omp simd reduction(+ : delta)
   for (std::size_t j = 0; j < N; ++j) {
     // Branchless mask to safely skip the moved particle
@@ -340,26 +311,9 @@ void EnergyTracker::update_real_energy(
         dz_old * dz_old
       )
     };
-
     // Protect against 1.0 / 0.0 generating NaN
     const real_t inv_r_old{(r_old < 1e-12_r) ? 1.0_r : 1.0_r / r_old};
-
-    // Abramowitz & Stegun formula for fast std::erfc approx.
-    const real_t erfc_arg_old{alpha * r_old};
-    const real_t t_old{1.0_r / (1.0_r + p * erfc_arg_old)};
-    const real_t tau_old{
-      t_old * (
-        a1 + t_old * (
-          a2 + t_old * (
-            a3 + t_old * (
-              a4 + t_old * a5
-            )
-          )
-        )
-      )
-    };
-
-    real_t const erfc_old{tau_old * vmc::exp(-erfc_arg_old * erfc_arg_old) * inv_r_old};
+    const real_t erfc_old{vmc::erfc(alpha * r_old) * inv_r_old};
 
     // New pair
     real_t dx_new{new_x - pos.x_[j]};
@@ -380,25 +334,7 @@ void EnergyTracker::update_real_energy(
 
     // Protect against 1.0 / 0.0 generating NaN
     const real_t inv_r_new{(r_new < 1e-12_r) ? 1.0_r : 1.0_r / r_new};
-
-    // Combine operations and apply the mask
-
-    // Abramowitz & Stegun formula for fast std::erfc approx.
-    const real_t erfc_arg_new{alpha * r_new};
-    const real_t t_new{1.0_r / (1.0_r + p * erfc_arg_new)};
-    const real_t tau_new{
-      t_new * (
-        a1 + t_new * (
-          a2 + t_new * (
-            a3 + t_new * (
-              a4 + t_new * a5
-            )
-          )
-        )
-      )
-    };
-
-    real_t const erfc_new{tau_new * vmc::exp(-erfc_arg_new * erfc_arg_new) * inv_r_new};
+    const real_t erfc_new{vmc::erfc(alpha * r_new) * inv_r_new};
 
     delta += valid_mask * (erfc_new - erfc_old);
   }

--- a/src/jastrow_pade/jastrow_pade.cu
+++ b/src/jastrow_pade/jastrow_pade.cu
@@ -19,6 +19,7 @@ real_t JastrowPade::value(const Particles& particles) const noexcept {
   for (std::size_t i = 0; i < num_particles; ++i) {
     real_t local_jastrow{};
 
+    // Not vectorized: loop contains control flow
     #pragma omp simd reduction(+ : local_jastrow)
     for (std::size_t j = 0; j < num_particles; ++j) {
       const real_t mask{i == j ? 0.0_r : 1.0_r};
@@ -75,6 +76,7 @@ void JastrowPade::add_derivatives(
   for (std::size_t i = 0; i < num_particles; ++i) {
     real_t d_grad_x{}, d_grad_y{}, d_grad_z{}, d_lap{};
 
+    // Not vectorized: loop contains control flow
     #pragma omp simd reduction(+ : d_grad_x, d_grad_y, d_grad_z, d_lap)
     for (std::size_t j = 0; j < num_particles; ++j) {
       const real_t valid_idx{i == j ? 0.0_r : 1.0_r};
@@ -146,6 +148,7 @@ real_t JastrowPade::delta_value(
 
   real_t delta{};
 
+  // Not vectorized: loop contains control flow
   #pragma omp simd reduction(+ : delta)
   for (std::size_t j = 0; j < num_particles; ++j) {
     const real_t valid_mask{(j == moved) ? 0.0_r : 1.0_r};
@@ -230,6 +233,7 @@ void JastrowPade::update_derivatives_for_move(
 
   real_t m_grad_x{}, m_grad_y{}, m_grad_z{}, m_lap{};
 
+  // Not vectorized: loop contains control flow
   #pragma omp simd reduction(+ : m_grad_x, m_grad_y, m_grad_z, m_lap)
   for (std::size_t j = 0; j < num_particles; ++j) {
     const bool is_moved{j == moved};

--- a/src/slater_plane_wave/log_abs_det.cu
+++ b/src/slater_plane_wave/log_abs_det.cu
@@ -2,7 +2,6 @@
 
 #if defined(__CUDACC__)
 #include <cublas_v2.h>
-
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -164,8 +163,23 @@ void cudaBuildIdentity(
 }
 
 } // namespace
+#else
+#include "slater_plane_wave.cuh"
+#include "../utilities/matrix.hpp"
+#include "particles/particles.cuh"
+#include "utilities/aligned_soa.cuh"
 
-real_t SlaterPlaneWave::cudaLogAbsDet(const Particles& particles) {
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstring>
+#include <limits>
+#include <vector>
+#endif
+
+
+real_t SlaterPlaneWave::log_abs_det(const Particles& particles) {
+#if defined(__CUDACC__)
   AlignedSoA<real_t> log_abs_det{1, 1};
 
   const int N{static_cast<int>(particles.size())};
@@ -279,6 +293,97 @@ real_t SlaterPlaneWave::cudaLogAbsDet(const Particles& particles) {
   }
 
   return *log_abs_det[0];
-}
+#else
+  const std::size_t N{this->num_orbitals()};
+  const std::size_t S{this->matrix_row_stride()};
+  const std::size_t padded_N{particles.p_stride()};
 
+  const auto pos{particles.pos().align()};
+  const auto kv{this->k_vector().align()};
+
+  const auto* k_index{this->orbital_k_index()};
+  const auto* orb_type{this->orbital_type()};
+
+  real_t* RESTRICT det_matrix{this->determinant()}; ASSUME_ALIGNED(det_matrix, SIMD_BYTES);
+  real_t* RESTRICT lower_upper_matrix{this->lower_upper()}; ASSUME_ALIGNED(lower_upper_matrix, SIMD_BYTES);
+  real_t* RESTRICT inv_det_matrix{this->inv_determinant()}; ASSUME_ALIGNED(inv_det_matrix, SIMD_BYTES);
+
+  int* RESTRICT pivot_vector{this->pivot()}; ASSUME_ALIGNED(pivot_vector, SIMD_BYTES);
+
+  real_t* RESTRICT rhs{this->rhs()}; ASSUME_ALIGNED(rhs, SIMD_BYTES);
+  real_t* RESTRICT solution{this->solution()}; ASSUME_ALIGNED(solution, SIMD_BYTES);
+
+  const std::size_t num_k{this->num_unique_k()};
+  real_t* RESTRICT cos_cache{this->cos_cache()}; ASSUME_ALIGNED(cos_cache, SIMD_BYTES);
+  real_t* RESTRICT sin_cache{this->sin_cache()}; ASSUME_ALIGNED(sin_cache, SIMD_BYTES);
+
+  const std::size_t ROW_STRIDE{this->trig_row_stride()};
+  for (std::size_t particle = 0; particle < N; ++particle) {
+    const std::size_t offset{particle * ROW_STRIDE};
+    const real_t px{pos.x_[particle]};
+    const real_t py{pos.y_[particle]};
+    const real_t pz{pos.z_[particle]};
+
+    // Not vectorized: data dependency
+    #pragma omp simd
+    for (std::size_t k = 0; k < num_k; ++k) {
+      const real_t dot{
+        kv.x_[k] * px +
+        kv.y_[k] * py +
+        kv.z_[k] * pz
+      };
+      const std::size_t i{offset + k};
+
+      vmc::sincos(dot, &sin_cache[i], &cos_cache[i]);
+    }
+
+    // Not vectorized: non-contiguous memory accesses
+    #pragma omp simd
+    for (std::size_t orbital = 0; orbital < N; ++orbital) {
+      const std::size_t k_idx{k_index[orbital]};
+      const std::size_t trig_idx{offset + k_idx};
+      const std::size_t mat_idx{particle * S + orbital};
+      
+      const real_t type{static_cast<real_t>(orb_type[orbital])};
+      const real_t cos_term{cos_cache[trig_idx]};
+      const real_t sin_term{sin_cache[trig_idx]};
+
+      det_matrix[mat_idx] = cos_term + type * (sin_term - cos_term);
+    }
+  }
+
+  std::copy_n(det_matrix, S * N, lower_upper_matrix);
+
+  static_cast<void>(
+    lower_upper_decomp(lower_upper_matrix, pivot_vector, N, S)
+  );
+
+  real_t log_abs_det{};
+
+  // Not vectorzied: loop-carried data dependency
+  #pragma omp simd reduction(+ : log_abs_det)
+  for (std::size_t diag = 0; diag < N; ++diag) {
+    const real_t U_ii{lower_upper_matrix[diag * S + diag]};
+    const real_t abs_U_ii{vmc::abs(U_ii)};
+
+    log_abs_det += vmc::log(abs_U_ii);
+  }
+
+  if (!std::isfinite(log_abs_det)) {
+    return -std::numeric_limits<real_t>::infinity();
+  }
+
+  for (std::size_t column = 0; column < N; ++column) {
+    std::fill(rhs, rhs + padded_N, 0.0_r);
+    rhs[column] = 1.0_r;
+
+    solve_lower_upper(lower_upper_matrix, pivot_vector, rhs, solution, N, S);
+
+    for (std::size_t row = 0; row < N; ++row) {
+      inv_det_matrix[column * S + row] = solution[row];
+    }
+  }
+
+  return log_abs_det;
 #endif
+}

--- a/src/slater_plane_wave/slater_plane_wave.cu
+++ b/src/slater_plane_wave/slater_plane_wave.cu
@@ -177,6 +177,7 @@ void SlaterPlaneWave::update_trig_cache(std::size_t particle, const Particles& p
   ASSUME_ALIGNED(c_row, SIMD_BYTES);
   ASSUME_ALIGNED(s_row, SIMD_BYTES);
 
+  // Not vectorized: loop-carried data dependency
   #pragma omp simd
   for (std::size_t k = 0; k < num_k; ++k) {
     const real_t dot{
@@ -187,112 +188,6 @@ void SlaterPlaneWave::update_trig_cache(std::size_t particle, const Particles& p
 
     vmc::sincos(dot, &s_row[k], &c_row[k]);
   }
-}
-
-real_t SlaterPlaneWave::cpu_log_abs_det(const Particles& particles) {
-  const std::size_t N{num_orbitals()};
-  const std::size_t S{matrix_row_stride()};
-  const std::size_t padded_N{particles.p_stride()};
-
-  const auto pos{particles.pos().align()};
-  const auto kv{k_vector().align()};
-
-  const auto& k_index{orbital_k_index()};
-  const auto& orb_type{orbital_type()};
-
-  real_t* RESTRICT det_matrix{determinant()};
-  real_t* RESTRICT lower_upper_matrix{lower_upper()};
-  real_t* RESTRICT inv_det_matrix{inv_determinant()};
-
-  int* RESTRICT pivot_vector{pivot()};
-
-  real_t* RESTRICT rhs{this->rhs()};
-  real_t* RESTRICT solution{this->solution()};
-
-  const std::size_t num_k{num_unique_k()};
-  real_t* RESTRICT cos_cache{this->cos_cache()};
-  real_t* RESTRICT sin_cache{this->sin_cache()};
-
-  ASSUME_ALIGNED(det_matrix, SIMD_BYTES);
-  ASSUME_ALIGNED(lower_upper_matrix, SIMD_BYTES);
-  ASSUME_ALIGNED(inv_det_matrix, SIMD_BYTES);
-
-  ASSUME_ALIGNED(pivot_vector, SIMD_BYTES);
-
-  ASSUME_ALIGNED(rhs, SIMD_BYTES);
-  ASSUME_ALIGNED(solution, SIMD_BYTES);
-
-  ASSUME_ALIGNED(cos_cache, SIMD_BYTES);
-  ASSUME_ALIGNED(sin_cache, SIMD_BYTES);
-
-  // Build determinant matrix D
-  const std::size_t ROW_STRIDE{trig_row_stride()};
-  for (std::size_t particle = 0; particle < N; ++particle) {
-    const std::size_t offset{particle * ROW_STRIDE};
-
-    #pragma omp simd
-    for (std::size_t k = 0; k < num_k; ++k) {
-      const real_t dot{
-        kv.x_[k] * pos.x_[particle] +
-        kv.y_[k] * pos.y_[particle] +
-        kv.z_[k] * pos.z_[particle]
-      };
-      const std::size_t i{offset + k};
-
-      vmc::sincos(dot, &sin_cache[i], &cos_cache[i]);
-    }
-
-    // Build D from cache
-    #pragma omp simd
-    for (std::size_t orbital = 0; orbital < N; ++orbital) {
-      const std::size_t k_idx{k_index[orbital]};
-
-      const real_t type{static_cast<real_t>(orb_type[orbital])};
-      const real_t cos_term{cos_cache[offset + k_idx]};
-      const real_t sin_term{sin_cache[offset + k_idx]};
-
-      det_matrix[particle * S + orbital] = cos_term + type * (sin_term - cos_term);
-    }
-  }
-
-  // Copy determinant matrix into LU storage
-  std::copy_n(det_matrix, S * N, lower_upper_matrix);
-
-  // Perform LU decomposition
-  static_cast<void>(
-    lower_upper_decomp(lower_upper_matrix, pivot_vector, N, S)
-  );
-
-  // Compute log|det(D)| = Σ log|U_ii|
-  real_t log_abs_det{};
-
-  #pragma omp simd reduction(+ : log_abs_det)
-  for (std::size_t diag = 0; diag < N; ++diag) {
-    const real_t U_ii{lower_upper_matrix[diag * S + diag]};
-    const real_t abs_U_ii{vmc::abs(U_ii)};
-
-    log_abs_det += vmc::log(abs_U_ii);
-  }
-
-  if (!std::isfinite(log_abs_det)) {
-    return -std::numeric_limits<real_t>::infinity();
-  }
-
-  for (std::size_t column = 0; column < N; ++column) {
-    // Using pointer arithmetic to start at rhs[start]
-    // and jump to rhs[end] - used padded_N since
-    // SIMD alignment might mess up pointer math
-    std::fill(rhs, rhs + padded_N, 0.0_r);
-    rhs[column] = 1.0_r;
-
-    solve_lower_upper(lower_upper_matrix, pivot_vector, rhs, solution, N, S);
-
-    for (std::size_t row = 0; row < N; ++row) {
-      inv_det_matrix[column * S + row] = solution[row];
-    }
-  }
-
-  return log_abs_det;
 }
 
 real_t* SlaterPlaneWave::build_row(std::size_t particle) noexcept {
@@ -310,6 +205,7 @@ real_t* SlaterPlaneWave::build_row(std::size_t particle) noexcept {
   ASSUME_ALIGNED(sin_cache, SIMD_BYTES);
   ASSUME_ALIGNED(cos_cache, SIMD_BYTES);
 
+  // Not vectorized: loop-carried data dependency
   #pragma omp simd
   for (std::size_t orbital = 0; orbital < N; ++orbital) {
     const std::size_t k_idx{k_index[orbital]};
@@ -368,10 +264,7 @@ void SlaterPlaneWave::accept_move(
   const std::size_t p_offset{particle * S}; // Pre-calculate particle row offset
 
   // Cache particle row column j for inv_D before changing
-  #pragma omp simd
-  for (std::size_t j = 0; j < N; ++j) {
-    inv_d_col[j] = inv_det[p_offset + j];
-  }
+  std::memcpy(inv_d_col, &inv_det[p_offset], N * sizeof(real_t));
 
   // Follows Sherman-Morrison update (branchless)
   for (std::size_t k = 0; k < N; ++k) {
@@ -390,6 +283,7 @@ void SlaterPlaneWave::accept_move(
 
     const real_t factor{s_k * inv_ratio};
 
+    // Not vectorized: loop-carried data dependency
     #pragma omp simd
     for (std::size_t j = 0; j < N; ++j) {
       inv_det[k_offset + j] -= inv_d_col[j] * factor;
@@ -403,10 +297,7 @@ void SlaterPlaneWave::accept_move(
   }
 
   // Patch row `particle` of D to match the new positions:
-  #pragma omp simd
-  for (std::size_t j = 0; j < N; ++j) {
-    det_matrix[p_offset + j] = new_row[j];
-  }
+  std::memcpy(&det_matrix[p_offset], new_row, N * sizeof(real_t));
 }
 
 void SlaterPlaneWave::add_derivatives(
@@ -444,6 +335,7 @@ void SlaterPlaneWave::add_derivatives(
     const std::size_t p_offset{particle * S};
 
     // Added reduction clauses so the compiler can safely vectorize the accumulators
+    // Not vectorized: loop-carried data dependency
     #pragma omp simd reduction(+ : d_log_det_dx, d_log_det_dy, d_log_det_dz, laplace_det_term)
     for (std::size_t orbital = 0; orbital < N; ++orbital) {
       const std::size_t k_idx{k_index[orbital]};

--- a/src/slater_plane_wave/slater_plane_wave.cuh
+++ b/src/slater_plane_wave/slater_plane_wave.cuh
@@ -99,21 +99,9 @@ public:
 
   void save_trig_row(std::size_t particle) noexcept;
   void restore_trig_row(std::size_t particle) noexcept;
-
   void update_trig_cache(std::size_t particle, const Particles& particles) noexcept;
 
-  #if defined(__CUDACC__)
-  real_t cudaLogAbsDet(const Particles& particles);
-  #endif
-  real_t cpu_log_abs_det(const Particles& particles);
-
-  real_t log_abs_det(const Particles& particles) {
-  #if defined(__CUDACC__)
-    return cudaLogAbsDet(particles);
-  #else
-    return cpu_log_abs_det(particles);
-  #endif
-  }
+  real_t log_abs_det(const Particles& particles);
 
   real_t* build_row(std::size_t particle) noexcept;
 

--- a/src/utilities/math.cuh
+++ b/src/utilities/math.cuh
@@ -155,4 +155,58 @@ inline unsigned int cudaNumBlocks(std::size_t size, unsigned int threads) noexce
   return static_cast<unsigned int>((size + threads - 1)) / threads;
 }
 
+CUDA_CALLABLE [[nodiscard]]
+inline real_t erfc(real_t arg) noexcept {
+#if defined(__CUDACC__) && defined(__CUDA_ARCH__)
+  #ifdef FP_64
+    return ::erfc(arg);
+  #elif defined(VMC_FAST_MATH)
+    const real_t t{1.0_r / (1.0_r + 0.3275911_r * arg)};
+    constexpr real_t p{0.3275911_r};
+    constexpr real_t a1{0.254829592_r};
+    constexpr real_t a2{-0.284496736_r};
+    constexpr real_t a3{1.421413741_r};
+    constexpr real_t a4{-1.453152027_r};
+    constexpr real_t a5{1.061405429_r};
+    const real_t poly{
+      t * (
+        a1 + t * (
+          a2 + t * (
+            a3 + t * (
+              a4 + t * a5
+            )
+          )
+        )
+      )
+    };
+    return poly * exp(-arg * arg);
+  #else
+    return erfcf(arg);
+  #endif
+#else
+  #if defined(VMC_FAST_MATH)
+    const real_t t{1.0_r / (1.0_r + 0.3275911_r * arg)};
+    constexpr real_t a1{0.254829592_r};
+    constexpr real_t a2{-0.284496736_r};
+    constexpr real_t a3{1.421413741_r};
+    constexpr real_t a4{-1.453152027_r};
+    constexpr real_t a5{1.061405429_r};
+    const real_t poly{
+      t * (
+        a1 + t * (
+          a2 + t * (
+            a3 + t * (
+              a4 + t * a5
+            )
+          )
+        )
+      )
+    };
+    return poly * exp(-arg * arg);
+  #else
+    return std::erfc(arg);
+  #endif
+#endif
+}
+
 } // namespace

--- a/src/utilities/matrix.hpp
+++ b/src/utilities/matrix.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "macros.cuh"
+#include "math.cuh"
 
 #include <cmath>
 #include <cstddef>


### PR DESCRIPTION
## Summary

Fixes: #68

Consolidates `log_abs_det` into a single translation unit. The CPU and CUDA implementations lived in three places (`slater_plane_wave.cu`, `slater_kernels.cu`, and a dispatch shim in the header); both now live in `src/slater_plane_wave/log_abs_det.cu` as one out-of-line `SlaterPlaneWave::log_abs_det` with the backend split via `__CUDACC__`. Also extracts the hand-inlined Abramowitz & Stegun erfc from energy_tracking into `vmc::erfc`.

## Changes

- `log_abs_det.cu` (new): both backends of `log_abs_det`; CUDA kernels and cuSOLVER wrappers moved from `slater_kernels.cu` into an anonymous namespace
- `slater_kernels.cu`: deleted
- `slater_plane_wave.cuh` / `.cu`: `cudaLogAbsDet` and `cpu_log_abs_det` removed, header dispatch gone, single declaration remains
- `math.cuh`: `vmc::erfc` with three-way dispatch: fp64 `::erfc`, fp32-accurate `erfcf`, A&S 7.1.26 under `VMC_FAST_MATH` (same constants energy_tracking used inline)
- `energy_tracking.cu`: both Ewald real-space paths call `vmc::erfc` instead of two inlined copies of the polynomial; `erfc(alpha * r) / r` and the divide-by-zero guard unchanged
- `jastrow_pade.cu` / `energy_tracking.cu`: comments recording which simd loops MSVC declines to vectorize and why (#61)
- `matrix.hpp`: includes `math.cuh`
- `CMakeLists.txt`: `slater_kernels.cu` replaced by `log_abs_det.cu`

## Notes

- Default builds now use libm `erfc` instead of the A&S approximation, so Ewald real-space is slightly more accurate; the approximation is opt-in via `VMC_FAST_MATH`, consistent with the rest of the math layer
- The A&S branch is valid for `arg >= 0` only, which holds for `erfc(alpha * r)`
- No behavior change in the CUDA path; kernels are as merged in #65. Handle caching stays tracked in #66

## Testing

- `.\scripts\test.ps1` (fp64): <results>
- `.\scripts\test.ps1 -Fp32`: <results>
- `.\scripts\test.ps1 -Fp32 -Vmc-fast-math`: <results>
- `.\scripts\profile.ps1` (MSVC host build): compiles clean; C5002 output matches the new loop comments
