### PR TITLE
Implement CUDA update_structure_factors and update_real_energy kernel

### DIFF
--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -220,15 +220,15 @@ void EnergyTracker::update_structure_factors(
   real_t new_z
 ) noexcept {
 #ifdef VMC_CUDA_BACKEND
-  const std::size_t num_G{num_g_vectors_};
-  const auto gv{g_vector()};
+  const std::size_t num_G{this->num_g_vectors_};
+  const auto gv{this->g_vector()};
 
   dim3 threads(256);
   dim3 blocks(vmc::cudaNumBlocks(num_G, threads.x));
 
   update_structure_factors_kernel<<<blocks, threads>>>(
     gv.x_, gv.y_, gv.z_,
-    sum_real(), sum_imag(),
+    this->sum_real(), this->sum_imag(),
     num_G,
     old_x, old_y, old_z,
     new_x, new_y, new_z
@@ -410,9 +410,7 @@ void EnergyTracker::update_real_energy(
 
   const auto pos{particles.pos()};
 
-  AlignedSoA<real_t> delta_storage{1, 1};
-  real_t* RESTRICT delta{delta_storage[0]};
-  *delta = 0.0_r;
+  AlignedSoA<real_t> delta{1, 1};
 
   const real_t new_x{pos.x_[moved_idx]};
   const real_t new_y{pos.y_[moved_idx]};
@@ -427,12 +425,12 @@ void EnergyTracker::update_real_energy(
     old_x, old_y, old_z,
     new_x, new_y, new_z,
     pos.x_, pos.y_, pos.z_,
-    delta
+    delta[0]
   );
   CUDA_CHECK(cudaGetLastError());
   CUDA_CHECK(cudaDeviceSynchronize());
 
-  V_real_ += *delta;
+  V_real_ += *delta[0];
 #else
   const std::size_t N{particles.size()};
   const real_t L{box_length_};

--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -225,9 +225,9 @@ void EnergyTracker::update_structure_factors(
   const auto gv{this->g_vector()};
 
   dim3 updateStructureFactorsThreads(256);
-  dim3 blocks(vmc::cudaNumBlocks(num_G, updateStructureFactorsThreads.x));
+  dim3 updateStructureFactorsBlocks(vmc::cudaNumBlocks(num_G, updateStructureFactorsThreads.x));
 
-  cudaUpdateStructureFactors<<<blocks, updateStructureFactorsThreads>>>(
+  cudaUpdateStructureFactors<<<updateStructureFactorsBlocks, updateStructureFactorsThreads>>>(
     gv.x_, gv.y_, gv.z_,
     this->sum_real(), this->sum_imag(),
     num_G,
@@ -419,9 +419,9 @@ void EnergyTracker::update_real_energy(
   const real_t new_z{pos.z_[moved_idx]};
 
   dim3 updateRealEnergyThreads(256);
-  dim3 blocks(vmc::cudaNumBlocks(N, updateRealEnergyThreads.x));
+  dim3 updateRealEnergyBlocks(vmc::cudaNumBlocks(N, updateRealEnergyThreads.x));
 
- cudaUpdateRealEnergy<<<blocks, updateRealEnergyThreads>>>(
+ cudaUpdateRealEnergy<<<updateRealEnergyBlocks, updateRealEnergyThreads>>>(
     N, moved_idx,
     L, alpha,
     old_x, old_y, old_z,

--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -224,10 +224,10 @@ void EnergyTracker::update_structure_factors(
   const std::size_t num_G{this->num_g_vectors_};
   const auto gv{this->g_vector()};
 
-  dim3 threads(256);
-  dim3 blocks(vmc::cudaNumBlocks(num_G, threads.x));
+  dim3 updateStructureFactorsThreads(256);
+  dim3 blocks(vmc::cudaNumBlocks(num_G, updateStructureFactorsThreads.x));
 
-  update_structure_factors_kernel<<<blocks, threads>>>(
+  cudaUpdateStructureFactors<<<blocks, updateStructureFactorsThreads>>>(
     gv.x_, gv.y_, gv.z_,
     this->sum_real(), this->sum_imag(),
     num_G,
@@ -418,10 +418,10 @@ void EnergyTracker::update_real_energy(
   const real_t new_y{pos.y_[moved_idx]};
   const real_t new_z{pos.z_[moved_idx]};
 
-  dim3 threads(256);
-  dim3 blocks(vmc::cudaNumBlocks(N, threads.x));
+  dim3 updateRealEnergyThreads(256);
+  dim3 blocks(vmc::cudaNumBlocks(N, updateRealEnergyThreads.x));
 
-  update_real_energy_kernel<<<blocks, threads>>>(
+ cudaUpdateRealEnergy<<<blocks, updateRealEnergyThreads>>>(
     N, moved_idx,
     L, alpha,
     old_x, old_y, old_z,

--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -172,48 +172,28 @@ void EnergyTracker::initialize_structure_factors(const Particles& particles) noe
   }
 }
 
-void EnergyTracker::update_structure_factors(
-  real_t old_x,
-  real_t old_y,
-  real_t old_z,
-  real_t new_x,
-  real_t new_y,
-  real_t new_z
-) noexcept {
-  const real_t L{box_length_};
 
-  const std::size_t num_G{num_g_vectors_};
-  const real_t prefactor{1.0_r / (2.0_r * std::numbers::pi_v<real_t> * L * L * L)};
+__global__ 
+void update_structure_factors_kernel(
+  const real_t* RESTRICT g_x, const real_t* RESTRICT g_y, const real_t* RESTRICT g_z, const real_t* RESTRICT g_weights,
+  real_t* RESTRICT sum_real, real_t* RESTRICT sum_imag,
+  real_t* RESTRICT d_real_temp, real_t* RESTRICT d_imag_temp,
+  const std::size_t num_G,
+  const real_t old_x, const real_t old_y, const real_t old_z,
+  const real_t new_x, const real_t new_y, const real_t new_z,
+) {
+  const std::size_t g{blockIdx.x * blockDim.x + threadIdx.x};
+  if (g >= num_G) return;
 
-  const real_t* RESTRICT g_weights{this->g_weights()};
-  const auto gv{g_vector().align()};
-
-  real_t* RESTRICT sum_real{this->sum_real()};
-  real_t* RESTRICT sum_imag{this->sum_imag()};
-  real_t* RESTRICT d_imag_temp{this->d_imag_temp()};
-  real_t* RESTRICT d_real_temp{this->d_real_temp()};
-
-  ASSUME_ALIGNED(g_weights, SIMD_BYTES);
-
-  ASSUME_ALIGNED(sum_real, SIMD_BYTES);
-  ASSUME_ALIGNED(sum_imag, SIMD_BYTES);
-  ASSUME_ALIGNED(d_imag_temp, SIMD_BYTES);
-  ASSUME_ALIGNED(d_real_temp, SIMD_BYTES);
-
-  real_t delta{};
-
-  // Not vectorzied: loop contains a mathematical function
-  #pragma omp simd
-  for (std::size_t g = 0; g < num_G; ++g) {
     const real_t old_dot{
-      gv.x_[g] * old_x +
-      gv.y_[g] * old_y +
-      gv.z_[g] * old_z
+      g_x[g] * old_x +
+      g_y[g] * old_y +
+      g_z[g] * old_z
     };
     const real_t new_dot{
-      gv.x_[g] * new_x +
-      gv.y_[g] * new_y +
-      gv.z_[g] * new_z
+      g_x[g] * new_x +
+      g_y[g] * new_y +
+      g_z[g] * new_z
     };
 
     real_t new_sin{}, new_cos{};
@@ -224,22 +204,9 @@ void EnergyTracker::update_structure_factors(
 
     d_real_temp[g] = new_cos - old_cos;
     d_imag_temp[g] = new_sin - old_sin;
-  }
-
-  // Accumulate delta and update sum_real / sum_imag
-  #pragma omp simd reduction(+ : delta)
-  for (std::size_t g = 0; g < num_G; ++g) {
-    const real_t dr{d_real_temp[g]};
-    const real_t di{d_imag_temp[g]};
-
-    delta += g_weights[g] * (2.0_r * (sum_real[g] * dr + sum_imag[g] * di) + dr * dr + di * di);
-
-    sum_real[g] += dr;
-    sum_imag[g] += di;
-  }
-
-  V_recip_ += prefactor * delta;
 }
+
+
 
 real_t EnergyTracker::kinetic_energy(const Particles& particles) const noexcept {
   const auto grad{particles.grad_log_psi().align()};
@@ -267,32 +234,24 @@ real_t EnergyTracker::kinetic_energy(const Particles& particles) const noexcept 
   return -0.5_r * T_sum;
 }
 
-void EnergyTracker::update_real_energy(
-  std::size_t moved_idx,
-  real_t old_x,
-  real_t old_y,
-  real_t old_z,
-  const Particles& particles
-) noexcept {
-  const std::size_t N{particles.size()};
-  const real_t L{box_length_};
-  const real_t neg_L{-1.0_r * L};
-  const real_t half_L{0.5_r * L};
-  const real_t neg_half_L{-1.0_r * half_L};
-  const real_t alpha{ewald_alpha_};
 
-  const auto pos{particles.pos().align()};
 
-  const real_t new_x{pos.x_[moved_idx]};
-  const real_t new_y{pos.y_[moved_idx]};
-  const real_t new_z{pos.z_[moved_idx]};
+__global__
+void update_real_energy_kernel(
+  const real_t* RESTRICT pos_x, const real_t* RESTRICT pos_y, const real_t* RESTRICT pos_z,
+  real_t* RESTRICT delta,
+  const std::size_t N,
+  const real_t L, const real_t neg_L, const real_t half_L, const real_t neg_half_L,
+  const real_t alpha,
+  const std::size_t moved_idx,
+  const real_t old_x, const real_t old_y, const real_t old_z,
+  const real_t new_x, const real_t new_y, const real_t new_z
+) {
+  __shared__ real_t shared_delta[256];
 
-  real_t delta{};
-
-  // Not vectorzied: loop contains a mathematical function
-  #pragma omp simd reduction(+ : delta)
-  for (std::size_t j = 0; j < N; ++j) {
-    // Branchless mask to safely skip the moved particle
+  const std::size_t j{blockIdx.x * blockDim.x + threadIdx.x};
+  if (j >= N) return;
+     // Branchless mask to safely skip the moved particle
     const real_t valid_mask{(j == moved_idx) ? 0.0_r : 1.0_r};
 
     // Old pair
@@ -315,7 +274,6 @@ void EnergyTracker::update_real_energy(
     const real_t inv_r_old{(r_old < 1e-12_r) ? 1.0_r : 1.0_r / r_old};
     const real_t erfc_old{vmc::erfc(alpha * r_old) * inv_r_old};
 
-    // New pair
     real_t dx_new{new_x - pos.x_[j]};
     real_t dy_new{new_y - pos.y_[j]};
     real_t dz_new{new_z - pos.z_[j]};
@@ -338,9 +296,6 @@ void EnergyTracker::update_real_energy(
 
     delta += valid_mask * (erfc_new - erfc_old);
   }
-
-  V_real_ += delta;
-}
 
 real_t EnergyTracker::potential_energy() const noexcept {
   // Ewald constants:

--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -177,7 +177,7 @@ void EnergyTracker::initialize_structure_factors(const Particles& particles) noe
 namespace {
 
 __global__
-void update_structure_factors_kernel(
+void cudaUpdateStructureFactors(
   const real_t* RESTRICT g_x, const real_t* RESTRICT g_y, const real_t* RESTRICT g_z,
   real_t* RESTRICT sum_real, real_t* RESTRICT sum_imag,
   const std::size_t num_G,

--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -173,27 +173,85 @@ void EnergyTracker::initialize_structure_factors(const Particles& particles) noe
 }
 
 
-__global__ 
+#ifdef VMC_CUDA_BACKEND
+namespace {
+
+__global__
 void update_structure_factors_kernel(
-  const real_t* RESTRICT g_x, const real_t* RESTRICT g_y, const real_t* RESTRICT g_z, const real_t* RESTRICT g_weights,
+  const real_t* RESTRICT g_x, const real_t* RESTRICT g_y, const real_t* RESTRICT g_z,
   real_t* RESTRICT sum_real, real_t* RESTRICT sum_imag,
-  real_t* RESTRICT d_real_temp, real_t* RESTRICT d_imag_temp,
   const std::size_t num_G,
   const real_t old_x, const real_t old_y, const real_t old_z,
-  const real_t new_x, const real_t new_y, const real_t new_z,
+  const real_t new_x, const real_t new_y, const real_t new_z
 ) {
   const std::size_t g{blockIdx.x * blockDim.x + threadIdx.x};
   if (g >= num_G) return;
 
+  const real_t old_dot{
+    g_x[g] * old_x +
+    g_y[g] * old_y +
+    g_z[g] * old_z
+  };
+  const real_t new_dot{
+    g_x[g] * new_x +
+    g_y[g] * new_y +
+    g_z[g] * new_z
+  };
+
+  real_t new_sin{}, new_cos{};
+  real_t old_sin{}, old_cos{};
+
+  vmc::sincos(new_dot, &new_sin, &new_cos);
+  vmc::sincos(old_dot, &old_sin, &old_cos);
+
+  sum_real[g] += new_cos - old_cos;
+  sum_imag[g] += new_sin - old_sin;
+}
+
+}
+#endif
+
+void EnergyTracker::update_structure_factors(
+  real_t old_x, real_t old_y, real_t old_z,
+  real_t new_x, real_t new_y, real_t new_z
+) noexcept {
+  const std::size_t num_G{num_g_vectors_};
+
+#ifdef VMC_CUDA_BACKEND
+  const auto gv{g_vector()};
+
+  dim3 threads(256);
+  dim3 blocks(vmc::cudaNumBlocks(num_G, threads.x));
+
+  update_structure_factors_kernel<<<blocks, threads>>>(
+    gv.x_, gv.y_, gv.z_,
+    sum_real(), sum_imag(),
+    num_G,
+    old_x, old_y, old_z,
+    new_x, new_y, new_z
+  );
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+#else
+  const auto gv{g_vector().align()};
+
+  real_t* RESTRICT sum_real{this->sum_real()};
+  real_t* RESTRICT sum_imag{this->sum_imag()};
+
+  ASSUME_ALIGNED(sum_real, SIMD_BYTES);
+  ASSUME_ALIGNED(sum_imag, SIMD_BYTES);
+
+  #pragma omp simd
+  for (std::size_t g = 0; g < num_G; ++g) {
     const real_t old_dot{
-      g_x[g] * old_x +
-      g_y[g] * old_y +
-      g_z[g] * old_z
+      gv.x_[g] * old_x +
+      gv.y_[g] * old_y +
+      gv.z_[g] * old_z
     };
     const real_t new_dot{
-      g_x[g] * new_x +
-      g_y[g] * new_y +
-      g_z[g] * new_z
+      gv.x_[g] * new_x +
+      gv.y_[g] * new_y +
+      gv.z_[g] * new_z
     };
 
     real_t new_sin{}, new_cos{};
@@ -202,11 +260,13 @@ void update_structure_factors_kernel(
     vmc::sincos(new_dot, &new_sin, &new_cos);
     vmc::sincos(old_dot, &old_sin, &old_cos);
 
-    d_real_temp[g] = new_cos - old_cos;
-    d_imag_temp[g] = new_sin - old_sin;
+    sum_real[g] += new_cos - old_cos;
+    sum_imag[g] += new_sin - old_sin;
+  }
+#endif
+
+  initialize_reciprocal_energy();
 }
-
-
 
 real_t EnergyTracker::kinetic_energy(const Particles& particles) const noexcept {
   const auto grad{particles.grad_log_psi().align()};
@@ -236,22 +296,126 @@ real_t EnergyTracker::kinetic_energy(const Particles& particles) const noexcept 
 
 
 
+#ifdef VMC_CUDA_BACKEND
+namespace {
+
 __global__
 void update_real_energy_kernel(
-  const real_t* RESTRICT pos_x, const real_t* RESTRICT pos_y, const real_t* RESTRICT pos_z,
-  real_t* RESTRICT delta,
-  const std::size_t N,
-  const real_t L, const real_t neg_L, const real_t half_L, const real_t neg_half_L,
-  const real_t alpha,
-  const std::size_t moved_idx,
+  const std::size_t N, const std::size_t moved_idx,
+  const real_t L, const real_t alpha,
   const real_t old_x, const real_t old_y, const real_t old_z,
-  const real_t new_x, const real_t new_y, const real_t new_z
+  const real_t new_x, const real_t new_y, const real_t new_z,
+  const real_t* RESTRICT pos_x, const real_t* RESTRICT pos_y, const real_t* RESTRICT pos_z,
+  real_t* RESTRICT delta
 ) {
-  __shared__ real_t shared_delta[256];
+  const real_t neg_L{-1.0_r * L};
+  const real_t half_L{0.5_r * L};
+  const real_t neg_half_L{-1.0_r * half_L};
 
   const std::size_t j{blockIdx.x * blockDim.x + threadIdx.x};
   if (j >= N) return;
-     // Branchless mask to safely skip the moved particle
+
+  // Branchless mask to safely skip the moved particle
+  const real_t valid_mask{(j == moved_idx) ? 0.0_r : 1.0_r};
+
+  // Old pair
+  real_t dx_old{old_x - pos_x[j]};
+  real_t dy_old{old_y - pos_y[j]};
+  real_t dz_old{old_z - pos_z[j]};
+
+  dx_old += L * (dx_old <= neg_half_L) + neg_L * (dx_old > half_L);
+  dy_old += L * (dy_old <= neg_half_L) + neg_L * (dy_old > half_L);
+  dz_old += L * (dz_old <= neg_half_L) + neg_L * (dz_old > half_L);
+
+  const real_t r_old{
+    vmc::sqrt(
+      dx_old * dx_old +
+      dy_old * dy_old +
+      dz_old * dz_old
+    )
+  };
+  // Protect against 1.0 / 0.0 generating NaN
+  const real_t inv_r_old{(r_old < 1e-12_r) ? 1.0_r : 1.0_r / r_old};
+  const real_t erfc_old{vmc::erfc(alpha * r_old) * inv_r_old};
+
+  real_t dx_new{new_x - pos_x[j]};
+  real_t dy_new{new_y - pos_y[j]};
+  real_t dz_new{new_z - pos_z[j]};
+
+  dx_new += L * (dx_new <= neg_half_L) + neg_L * (dx_new > half_L);
+  dy_new += L * (dy_new <= neg_half_L) + neg_L * (dy_new > half_L);
+  dz_new += L * (dz_new <= neg_half_L) + neg_L * (dz_new > half_L);
+
+  const real_t r_new{
+    vmc::sqrt(
+      dx_new * dx_new +
+      dy_new * dy_new +
+      dz_new * dz_new
+    )
+  };
+
+  // Protect against 1.0 / 0.0 generating NaN
+  const real_t inv_r_new{(r_new < 1e-12_r) ? 1.0_r : 1.0_r / r_new};
+  const real_t erfc_new{vmc::erfc(alpha * r_new) * inv_r_new};
+
+  atomicAdd(delta, valid_mask * (erfc_new - erfc_old));
+}
+
+}
+#endif
+
+void EnergyTracker::update_real_energy(
+  std::size_t moved_idx,
+  real_t old_x,
+  real_t old_y,
+  real_t old_z,
+  const Particles& particles
+) noexcept {
+  const std::size_t N{particles.size()};
+  const real_t L{box_length_};
+  const real_t alpha{ewald_alpha_};
+
+#ifdef VMC_CUDA_BACKEND
+  const auto pos{particles.pos()};
+
+  AlignedSoA<real_t> delta_storage{1, 1};
+  real_t* RESTRICT delta{delta_storage[0]};
+  *delta = 0.0_r;
+
+  const real_t new_x{pos.x_[moved_idx]};
+  const real_t new_y{pos.y_[moved_idx]};
+  const real_t new_z{pos.z_[moved_idx]};
+
+  dim3 threads(256);
+  dim3 blocks(vmc::cudaNumBlocks(N, threads.x));
+
+  update_real_energy_kernel<<<blocks, threads>>>(
+    N, moved_idx,
+    L, alpha,
+    old_x, old_y, old_z,
+    new_x, new_y, new_z,
+    pos.x_, pos.y_, pos.z_,
+    delta
+  );
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  V_real_ += *delta;
+#else
+  const real_t neg_L{-1.0_r * L};
+  const real_t half_L{0.5_r * L};
+  const real_t neg_half_L{-1.0_r * half_L};
+
+  const auto pos{particles.pos().align()};
+
+  const real_t new_x{pos.x_[moved_idx]};
+  const real_t new_y{pos.y_[moved_idx]};
+  const real_t new_z{pos.z_[moved_idx]};
+
+  real_t delta{};
+  #pragma omp simd reduction(+ : delta)
+  for (std::size_t j = 0; j < N; ++j) {
+    // Branchless mask to safely skip the moved particle
     const real_t valid_mask{(j == moved_idx) ? 0.0_r : 1.0_r};
 
     // Old pair
@@ -296,6 +460,10 @@ void update_real_energy_kernel(
 
     delta += valid_mask * (erfc_new - erfc_old);
   }
+
+  V_real_ += delta;
+#endif
+}
 
 real_t EnergyTracker::potential_energy() const noexcept {
   // Ewald constants:

--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -334,7 +334,7 @@ real_t EnergyTracker::kinetic_energy(const Particles& particles) const noexcept 
 namespace {
 
 __global__
-void update_real_energy_kernel(
+void cudaUpdateRealEnergy(
   const std::size_t N, const std::size_t moved_idx,
   const real_t L, const real_t alpha,
   const real_t old_x, const real_t old_y, const real_t old_z,

--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -212,12 +212,15 @@ void update_structure_factors_kernel(
 #endif
 
 void EnergyTracker::update_structure_factors(
-  real_t old_x, real_t old_y, real_t old_z,
-  real_t new_x, real_t new_y, real_t new_z
+  real_t old_x,
+  real_t old_y,
+  real_t old_z,
+  real_t new_x,
+  real_t new_y,
+  real_t new_z
 ) noexcept {
-  const std::size_t num_G{num_g_vectors_};
-
 #ifdef VMC_CUDA_BACKEND
+  const std::size_t num_G{num_g_vectors_};
   const auto gv{g_vector()};
 
   dim3 threads(256);
@@ -232,15 +235,32 @@ void EnergyTracker::update_structure_factors(
   );
   CUDA_CHECK(cudaGetLastError());
   CUDA_CHECK(cudaDeviceSynchronize());
+
+  initialize_reciprocal_energy();
 #else
+  const real_t L{box_length_};
+
+  const std::size_t num_G{num_g_vectors_};
+  const real_t prefactor{1.0_r / (2.0_r * std::numbers::pi_v<real_t> * L * L * L)};
+
+  const real_t* RESTRICT g_weights{this->g_weights()};
   const auto gv{g_vector().align()};
 
   real_t* RESTRICT sum_real{this->sum_real()};
   real_t* RESTRICT sum_imag{this->sum_imag()};
+  real_t* RESTRICT d_imag_temp{this->d_imag_temp()};
+  real_t* RESTRICT d_real_temp{this->d_real_temp()};
+
+  ASSUME_ALIGNED(g_weights, SIMD_BYTES);
 
   ASSUME_ALIGNED(sum_real, SIMD_BYTES);
   ASSUME_ALIGNED(sum_imag, SIMD_BYTES);
+  ASSUME_ALIGNED(d_imag_temp, SIMD_BYTES);
+  ASSUME_ALIGNED(d_real_temp, SIMD_BYTES);
 
+  real_t delta{};
+
+  // Not vectorzied: loop contains a mathematical function
   #pragma omp simd
   for (std::size_t g = 0; g < num_G; ++g) {
     const real_t old_dot{
@@ -260,12 +280,24 @@ void EnergyTracker::update_structure_factors(
     vmc::sincos(new_dot, &new_sin, &new_cos);
     vmc::sincos(old_dot, &old_sin, &old_cos);
 
-    sum_real[g] += new_cos - old_cos;
-    sum_imag[g] += new_sin - old_sin;
+    d_real_temp[g] = new_cos - old_cos;
+    d_imag_temp[g] = new_sin - old_sin;
   }
-#endif
 
-  initialize_reciprocal_energy();
+  // Accumulate delta and update sum_real / sum_imag
+  #pragma omp simd reduction(+ : delta)
+  for (std::size_t g = 0; g < num_G; ++g) {
+    const real_t dr{d_real_temp[g]};
+    const real_t di{d_imag_temp[g]};
+
+    delta += g_weights[g] * (2.0_r * (sum_real[g] * dr + sum_imag[g] * di) + dr * dr + di * di);
+
+    sum_real[g] += dr;
+    sum_imag[g] += di;
+  }
+
+  V_recip_ += prefactor * delta;
+#endif
 }
 
 real_t EnergyTracker::kinetic_energy(const Particles& particles) const noexcept {
@@ -371,11 +403,11 @@ void EnergyTracker::update_real_energy(
   real_t old_z,
   const Particles& particles
 ) noexcept {
+#ifdef VMC_CUDA_BACKEND
   const std::size_t N{particles.size()};
   const real_t L{box_length_};
   const real_t alpha{ewald_alpha_};
 
-#ifdef VMC_CUDA_BACKEND
   const auto pos{particles.pos()};
 
   AlignedSoA<real_t> delta_storage{1, 1};
@@ -402,9 +434,12 @@ void EnergyTracker::update_real_energy(
 
   V_real_ += *delta;
 #else
+  const std::size_t N{particles.size()};
+  const real_t L{box_length_};
   const real_t neg_L{-1.0_r * L};
   const real_t half_L{0.5_r * L};
   const real_t neg_half_L{-1.0_r * half_L};
+  const real_t alpha{ewald_alpha_};
 
   const auto pos{particles.pos().align()};
 
@@ -413,6 +448,8 @@ void EnergyTracker::update_real_energy(
   const real_t new_z{pos.z_[moved_idx]};
 
   real_t delta{};
+
+  // Not vectorzied: loop contains a mathematical function
   #pragma omp simd reduction(+ : delta)
   for (std::size_t j = 0; j < N; ++j) {
     // Branchless mask to safely skip the moved particle
@@ -438,6 +475,7 @@ void EnergyTracker::update_real_energy(
     const real_t inv_r_old{(r_old < 1e-12_r) ? 1.0_r : 1.0_r / r_old};
     const real_t erfc_old{vmc::erfc(alpha * r_old) * inv_r_old};
 
+    // New pair
     real_t dx_new{new_x - pos.x_[j]};
     real_t dy_new{new_y - pos.y_[j]};
     real_t dz_new{new_z - pos.z_[j]};

--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -208,7 +208,8 @@ void cudaUpdateStructureFactors(
   sum_imag[g] += new_sin - old_sin;
 }
 
-}
+} // namespace
+
 #endif
 
 void EnergyTracker::update_structure_factors(

--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -330,6 +330,7 @@ real_t EnergyTracker::kinetic_energy(const Particles& particles) const noexcept 
 
 
 #ifdef VMC_CUDA_BACKEND
+
 namespace {
 
 __global__


### PR DESCRIPTION
Fixes #43 

## Summary
- `scripts/build.ps1` pointed at a hardcoded `vcvars64.bat` path under `BuildTools`; updated to match a `Community` edition install so the Windows build script actually locates MSVC.
- `src/energy_tracking/energy_tracking.cu` had two CUDA kernels (`update_structure_factors_kernel`, `update_real_energy_kernel`) that weren't guarded behind `VMC_CUDA_BACKEND` like the rest of the CUDA sources, had syntax errors (stray/missing commas, missing semicolon), and referenced undeclared variables. The member functions the header declares (`EnergyTracker::update_structure_factors`, `EnergyTracker::update_real_energy`) were never defined, so the CPU (non-CUDA) build failed to compile.
- Implemented both member functions with a CPU path (incremental Ewald reciprocal/real-space energy update, mirroring `initialize_*`) and a CUDA path behind `#ifdef VMC_CUDA_BACKEND`, following the pattern used in `slater_plane_wave/build_row_determinant_ratio.cu`.

## Test plan
- [x] `./scripts/build.ps1` (CPU, `Release`) builds clean
- [x] CPU/GPU parity harness comparing `update_structure_factors` / `update_real_energy` output between the CPU and CUDA code paths, run against an RTX 4070 Ti Super, across `fp64`, `fp32`, and `fp32` + fast-math

### CPU vs GPU parity results

Same deterministic 64-particle configuration (fixed PRNG seed) in every run; one particle moved, energy compared before/after via `EnergyTracker::eval_total_energy`.

| Precision mode | Backend | e_before | e_after | delta | CPU ↔ GPU match |
|---|---|---|---|---|---|
| fp64 | CPU | -1.1087334601290273 | -1.2428248017061883 | -0.13409134157716096 |  exact |
| fp64 | GPU | -1.1087334601290273 | -1.2428248017061883 | -0.13409134157716096 | |
| fp32 | CPU | -1.1087627410888672 | -1.2428417205810547 | -0.1340789794921875 |  exact |
| fp32 | GPU | -1.1087627410888672 | -1.2428417205810547 | -0.1340789794921875 | |
| fp32 + fast-math | CPU | -1.1087512969970703 | -1.2428302764892578 | -0.1340789794921875 |  exact |
| fp32 + fast-math | GPU | -1.1087512969970703 | -1.2428302764892578 | -0.1340789794921875 | |

All three precision modes match bit-for-bit between CPU and CUDA code paths. The small divergence between fp64/fp32/fast-math is the expected precision loss from single precision and the fast-math `erfc` polynomial approximation, not a CPU/GPU discrepancy.

