### PR TITLE
Add structured bindings for zero cost abstraction of threads in GPU kernels

### DIFF
--- a/src/slater_plane_wave/add_derivatives.cu
+++ b/src/slater_plane_wave/add_derivatives.cu
@@ -13,7 +13,7 @@ void cudaAccumulateDerivatives(
   real_t* RESTRICT g_mag,
   real_t* RESTRICT lap
 ) {
-  const std::size_t i{blockIdx.x * blockDim.x + threadIdx.x};
+  const auto [i]{vmc::cudaThreadIdx<1>()};
   if (i >= size_orb) { return; }
 
   g_mag[i] = (
@@ -33,11 +33,8 @@ void cudaAddDerivatives(
   const real_t* RESTRICT inv_det, const real_t* RESTRICT s_cache, const real_t* RESTRICT c_cache,
   real_t* RESTRICT grad_x, real_t* RESTRICT grad_y, real_t* RESTRICT grad_z, real_t* RESTRICT lap
 ) {
-  const std::size_t i{blockIdx.x * blockDim.x + threadIdx.x};
-  if (i >= size_orb) { return; }
-
-  const std::size_t j{blockIdx.y * blockDim.y + threadIdx.y};
-  if (j >= size_orb) { return; }
+  const auto [i, j]{vmc::cudaThreadIdx<2>()};
+  if (i >= size_orb || j >= size_orb) { return; }
 
   const std::size_t trig_offset{i * trig_S};
   const std::size_t mat_offset{i * mat_S};

--- a/src/slater_plane_wave/build_row_determinant_ratio.cu
+++ b/src/slater_plane_wave/build_row_determinant_ratio.cu
@@ -10,7 +10,7 @@ __global__ void cudaBuildRow(
   const std::size_t* RESTRICT k_idx, const std::uint8_t* RESTRICT orb_t,
   real_t* RESTRICT row
 ) {
-  const std::size_t i{blockIdx.x * blockDim.x + threadIdx.x};
+  const auto [i]{vmc::cudaThreadIdx<1>()};
   if (i >= N) { return; }
 
   const real_t type{static_cast<real_t>(orb_t[i])};
@@ -26,7 +26,7 @@ __global__ void cudaDeterminantRatio(
   const real_t* RESTRICT new_row, const real_t* RESTRICT inv_det,
   real_t* RESTRICT ratio
 ) {
-  const std::size_t i{blockIdx.x * blockDim.x + threadIdx.x};
+  const auto [i]{vmc::cudaThreadIdx<1>()};
   if (i >= N) { return; }
 
   real_t product{new_row[i] * inv_det[particle * S + i]};

--- a/src/slater_plane_wave/log_abs_det.cu
+++ b/src/slater_plane_wave/log_abs_det.cu
@@ -90,20 +90,17 @@ void cudaBuildTrigCache(
   const real_t* RESTRICT k_x, const real_t* RESTRICT k_y, const real_t* RESTRICT k_z,
   real_t* RESTRICT s_cache, real_t* RESTRICT c_cache
 ) {
-  const std::size_t j{blockIdx.x * blockDim.x + threadIdx.x};
-  if (j >= num_unique_k) { return; }
-
-  const std::size_t i{blockIdx.y * blockDim.y + threadIdx.y};
-  if (i >= N) { return; }
+  const auto [i, j]{vmc::cudaThreadIdx<2>()};
+  if (i >= num_unique_k || j >= N) {return; }
 
   const real_t dot{
-    k_x[j] * p_x[i] +
-    k_y[j] * p_y[i] +
-    k_z[j] * p_z[i]
+    k_x[i] * p_x[j] +
+    k_y[i] * p_y[j] +
+    k_z[i] * p_z[j]
   };
 
-  const std::size_t offset{i * trig_S};
-  const std::size_t sc_idx{offset + j};
+  const std::size_t offset{j * trig_S};
+  const std::size_t sc_idx{offset + i};
 
   vmc::sincos(dot, &s_cache[sc_idx], &c_cache[sc_idx]);
 }
@@ -115,17 +112,14 @@ void cudaBuildDetFromCache(
   const std::size_t* RESTRICT k_idx, const std::uint8_t* RESTRICT orb_t,
   real_t* RESTRICT det_mat
 ) {
-  const std::size_t j{blockIdx.x * blockDim.x + threadIdx.x};
-  if (j >= N) { return; }
+  const auto [i, j]{vmc::cudaThreadIdx<2>()};
+  if (i >= N || j >= N) { return; }
 
-  const std::size_t i{blockIdx.y * blockDim.y + threadIdx.y};
-  if (i >= N) { return; }
+  const std::size_t offset{j * trig_S};
+  const std::size_t trig_idx{offset + k_idx[i]};
+  const std::size_t mat_idx{j * mat_S + i};
 
-  const std::size_t offset{i * trig_S};
-  const std::size_t trig_idx{offset + k_idx[j]};
-  const std::size_t mat_idx{i * mat_S + j};
-
-  const real_t type{static_cast<real_t>(orb_t[j])};
+  const real_t type{static_cast<real_t>(orb_t[i])};
   const real_t cos_term{c_cache[trig_idx]};
   const real_t sin_term{s_cache[trig_idx]};
 
@@ -138,7 +132,7 @@ void cudaComputeLogAbsDet(
   const real_t* lower_upper,
   real_t* log_abs_det
 ) {
-  const std::size_t i{blockIdx.x * blockDim.x + threadIdx.x};
+  const auto [i]{vmc::cudaThreadIdx<1>()};
   if (i >= N) { return; }
 
   const real_t U_diag{lower_upper[i * mat_S + i]};
@@ -152,9 +146,8 @@ void cudaBuildIdentity(
   std::size_t mat_S,
   real_t* matrix
 ) {
-  const std::size_t i{blockIdx.x * blockDim.x + threadIdx.x};
-  const std::size_t size{N * mat_S};
-  if (i >= size) { return; }
+  const auto [i]{vmc::cudaThreadIdx<1>()};
+  if (i >= N * mat_S) { return; }
 
   const std::size_t row{i / mat_S};
   const std::size_t col{i - row * mat_S};

--- a/src/slater_plane_wave/update_restore_trig.cu
+++ b/src/slater_plane_wave/update_restore_trig.cu
@@ -10,7 +10,7 @@ __global__ void cudaUpdateTrigRow(
   const real_t* RESTRICT k_x, const real_t* RESTRICT k_y, const real_t* RESTRICT k_z,
   real_t* RESTRICT s_cache, real_t* RESTRICT c_cache
 ) {
-  const std::size_t i{blockIdx.x * blockDim.x + threadIdx.x};
+  const auto [i]{vmc::cudaThreadIdx<1>()};
   if (i >= num_k) { return; }
 
   const real_t dot{

--- a/src/utilities/math.cuh
+++ b/src/utilities/math.cuh
@@ -72,7 +72,7 @@ inline real_t pow(real_t arg, real_t power) noexcept {
   #ifdef FP_64
     return ::pow(arg, power);
   #elif defined(VMC_FAST_MATH)
-    return __powf(arg, power);;
+    return __powf(arg, power);
   #else
     return powf(arg, power);
   #endif
@@ -152,8 +152,35 @@ inline real_t ceil(real_t arg) noexcept {
 
 CUDA_CALLABLE [[nodiscard]]
 inline unsigned int cudaNumBlocks(std::size_t size, unsigned int threads) noexcept {
-  return static_cast<unsigned int>((size + threads - 1)) / threads;
+  return static_cast<unsigned int>((size + threads - 1) / threads);
 }
+
+#if defined(__CUDACC__)
+
+template <int Dims> struct GlobalId;
+template <> struct GlobalId<1> { std::size_t x{}; };
+template <> struct GlobalId<2> { std::size_t x{}, y{}; };
+template <> struct GlobalId<3> { std::size_t x{}, y{}, z{}; };
+
+template <int Dims>
+__device__ [[nodiscard]]
+inline GlobalId<Dims> cudaThreadIdx() noexcept {
+  GlobalId<Dims> id{};
+  
+  if constexpr (Dims >= 1) {
+    id.x = static_cast<std::size_t>(blockDim.x) * blockIdx.x + threadIdx.x;
+  }
+  if constexpr (Dims >= 2) {
+    id.y = static_cast<std::size_t>(blockDim.y) * blockIdx.y + threadIdx.y;
+  }
+  if constexpr (Dims >= 3) {
+    id.z = static_cast<std::size_t>(blockDim.z) * blockIdx.z + threadIdx.z;
+  }
+
+  return id;
+}
+
+#endif
 
 CUDA_CALLABLE [[nodiscard]]
 inline real_t erfc(real_t arg) noexcept {
@@ -162,7 +189,6 @@ inline real_t erfc(real_t arg) noexcept {
     return ::erfc(arg);
   #elif defined(VMC_FAST_MATH)
     const real_t t{1.0_r / (1.0_r + 0.3275911_r * arg)};
-    constexpr real_t p{0.3275911_r};
     constexpr real_t a1{0.254829592_r};
     constexpr real_t a2{-0.284496736_r};
     constexpr real_t a3{1.421413741_r};


### PR DESCRIPTION
## Summary

Fixes: #83

Adds `vmc::cudaThreadIdx<Dims>()`, a small helper in `math.cuh` that returns global thread indices as a struct, and switches the CUDA kernels over to it via structured bindings instead of manually computing `blockIdx.x * blockDim.x + threadIdx.x` in each kernel.

## Changes

- `vmc::cudaThreadIdx<1|2|3>()` computes global x/y/z thread indices from `blockDim`/`blockIdx`/`threadIdx`, gated under `__CUDACC__`.
- Kernels in `add_derivatives.cu`, `build_row_determinant_ratio.cu`, `log_abs_det.cu`, and `update_restore_trig.cu` now use `const auto [i] = vmc::cudaThreadIdx<1>()` or `const auto [i, j] = vmc::cudaThreadIdx<2>()` instead of the old per-dimension boilerplate.
- `cudaBuildTrigCache` and `cudaBuildDetFromCache` in `log_abs_det.cu` had their `i`/`j` names swapped so `x` always maps to the first structured binding element and `y` to the second. This is a rename only, not a behavior change: the grid/block dimension bound to each array size is unchanged, and I traced both kernels by hand to confirm they compute the same values as before.
- Small cleanup in `math.cuh`: removed a stray double semicolon in `pow`, simplified the cast in `cudaNumBlocks`, and dropped an unused constant in `erfc`.

## Testing

Ran a manual CPU vs CUDA parity check covering all four changed kernels (build determinant, log|det|, gradients, trial move, accepted move) on an N=7 case. Both backends agree to machine precision. This check was done in a throwaway build, not in CI, since the repo has no in-repo way to build and run CUDA tests yet.
