### PR TITLE
Add VMC_CUDA_BACKEND flag gating

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,8 @@ if(VMC_CUDA)
     CUDA_SEPARABLE_COMPILATION ON
   )
 
+  target_compile_definitions(vmc_lib PUBLIC VMC_CUDA_BACKEND)
+
   target_link_libraries(vmc_lib PUBLIC
     CUDA::cudart
     CUDA::cusolver

--- a/src/slater_plane_wave/log_abs_det.cu
+++ b/src/slater_plane_wave/log_abs_det.cu
@@ -1,6 +1,6 @@
 #include "slater_plane_wave.cuh"
 
-#if defined(__CUDACC__)
+#ifdef VMC_CUDA_BACKEND
 #include <cublas_v2.h>
 #include <cmath>
 #include <cstddef>
@@ -179,7 +179,7 @@ void cudaBuildIdentity(
 
 
 real_t SlaterPlaneWave::log_abs_det(const Particles& particles) {
-#if defined(__CUDACC__)
+#ifdef VMC_CUDA_BACKEND
   AlignedSoA<real_t> log_abs_det{1, 1};
 
   const int N{static_cast<int>(particles.size())};

--- a/src/slater_plane_wave/update_restore_trig.cu
+++ b/src/slater_plane_wave/update_restore_trig.cu
@@ -1,6 +1,6 @@
 #include "slater_plane_wave.cuh"
 
-#if defined(__CUDACC__)
+#ifdef VMC_CUDA_BACKEND
 #include <cstddef>
 namespace {
 
@@ -35,7 +35,7 @@ void SlaterPlaneWave::restore_trig_row(std::size_t particle) {
   const std::size_t ROW_STRIDE{this->trig_row_stride()};
   const std::size_t offset{particle * ROW_STRIDE};
 
-#if defined(__CUDACC__)
+#ifdef VMC_CUDA_BACKEND
   CUDA_CHECK(cudaMemcpy(this->sin_cache() + offset, trig_scratch_[SIN_SAVED], num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
   CUDA_CHECK(cudaMemcpy(this->cos_cache() + offset, trig_scratch_[COS_SAVED], num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
 #else
@@ -49,7 +49,7 @@ void SlaterPlaneWave::update_trig_cache(
   const std::size_t num_k{this->num_unique_k()};
   const std::size_t ROW_STRIDE{this->trig_row_stride()};
   const std::size_t offset{particle * ROW_STRIDE};
-#if defined(__CUDACC__)
+#ifdef VMC_CUDA_BACKEND
   // save
   CUDA_CHECK(cudaMemcpy(trig_scratch_[SIN_SAVED], this->sin_cache() + offset, num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));
   CUDA_CHECK(cudaMemcpy(trig_scratch_[COS_SAVED], this->cos_cache() + offset, num_k * sizeof(real_t), cudaMemcpyDeviceToDevice));

--- a/src/utilities/aligned_soa.cuh
+++ b/src/utilities/aligned_soa.cuh
@@ -9,7 +9,7 @@
 #include <new>
 
 inline void* backend_alloc(std::size_t alignment, std::size_t size) {
-#if defined(__CUDACC__)
+#ifdef VMC_CUDA_BACKEND
   static_cast<void>(alignment);
 
   void* ptr{};
@@ -31,7 +31,7 @@ inline void* backend_alloc(std::size_t alignment, std::size_t size) {
 }
 
 inline void backend_free(void* ptr) {
-#if defined(__CUDACC__)
+#ifdef VMC_CUDA_BACKEND
   cudaFree(ptr);
 #elif defined(_MSC_VER)
   _aligned_free(ptr);
@@ -63,6 +63,10 @@ public:
   AlignedSoA(std::size_t num_elements, std::size_t num_arrays)
   : num_elements_{num_elements}
   , stride_length_{round_up(num_elements)} {
+    #ifdef VMC_CUDA_BACKEND
+    stride_length_ = num_elements;
+    #endif
+    
     const std::size_t total_elements{num_arrays * stride_length_};
     const std::size_t total_bytes{total_elements * sizeof(T)};
 
@@ -70,7 +74,7 @@ public:
     if (!ptr) { throw std::bad_alloc(); }
 
     // For once cudaMalloc is used:
-    // #if defined(__CUDACC__)
+    // #ifdef VMC_CUDA_BACKEND
     //   CUDA_CHECK(cudaMemset(ptr, 0, total_bytes));
     // #else
     //   std::fill_n(ptr, total_elements, T{});

--- a/src/utilities/macros.cuh
+++ b/src/utilities/macros.cuh
@@ -21,7 +21,7 @@ using real_t = float;
 
 using complex_t = std::complex<real_t>;
 
-#if defined(__CUDACC__)
+#ifdef VMC_CUDA_BACKEND
 #include <cstdio>
 #include <cstdlib>
 #include <cuda_runtime.h>
@@ -59,7 +59,7 @@ using complex_t = std::complex<real_t>;
 #endif
 
 // Cuda Callable
-#if defined(__CUDACC__)
+#ifdef VMC_CUDA_BACKEND
   #define CUDA_CALLABLE __host__ __device__
 #else
   #define CUDA_CALLABLE

--- a/src/utilities/math.cuh
+++ b/src/utilities/math.cuh
@@ -10,7 +10,7 @@ namespace vmc {
 
 CUDA_CALLABLE
 inline void sincos(real_t theta, real_t* s, real_t* c) noexcept {
-#if defined(__CUDACC__) && defined(__CUDA_ARCH__)
+#if defined(VMC_CUDA_BACKEND) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     ::sincos(theta, s, c);
   #elif defined(VMC_FAST_MATH)
@@ -38,7 +38,7 @@ inline void sincos(real_t theta, real_t* s, real_t* c) noexcept {
 
 CUDA_CALLABLE [[nodiscard]]
 inline real_t sqrt(real_t arg) noexcept {
-#if defined(__CUDACC__) && defined(__CUDA_ARCH__)
+#if defined(VMC_CUDA_BACKEND) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::sqrt(arg);
   #elif defined(VMC_FAST_MATH)
@@ -53,7 +53,7 @@ inline real_t sqrt(real_t arg) noexcept {
 
 CUDA_CALLABLE [[nodiscard]]
 inline real_t exp(real_t arg) noexcept {
-#if defined(__CUDACC__) && defined(__CUDA_ARCH__)
+#if defined(VMC_CUDA_BACKEND) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::exp(arg);
   #elif defined(VMC_FAST_MATH)
@@ -68,7 +68,7 @@ inline real_t exp(real_t arg) noexcept {
 
 CUDA_CALLABLE [[nodiscard]]
 inline real_t pow(real_t arg, real_t power) noexcept {
-#if defined(__CUDACC__) && defined(__CUDA_ARCH__)
+#if defined(VMC_CUDA_BACKEND) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::pow(arg, power);
   #elif defined(VMC_FAST_MATH)
@@ -83,7 +83,7 @@ inline real_t pow(real_t arg, real_t power) noexcept {
 
 CUDA_CALLABLE [[nodiscard]]
 inline real_t cbrt(real_t arg) noexcept {
-#if defined(__CUDACC__) && defined(__CUDA_ARCH__)
+#if defined(VMC_CUDA_BACKEND) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::cbrt(arg);
   #elif defined(VMC_FAST_MATH)
@@ -98,7 +98,7 @@ inline real_t cbrt(real_t arg) noexcept {
 
 CUDA_CALLABLE [[nodiscard]]
 inline real_t log(real_t arg) noexcept {
-#if defined(__CUDACC__) && defined(__CUDA_ARCH__)
+#if defined(VMC_CUDA_BACKEND) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::log(arg);
   #elif defined(VMC_FAST_MATH)
@@ -113,7 +113,7 @@ inline real_t log(real_t arg) noexcept {
 
 CUDA_CALLABLE [[nodiscard]]
 inline real_t abs(real_t arg) noexcept {
-#if defined(__CUDACC__) && defined(__CUDA_ARCH__)
+#if defined(VMC_CUDA_BACKEND) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return fabs(arg);
   #else
@@ -126,7 +126,7 @@ inline real_t abs(real_t arg) noexcept {
 
 CUDA_CALLABLE [[nodiscard]]
 inline real_t floor(real_t arg) noexcept {
-#if defined(__CUDACC__) && defined(__CUDA_ARCH__)
+#if defined(VMC_CUDA_BACKEND) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::floor(arg);
   #else
@@ -139,7 +139,7 @@ inline real_t floor(real_t arg) noexcept {
 
 CUDA_CALLABLE [[nodiscard]]
 inline real_t ceil(real_t arg) noexcept {
-#if defined(__CUDACC__) && defined(__CUDA_ARCH__)
+#if defined(VMC_CUDA_BACKEND) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::ceil(arg);
   #else
@@ -157,7 +157,7 @@ inline unsigned int cudaNumBlocks(std::size_t size, unsigned int threads) noexce
 
 CUDA_CALLABLE [[nodiscard]]
 inline real_t erfc(real_t arg) noexcept {
-#if defined(__CUDACC__) && defined(__CUDA_ARCH__)
+#if defined(VMC_CUDA_BACKEND) && defined(__CUDA_ARCH__)
   #ifdef FP_64
     return ::erfc(arg);
   #elif defined(VMC_FAST_MATH)

--- a/src/utilities/random.cuh
+++ b/src/utilities/random.cuh
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined(__CUDACC__)
+#ifdef VMC_CUDA_BACKEND
 #include <curand_kernel.h>
 #endif
 
@@ -25,10 +25,9 @@ private:
   real_t step_size_;
 
 public:
-  #if defined(__CUDA_ARCH__)
-  __device__ 
   WalkerRNG() = default;
 
+  #if defined(__CUDA_ARCH__)
   __device__ 
   void init(const Config& config, uint64_t walker_id, uint64_t offset = 0) {
     step_size_ = config.step_size;
@@ -37,9 +36,7 @@ public:
 
   }
   #else
-  WalkerRNG() = default;
-
-  void init(const Config& config, uint64_t walker_id, uint64_t offset = 0) {
+  void init(const Config& config, uint64_t walker_id, [[maybe_unused]] uint64_t offset = 0) {
     step_size_ = config.step_size;
     rng_.seed(config.master_seed + walker_id);
     proposal_ = std::uniform_real_distribution<real_t>(-config.step_size, config.step_size);

--- a/test_config_tmp.cfg
+++ b/test_config_tmp.cfg
@@ -1,1 +1,0 @@
-Measure_Sweeps = 0


### PR DESCRIPTION
## Summary

Fixes: #74

`__CUDACC__` is per translation unit: true only in files nvcc actually compiles. A header shared between nvcc-compiled `.cu` files and host-compiled `.cpp` files in the same CUDA-enabled binary getting a different answer to `__CUDACC__` per TU is a real hazard for anything layout- or allocator-affecting (inconsistent `AlignedSoA` allocator choice, mismatched struct layout). `target_compile_definitions(vmc_lib PUBLIC VMC_CUDA_BACKEND)` in `CMakeLists.txt` now gives every TU in a CUDA-enabled build, nvcc or host compiler, the same build-wide signal, and the affected headers are migrated to use it.

## Changes

- `CMakeLists.txt`: `target_compile_definitions(vmc_lib PUBLIC VMC_CUDA_BACKEND)` under `if(VMC_CUDA)`, propagates to `vmc` and `vmc_tests` since both link `vmc_lib`
- `macros.cuh`: `CUDA_CALLABLE` and the CUDA header include block (`cuda_runtime.h`, `cusolverDn.h`, `CUDA_CHECK`/`CUSOLVER_CHECK`) switched from `__CUDACC__` to `VMC_CUDA_BACKEND`
- `aligned_soa.cuh`: `backend_alloc`/`backend_free` switched from `__CUDACC__` to `VMC_CUDA_BACKEND`, so the allocator choice is consistent build-wide instead of per-TU. Also implemented the CUDA stride override (`stride_length_ = num_elements`, no SIMD round-up) that was previously just a dead comment
- `random.cuh`: `curand_kernel.h` include switched from `__CUDACC__` to `VMC_CUDA_BACKEND`. `WalkerRNG`'s defaulted constructor de-duplicated to one unconditional declaration (it was identical on both branches, and nvcc warns that `__device__` on an explicitly-defaulted first declaration is ignored anyway). Host `init()`'s unused `offset` parameter marked `[[maybe_unused]]`
- `math.cuh`: all ten device-dispatch guards switched from `defined(__CUDACC__) && defined(__CUDA_ARCH__)` to `defined(VMC_CUDA_BACKEND) && defined(__CUDA_ARCH__)`. Functionally identical, since `__CUDA_ARCH__` can only be true inside an nvcc-compiled TU regardless of which build-wide macro gates it, but keeps the file on the same convention as everything else
- `log_abs_det.cu` / `update_restore_trig.cu`: `__CUDACC__` to `VMC_CUDA_BACKEND` for consistency; no functional change, since CMake already compiles these files 1:1 with nvcc whenever `VMC_CUDA` is on

## Notes

- `WalkerRNG::rng_`'s member type is still gated on `__CUDA_ARCH__`, not `VMC_CUDA_BACKEND`. That's the deepest instance of the hazard this PR targets: nvcc parses the header twice per `.cu` file, once with `__CUDA_ARCH__` unset for the host pass and once with it set for the device pass, so the class layout can differ within a single translation unit. Left out of this PR since it needs the curand/init redesign, not just a macro swap.
- Caught a preprocessor bug along the way in `math.cuh`: an earlier pass wrote `#ifdef VMC_CUDA_BACKEND && defined(__CUDA_ARCH__)`, which MSVC (`C4067`) silently truncates to just `#ifdef VMC_CUDA_BACKEND`, since `#ifdef` only takes a single macro name. Fixed to `#if defined(...) && defined(...)`.

## Testing

- `.\scripts\profile.ps1` (no `-Cuda`): compiles clean, links `vmc.exe`
- `.\scripts\profile.ps1 -Cuda`: compiles clean, links `vmc.exe`. Remaining warnings are pre-existing and unrelated: `C4211` in nvcc's autogenerated kernel launch stubs, and `#20012-D` on `WalkerRNG`'s defaulted constructor (see Notes)