### PR TITLE
Clean up trig cache kernels

### DIFF
--- a/src/slater_plane_wave/update_restore_trig.cu
+++ b/src/slater_plane_wave/update_restore_trig.cu
@@ -3,26 +3,26 @@
 #if defined(__CUDACC__)
 #include <cstddef>
 namespace {
-  __global__ void cudaUpdateTrigRow(
-    std::size_t particle, std::size_t num_k, std::size_t row_stride,
-    const real_t* RESTRICT p_x, const real_t* RESTRICT p_y, const real_t* RESTRICT p_z,
-    const real_t* RESTRICT k_x, const real_t* RESTRICT k_y, const real_t* RESTRICT k_z,
-    real_t* RESTRICT s_cache, real_t* RESTRICT c_cache
-  ) {
-    const std::size_t k{blockIdx.x * blockDim.x + threadIdx.x};
-    if (k >= num_k) { return; }
 
-    const std::size_t offset{particle * row_stride};
+__global__ void cudaUpdateTrigRow(
+  std::size_t num_k, std::size_t offset,
+  real_t p_x, real_t p_y, real_t p_z,
+  const real_t* RESTRICT k_x, const real_t* RESTRICT k_y, const real_t* RESTRICT k_z,
+  real_t* RESTRICT s_cache, real_t* RESTRICT c_cache
+) {
+  const std::size_t i{blockIdx.x * blockDim.x + threadIdx.x};
+  if (i >= num_k) { return; }
 
-    const real_t dot{
-      k_x[k] * p_x[particle] +
-      k_y[k] * p_y[particle] +
-      k_z[k] * p_z[particle]
-    };
+  const real_t dot{
+    k_x[i] * p_x +
+    k_y[i] * p_y +
+    k_z[i] * p_z
+  };
 
-    vmc::sincos(dot, &s_cache[offset + k], &c_cache[offset + k]);
-  }
+  vmc::sincos(dot, &s_cache[offset + i], &c_cache[offset + i]);
 }
+
+} // namespace
 #else
 #include "particles/particles.cuh"
 #include "utilities/aligned_soa.cuh"
@@ -31,57 +31,54 @@ namespace {
 
 
 void SlaterPlaneWave::restore_trig_row(std::size_t particle) {
-  const std::size_t num_k{num_unique_k()};
-  const std::size_t ROW_STRIDE{trig_row_stride()};
+  const std::size_t num_k{this->num_unique_k()};
+  const std::size_t ROW_STRIDE{this->trig_row_stride()};
   const std::size_t offset{particle * ROW_STRIDE};
 
 #if defined(__CUDACC__)
-  CUDA_CHECK(cudaMemcpy(sin_cache() + offset, trig_scratch_[SIN_SAVED], num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
-  CUDA_CHECK(cudaMemcpy(cos_cache() + offset, trig_scratch_[COS_SAVED], num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
+  CUDA_CHECK(cudaMemcpy(this->sin_cache() + offset, trig_scratch_[SIN_SAVED], num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
+  CUDA_CHECK(cudaMemcpy(this->cos_cache() + offset, trig_scratch_[COS_SAVED], num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
 #else
-  std::memcpy(sin_cache() + offset, trig_scratch_[SIN_SAVED], num_k * sizeof(real_t));
-  std::memcpy(cos_cache() + offset, trig_scratch_[COS_SAVED], num_k * sizeof(real_t));
+  std::memcpy(this->sin_cache() + offset, trig_scratch_[SIN_SAVED], num_k * sizeof(real_t));
+  std::memcpy(this->cos_cache() + offset, trig_scratch_[COS_SAVED], num_k * sizeof(real_t));
 #endif
 }
 
 void SlaterPlaneWave::update_trig_cache(
   std::size_t particle, const Particles& particles) {
-  const std::size_t num_k{num_unique_k()};
-  const std::size_t ROW_STRIDE{trig_row_stride()};
+  const std::size_t num_k{this->num_unique_k()};
+  const std::size_t ROW_STRIDE{this->trig_row_stride()};
   const std::size_t offset{particle * ROW_STRIDE};
 #if defined(__CUDACC__)
   // save
-  CUDA_CHECK(cudaMemcpy(trig_scratch_[SIN_SAVED], sin_cache() + offset, num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
-  CUDA_CHECK(cudaMemcpy(trig_scratch_[COS_SAVED], cos_cache() + offset, num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
+  CUDA_CHECK(cudaMemcpy(trig_scratch_[SIN_SAVED], this->sin_cache() + offset, num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
+  CUDA_CHECK(cudaMemcpy(trig_scratch_[COS_SAVED], this->cos_cache() + offset, num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
   
   // update
   dim3 updateTrigRowThreads(256);
   dim3 updateTrigRowBlocks(
-    vmc::cudaNumBlocks(num_k, threads.x)
+    vmc::cudaNumBlocks(num_k, updateTrigRowThreads.x)
   );
   cudaUpdateTrigRow<<<updateTrigRowBlocks, updateTrigRowThreads>>>(
-    particle, num_k, ROW_STRIDE,
-    particles.pos().x_, particles.pos().y_, particles.pos().z_,
-    k_vector().x_, k_vector().y_, k_vector().z_,
-    sin_cache(), cos_cache()
+    num_k, particle * ROW_STRIDE,
+    particles.pos().x_[particle], particles.pos().y_[particle], particles.pos().z_[particle],
+    this->k_vector().x_, this->k_vector().y_, this->k_vector().z_,
+    this->sin_cache(), this->cos_cache()
   );
   CUDA_CHECK(cudaGetLastError());
 
   CUDA_CHECK(cudaDeviceSynchronize());
 #else
   // save
-  std::memcpy(trig_scratch_[SIN_SAVED], sin_cache() + offset, num_k * sizeof(real_t));
-  std::memcpy(trig_scratch_[COS_SAVED], cos_cache() + offset, num_k * sizeof(real_t));
+  std::memcpy(trig_scratch_[SIN_SAVED], this->sin_cache() + offset, num_k * sizeof(real_t));
+  std::memcpy(trig_scratch_[COS_SAVED], this->cos_cache() + offset, num_k * sizeof(real_t));
 
   // update
   const auto pos{particles.pos().align()};
-  const auto kv{k_vector().align()};
+  const auto kv{this->k_vector().align()};
 
-  real_t* RESTRICT c_row{cos_cache() + particle * ROW_STRIDE};
-  real_t* RESTRICT s_row{sin_cache() + particle * ROW_STRIDE};
-
-  ASSUME_ALIGNED(c_row, SIMD_BYTES);
-  ASSUME_ALIGNED(s_row, SIMD_BYTES);
+  real_t* RESTRICT c_row{this->cos_cache() + particle * ROW_STRIDE}; ASSUME_ALIGNED(c_row, SIMD_BYTES);
+  real_t* RESTRICT s_row{this->sin_cache() + particle * ROW_STRIDE}; ASSUME_ALIGNED(s_row, SIMD_BYTES);
 
   const real_t px{pos.x_[particle]};
   const real_t py{pos.y_[particle]};
@@ -98,6 +95,5 @@ void SlaterPlaneWave::update_trig_cache(
 
     vmc::sincos(dot, &s_row[k], &c_row[k]);
   }
-
 #endif
 }

--- a/src/utilities/aligned_soa.cuh
+++ b/src/utilities/aligned_soa.cuh
@@ -63,9 +63,6 @@ public:
   AlignedSoA(std::size_t num_elements, std::size_t num_arrays)
   : num_elements_{num_elements}
   , stride_length_{round_up(num_elements)} {
-    #if defined(__CUDACC__)
-      stride_length_ = num_elements;
-    #endif
     const std::size_t total_elements{num_arrays * stride_length_};
     const std::size_t total_bytes{total_elements * sizeof(T)};
 


### PR DESCRIPTION
## Summary

Fixes: #40 
Follows up: #72

The CUDA path in that PR never actually compiled and was never tested on real hardware.

## Changes

- Fixed a compile error in `cudaUpdateTrigRow`'s launch config (`threads.x` was undefined, should be `updateTrigRowThreads.x`)
- Simplified the kernel: the particle's position is passed by value instead of the full array plus index
- Added `this->` for consistency with the rest of the class
- Removed a leftover `AlignedSoA` override that skipped SIMD padding on CUDA builds; both backends now pad the same way

## Testing

Standalone CPU vs CUDA comparison on the trig cache update/restore, no CMake:

- fp64: max diff 1 ULP, restore is exact
- fp32 + fast math: max diff 2 ULP, within CUDA's documented error bound

<img width="513" height="261" alt="image" src="https://github.com/user-attachments/assets/f2a10006-0ed5-4cdd-bc6a-0138d150dfdd" />

- `.\scripts\test.ps1`: <results>
- `.\scripts\test.ps1 -Fp32`: <results>
- `.\scripts\test.ps1 -Cuda`: <results>
