### PR TITLE
Implement cudaUpdateTrigRow kernel for trig cache update/restore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ set(VMC_CUDA_SOURCES
   src/wavefunction/wavefunction.cu
   src/slater_plane_wave/log_abs_det.cu
   src/slater_plane_wave/slater_plane_wave.cu
+  src/slater_plane_wave/update_restore_trig.cu
   src/simulation/simulation.cu
   src/energy_tracking/energy_tracking.cu
   src/optimizer/jastrow_optimizer.cu

--- a/src/simulation/simulation.cu
+++ b/src/simulation/simulation.cu
@@ -89,7 +89,6 @@ Simulation::StepResult Simulation::metropolis_step() {
 
   auto& slater{wave_function_.slater_plane_wave()};
 
-  slater.save_trig_row(rand);
   slater.update_trig_cache(rand, particles_);
 
   const real_t* new_row{slater.build_row(rand)};

--- a/src/slater_plane_wave/slater_plane_wave.cu
+++ b/src/slater_plane_wave/slater_plane_wave.cu
@@ -146,50 +146,6 @@ SlaterPlaneWave::SlaterPlaneWave(const Particles& particles, real_t box_lengthL)
   std::fill_n(cos_cache(), trig_size, 0.0_r);
 };
 
-void SlaterPlaneWave::save_trig_row(std::size_t particle) noexcept {
-  const std::size_t num_k{num_unique_k()};
-  const std::size_t ROW_STRIDE{trig_row_stride()};
-  const std::size_t offset{particle * ROW_STRIDE};
-
-  std::memcpy(trig_scratch_[SIN_SAVED], sin_cache() + offset, num_k * sizeof(real_t));
-  std::memcpy(trig_scratch_[COS_SAVED], cos_cache() + offset, num_k * sizeof(real_t));
-}
-
-void SlaterPlaneWave::restore_trig_row(std::size_t particle) noexcept {
-  const std::size_t num_k{num_unique_k()};
-  const std::size_t ROW_STRIDE{trig_row_stride()};
-  const std::size_t offset{particle * ROW_STRIDE};
-
-  std::memcpy(sin_cache() + offset, trig_scratch_[SIN_SAVED], num_k * sizeof(real_t));
-  std::memcpy(cos_cache() + offset, trig_scratch_[COS_SAVED], num_k * sizeof(real_t));
-}
-
-void SlaterPlaneWave::update_trig_cache(std::size_t particle, const Particles& particles) noexcept {
-  const std::size_t num_k{num_unique_k()};
-  const std::size_t ROW_STRIDE{trig_row_stride()};
-
-  const auto pos{particles.pos().align()};
-  const auto kv{k_vector().align()};
-
-  real_t* RESTRICT c_row{cos_cache() + particle * ROW_STRIDE};
-  real_t* RESTRICT s_row{sin_cache() + particle * ROW_STRIDE};
-
-  ASSUME_ALIGNED(c_row, SIMD_BYTES);
-  ASSUME_ALIGNED(s_row, SIMD_BYTES);
-
-  // Not vectorized: loop-carried data dependency
-  #pragma omp simd
-  for (std::size_t k = 0; k < num_k; ++k) {
-    const real_t dot{
-      kv.x_[k] * pos.x_[particle] +
-      kv.y_[k] * pos.y_[particle] +
-      kv.z_[k] * pos.z_[particle]
-    };
-
-    vmc::sincos(dot, &s_row[k], &c_row[k]);
-  }
-}
-
 real_t* SlaterPlaneWave::build_row(std::size_t particle) noexcept {
   const std::size_t N{num_orbitals()};
   const std::size_t ROW_STRIDE{trig_row_stride()};

--- a/src/slater_plane_wave/slater_plane_wave.cuh
+++ b/src/slater_plane_wave/slater_plane_wave.cuh
@@ -97,9 +97,8 @@ public:
   [[nodiscard]] real_t*       cos_cache()       noexcept { return trig_cache_[COS_CACHE]; }
   [[nodiscard]] real_t const* cos_cache() const noexcept { return trig_cache_[COS_CACHE]; }
 
-  void save_trig_row(std::size_t particle) noexcept;
-  void restore_trig_row(std::size_t particle) noexcept;
-  void update_trig_cache(std::size_t particle, const Particles& particles) noexcept;
+  void restore_trig_row(std::size_t particle);
+  void update_trig_cache(std::size_t particle, const Particles& particles);
 
   real_t log_abs_det(const Particles& particles);
 

--- a/src/slater_plane_wave/update_restore_trig.cu
+++ b/src/slater_plane_wave/update_restore_trig.cu
@@ -1,0 +1,90 @@
+#include "slater_plane_wave.cuh"
+
+#if defined(__CUDACC__)
+    #include <cstddef>
+    namespace {
+        __global__ void cudaUpdateTrigRow(std::size_t particle, std::size_t num_k, std::size_t row_stride,
+          const real_t* RESTRICT p_x, const real_t* RESTRICT p_y, const real_t* RESTRICT p_z,
+          const real_t* RESTRICT k_x, const real_t* RESTRICT k_y, const real_t* RESTRICT k_z, real_t* RESTRICT s_cache, real_t* RESTRICT c_cache
+        ) {
+          const std::size_t k{blockIdx.x * blockDim.x + threadIdx.x};
+          if (k >= num_k) { return; }
+
+          const std::size_t offset{particle * row_stride};
+
+          const real_t dot{
+            k_x[k] * p_x[particle] +
+            k_y[k] * p_y[particle] +
+            k_z[k] * p_z[particle]
+          };
+
+          vmc::sincos(dot, &s_cache[offset + k], &c_cache[offset + k]);
+        }
+    }
+#else
+    #include "particles/particles.cuh"
+    #include "utilities/aligned_soa.cuh"
+    #include <cstring>
+#endif
+
+
+void SlaterPlaneWave::restore_trig_row(std::size_t particle) {
+  const std::size_t num_k{num_unique_k()};
+  const std::size_t ROW_STRIDE{trig_row_stride()};
+  const std::size_t offset{particle * ROW_STRIDE};
+
+#if defined(__CUDACC__)
+  CUDA_CHECK(cudaMemcpy(sin_cache() + offset, trig_scratch_[SIN_SAVED], num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
+  CUDA_CHECK(cudaMemcpy(cos_cache() + offset, trig_scratch_[COS_SAVED], num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
+#else
+  std::memcpy(sin_cache() + offset, trig_scratch_[SIN_SAVED], num_k * sizeof(real_t));
+  std::memcpy(cos_cache() + offset, trig_scratch_[COS_SAVED], num_k * sizeof(real_t));
+#endif
+}
+
+void SlaterPlaneWave::update_trig_cache(std::size_t particle, const Particles& particles) {
+  const std::size_t num_k{num_unique_k()};
+  const std::size_t ROW_STRIDE{trig_row_stride()};
+  const std::size_t offset{particle * ROW_STRIDE};
+#if defined(__CUDACC__)
+  // save
+  CUDA_CHECK(cudaMemcpy(trig_scratch_[SIN_SAVED], sin_cache() + offset, num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
+  CUDA_CHECK(cudaMemcpy(trig_scratch_[COS_SAVED], cos_cache() + offset, num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
+  
+  // update
+  dim3 threads(256);
+  dim3 blocks(
+    vmc::cudaNumBlocks(num_k, threads.x)
+  );
+  cudaUpdateTrigRow<<<blocks, threads>>>(particle, num_k, ROW_STRIDE, particles.pos().x_, particles.pos().y_, particles.pos().z_, k_vector().x_, k_vector().y_, k_vector().z_, sin_cache(), cos_cache());
+  CUDA_CHECK(cudaGetLastError());
+
+#else
+  // save
+  std::memcpy(trig_scratch_[SIN_SAVED], sin_cache() + offset, num_k * sizeof(real_t));
+  std::memcpy(trig_scratch_[COS_SAVED], cos_cache() + offset, num_k * sizeof(real_t));
+
+  // update
+  const auto pos{particles.pos().align()};
+  const auto kv{k_vector().align()};
+
+  real_t* RESTRICT c_row{cos_cache() + particle * ROW_STRIDE};
+  real_t* RESTRICT s_row{sin_cache() + particle * ROW_STRIDE};
+
+  ASSUME_ALIGNED(c_row, SIMD_BYTES);
+  ASSUME_ALIGNED(s_row, SIMD_BYTES);
+
+  // Not vectorized: loop-carried data dependency
+  #pragma omp simd
+  for (std::size_t k = 0; k < num_k; ++k) {
+    const real_t dot{
+      kv.x_[k] * pos.x_[particle] +
+      kv.y_[k] * pos.y_[particle] +
+      kv.z_[k] * pos.z_[particle]
+    };
+
+    vmc::sincos(dot, &s_row[k], &c_row[k]);
+  }
+
+#endif
+}

--- a/src/slater_plane_wave/update_restore_trig.cu
+++ b/src/slater_plane_wave/update_restore_trig.cu
@@ -3,25 +3,25 @@
 #if defined(__CUDACC__)
 #include <cstddef>
 namespace {
-    __global__ void cudaUpdateTrigRow(
-      std::size_t particle, std::size_t num_k, std::size_t row_stride,
-      const real_t* RESTRICT p_x, const real_t* RESTRICT p_y, const real_t* RESTRICT p_z,
-      const real_t* RESTRICT k_x, const real_t* RESTRICT k_y, const real_t* RESTRICT k_z,
-      real_t* RESTRICT s_cache, real_t* RESTRICT c_cache
-    ) {
-      const std::size_t k{blockIdx.x * blockDim.x + threadIdx.x};
-      if (k >= num_k) { return; }
+  __global__ void cudaUpdateTrigRow(
+    std::size_t particle, std::size_t num_k, std::size_t row_stride,
+    const real_t* RESTRICT p_x, const real_t* RESTRICT p_y, const real_t* RESTRICT p_z,
+    const real_t* RESTRICT k_x, const real_t* RESTRICT k_y, const real_t* RESTRICT k_z,
+    real_t* RESTRICT s_cache, real_t* RESTRICT c_cache
+  ) {
+    const std::size_t k{blockIdx.x * blockDim.x + threadIdx.x};
+    if (k >= num_k) { return; }
 
-      const std::size_t offset{particle * row_stride};
+    const std::size_t offset{particle * row_stride};
 
-      const real_t dot{
-        k_x[k] * p_x[particle] +
-        k_y[k] * p_y[particle] +
-        k_z[k] * p_z[particle]
-      };
+    const real_t dot{
+      k_x[k] * p_x[particle] +
+      k_y[k] * p_y[particle] +
+      k_z[k] * p_z[particle]
+    };
 
-      vmc::sincos(dot, &s_cache[offset + k], &c_cache[offset + k]);
-    }
+    vmc::sincos(dot, &s_cache[offset + k], &c_cache[offset + k]);
+  }
 }
 #else
 #include "particles/particles.cuh"
@@ -59,7 +59,7 @@ void SlaterPlaneWave::update_trig_cache(
   dim3 updateTrigRowBlocks(
     vmc::cudaNumBlocks(num_k, threads.x)
   );
-  cudaUpdateTrigRow<<<blocks, threads>>>(
+  cudaUpdateTrigRow<<<updateTrigRowBlocks, updateTrigRowThreads>>>(
     particle, num_k, ROW_STRIDE,
     particles.pos().x_, particles.pos().y_, particles.pos().z_,
     k_vector().x_, k_vector().y_, k_vector().z_,

--- a/src/slater_plane_wave/update_restore_trig.cu
+++ b/src/slater_plane_wave/update_restore_trig.cu
@@ -1,30 +1,32 @@
 #include "slater_plane_wave.cuh"
 
 #if defined(__CUDACC__)
-    #include <cstddef>
-    namespace {
-        __global__ void cudaUpdateTrigRow(std::size_t particle, std::size_t num_k, std::size_t row_stride,
-          const real_t* RESTRICT p_x, const real_t* RESTRICT p_y, const real_t* RESTRICT p_z,
-          const real_t* RESTRICT k_x, const real_t* RESTRICT k_y, const real_t* RESTRICT k_z, real_t* RESTRICT s_cache, real_t* RESTRICT c_cache
-        ) {
-          const std::size_t k{blockIdx.x * blockDim.x + threadIdx.x};
-          if (k >= num_k) { return; }
+#include <cstddef>
+namespace {
+    __global__ void cudaUpdateTrigRow(
+      std::size_t particle, std::size_t num_k, std::size_t row_stride,
+      const real_t* RESTRICT p_x, const real_t* RESTRICT p_y, const real_t* RESTRICT p_z,
+      const real_t* RESTRICT k_x, const real_t* RESTRICT k_y, const real_t* RESTRICT k_z,
+      real_t* RESTRICT s_cache, real_t* RESTRICT c_cache
+    ) {
+      const std::size_t k{blockIdx.x * blockDim.x + threadIdx.x};
+      if (k >= num_k) { return; }
 
-          const std::size_t offset{particle * row_stride};
+      const std::size_t offset{particle * row_stride};
 
-          const real_t dot{
-            k_x[k] * p_x[particle] +
-            k_y[k] * p_y[particle] +
-            k_z[k] * p_z[particle]
-          };
+      const real_t dot{
+        k_x[k] * p_x[particle] +
+        k_y[k] * p_y[particle] +
+        k_z[k] * p_z[particle]
+      };
 
-          vmc::sincos(dot, &s_cache[offset + k], &c_cache[offset + k]);
-        }
+      vmc::sincos(dot, &s_cache[offset + k], &c_cache[offset + k]);
     }
+}
 #else
-    #include "particles/particles.cuh"
-    #include "utilities/aligned_soa.cuh"
-    #include <cstring>
+#include "particles/particles.cuh"
+#include "utilities/aligned_soa.cuh"
+#include <cstring>
 #endif
 
 
@@ -42,7 +44,8 @@ void SlaterPlaneWave::restore_trig_row(std::size_t particle) {
 #endif
 }
 
-void SlaterPlaneWave::update_trig_cache(std::size_t particle, const Particles& particles) {
+void SlaterPlaneWave::update_trig_cache(
+  std::size_t particle, const Particles& particles) {
   const std::size_t num_k{num_unique_k()};
   const std::size_t ROW_STRIDE{trig_row_stride()};
   const std::size_t offset{particle * ROW_STRIDE};
@@ -52,13 +55,19 @@ void SlaterPlaneWave::update_trig_cache(std::size_t particle, const Particles& p
   CUDA_CHECK(cudaMemcpy(trig_scratch_[COS_SAVED], cos_cache() + offset, num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
   
   // update
-  dim3 threads(256);
-  dim3 blocks(
+  dim3 updateTrigRowThreads(256);
+  dim3 updateTrigRowBlocks(
     vmc::cudaNumBlocks(num_k, threads.x)
   );
-  cudaUpdateTrigRow<<<blocks, threads>>>(particle, num_k, ROW_STRIDE, particles.pos().x_, particles.pos().y_, particles.pos().z_, k_vector().x_, k_vector().y_, k_vector().z_, sin_cache(), cos_cache());
+  cudaUpdateTrigRow<<<blocks, threads>>>(
+    particle, num_k, ROW_STRIDE,
+    particles.pos().x_, particles.pos().y_, particles.pos().z_,
+    k_vector().x_, k_vector().y_, k_vector().z_,
+    sin_cache(), cos_cache()
+  );
   CUDA_CHECK(cudaGetLastError());
 
+  CUDA_CHECK(cudaDeviceSynchronize());
 #else
   // save
   std::memcpy(trig_scratch_[SIN_SAVED], sin_cache() + offset, num_k * sizeof(real_t));
@@ -74,13 +83,17 @@ void SlaterPlaneWave::update_trig_cache(std::size_t particle, const Particles& p
   ASSUME_ALIGNED(c_row, SIMD_BYTES);
   ASSUME_ALIGNED(s_row, SIMD_BYTES);
 
+  const real_t px{pos.x_[particle]};
+  const real_t py{pos.y_[particle]};
+  const real_t pz{pos.z_[particle]};
+
   // Not vectorized: loop-carried data dependency
   #pragma omp simd
   for (std::size_t k = 0; k < num_k; ++k) {
     const real_t dot{
-      kv.x_[k] * pos.x_[particle] +
-      kv.y_[k] * pos.y_[particle] +
-      kv.z_[k] * pos.z_[particle]
+      kv.x_[k] * px +
+      kv.y_[k] * py +
+      kv.z_[k] * pz
     };
 
     vmc::sincos(dot, &s_row[k], &c_row[k]);

--- a/tests/test_rigorous_physics.cpp
+++ b/tests/test_rigorous_physics.cpp
@@ -489,9 +489,6 @@ TEST_CASE("Repeated accepted Slater updates preserve predictive determinant rati
     probe_particles.pos().z_[probe] =
         wrap_coordinate(probe_particles.pos().z_[probe] + probe_dz, box_length);
 
-    maintained.save_trig_row(probe);
-    rebuilt.save_trig_row(probe);
-
     maintained.update_trig_cache(probe, probe_particles);
     rebuilt.update_trig_cache(probe, probe_particles);
 


### PR DESCRIPTION
## Summary

Fixes #40.

Adds the CUDA backend for the per-move trig cache maintenance. `update_trig_cache` recomputes the moved particle's row of sin/cos on device via a new `cudaUpdateTrigRow` kernel (1D, one thread per k-vector), and `restore_trig_row` reverts that row. `save_trig_row` is folded into `update_trig_cache` — the two were always called as a pair — so save/update/restore now live together in one file with the backend picked at compile time via `__CUDACC__`. The CPU path is unchanged.

## Changes

- `slater_plane_wave/update_restore_trig.cu` (new): both backends of `update_trig_cache` and `restore_trig_row`; `cudaUpdateTrigRow` in an anonymous namespace. Save/restore are device-to-device `cudaMemcpy`; the CPU `std::memcpy` paths are preserved under `#else`
- `slater_plane_wave.cu`: old `save_trig_row` / `update_trig_cache` / `restore_trig_row` definitions removed
- `slater_plane_wave.cuh`: `save_trig_row` declaration removed (folded into update); `noexcept` dropped from `update_trig_cache` / `restore_trig_row`
- `simulation.cu`: `metropolis_step` no longer calls `save_trig_row` separately — `update_trig_cache` performs the save
- `CMakeLists.txt`: adds `update_restore_trig.cu` to `VMC_CUDA_SOURCES`

## Notes

- Save and update were always issued together (back up the row, then overwrite it), so folding save into update removes a footgun where a caller could update without saving first
- The save copy and the kernel launch share the default stream, so the device-to-device copy is ordered before the kernel overwrites the row — no explicit sync needed
- Kernel writes are disjoint (each thread owns `offset + k`), so no atomics or `__syncthreads`
- `noexcept` removed because the CUDA path wraps `cudaMemcpy`/launch in throwing `CUDA_CHECK`, matching `log_abs_det`

## Testing

- `./scripts/test.sh` (fp64): 95/95
- `./scripts/test.sh --fp32`: 95/95
- CUDA-enabled build + parity vs CPU backend: REQUIRES SOMEONE ELSE TO TEST