### PR TITLE
Kinetic Energy Cuda Port 

### DIFF
--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -184,7 +184,7 @@ void cudaUpdateStructureFactors(
   const real_t old_x, const real_t old_y, const real_t old_z,
   const real_t new_x, const real_t new_y, const real_t new_z
 ) {
-  const std::size_t g{blockIdx.x * blockDim.x + threadIdx.x};
+  const auto [g]{vmc::cudaThreadIdx<1>()};
   if (g >= num_G) return;
 
   const real_t old_dot{
@@ -301,8 +301,58 @@ void EnergyTracker::update_structure_factors(
 #endif
 }
 
+
+#ifdef VMC_CUDA_BACKEND
+namespace {
+
+__global__
+void cudaKineticEnergy(
+  const std::size_t N,
+  const real_t* RESTRICT grad_x,
+  const real_t* RESTRICT grad_y,
+  const real_t* RESTRICT grad_z,
+  const real_t* RESTRICT lap,
+  real_t* RESTRICT T_sum
+) {
+  const auto [i]{vmc::cudaThreadIdx<1>()};;
+  if (i >= N) return;
+
+  // ||Grad(logPsi)||^2 for particle i
+  const real_t grad_sq{
+    grad_x[i] * grad_x[i] +
+    grad_y[i] * grad_y[i] +
+    grad_z[i] * grad_z[i]
+  };
+
+  // Accumulate Lapl(logPsi) + ||Grad(logPsi)||^2
+  atomicAdd(T_sum, lap[i] + grad_sq);
+}
+
+} // namespace
+#endif
+
+
 real_t EnergyTracker::kinetic_energy(const Particles& particles) const noexcept {
-  const auto grad{particles.grad_log_psi().align()};
+ #ifdef VMC_CUDA_BACKEND
+
+  const std::size_t N{particles.size()};
+  const auto grad{particles.grad_log_psi()};   
+  const real_t* lap{particles.lap_log_psi()};
+
+  AlignedSoA<real_t> T_sum{1, 1};           
+
+  dim3 kineticEnergyThreads(256);
+  dim3 kineticEnergyBlocks(vmc::cudaNumBlocks(N, kineticEnergyThreads.x));
+
+  cudaKineticEnergy<<<kineticEnergyBlocks, kineticEnergyThreads>>>(
+    N, grad.x_, grad.y_, grad.z_, lap, T_sum[0]
+  );
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  return *T_sum[0]*-0.5_r ;
+#else
+ const auto grad{particles.grad_log_psi().align()};
   const real_t* RESTRICT lap{particles.lap_log_psi()};
 
   ASSUME_ALIGNED(lap, SIMD_BYTES);
@@ -325,8 +375,8 @@ real_t EnergyTracker::kinetic_energy(const Particles& particles) const noexcept 
   }
 
   return -0.5_r * T_sum;
+#endif
 }
-
 
 
 #ifdef VMC_CUDA_BACKEND
@@ -346,7 +396,7 @@ void cudaUpdateRealEnergy(
   const real_t half_L{0.5_r * L};
   const real_t neg_half_L{-1.0_r * half_L};
 
-  const std::size_t j{blockIdx.x * blockDim.x + threadIdx.x};
+  const auto [j]{vmc::cudaThreadIdx<1>()};;
   if (j >= N) return;
 
   // Branchless mask to safely skip the moved particle
@@ -503,17 +553,8 @@ void EnergyTracker::update_real_energy(
 #endif
 }
 
-real_t EnergyTracker::potential_energy() const noexcept {
-  // Ewald constants:
-  const real_t ewald_self_correction_term{ewald_correction_};
-  const real_t ewald_background{ewald_background_};
-
-  // Potentials calcualted in cache:
-  const real_t V_recip{V_recip_};
-  const real_t V_real{V_real_};
-
-  // Self + background:
-  return V_real + V_recip + ewald_self_correction_term + ewald_background;
+inline real_t EnergyTracker::potential_energy() const noexcept {
+  return V_real_ + V_recip_ + ewald_correction_ + ewald_background_;
 }
 
 real_t EnergyTracker::eval_total_energy(const Particles& particles) const noexcept {

--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -314,7 +314,7 @@ void cudaKineticEnergy(
   const real_t* RESTRICT lap,
   real_t* RESTRICT T_sum
 ) {
-  const auto [i]{vmc::cudaThreadIdx<1>()};;
+  const auto [i]{vmc::cudaThreadIdx<1>()};
   if (i >= N) return;
 
   // ||Grad(logPsi)||^2 for particle i
@@ -396,7 +396,7 @@ void cudaUpdateRealEnergy(
   const real_t half_L{0.5_r * L};
   const real_t neg_half_L{-1.0_r * half_L};
 
-  const auto [j]{vmc::cudaThreadIdx<1>()};;
+  const auto [j]{vmc::cudaThreadIdx<1>()};
   if (j >= N) return;
 
   // Branchless mask to safely skip the moved particle


### PR DESCRIPTION
FIxes #86 

## Summary

Ports `EnergyTracker::kinetic_energy` to CUDA and migrates the energy-tracking kernels to the new `vmc::cudaThreadIdx` indexing helper.

## Changes

- **Kinetic energy CUDA port** — Adds a `cudaKineticEnergy` kernel behind `#ifdef VMC_CUDA_BACKEND` that computes the local kinetic energy `T = -0.5 * Σ (∇²lnΨ + ‖∇lnΨ‖²)`. One thread per particle computes the gradient-squared plus Laplacian term and accumulates into a single device scalar via `atomicAdd`. The host side allocates a 1-element sum buffer, launches at 256 threads/block, and returns `T_sum * -0.5`. The original CPU SIMD path is preserved unchanged under `#else`.
- **`cudaThreadIdx` migration** — Kernels (`cudaUpdateStructureFactors`, `cudaKineticEnergy`, `cudaUpdateRealEnergy`) drop the verbose `blockIdx.x * blockDim.x + threadIdx.x` idiom in favor of structured bindings `const auto [i]{vmc::cudaThreadIdx<1>()};`. This returns a destructurable `GlobalId` struct and casts to `std::size_t` before multiplying, avoiding 32-bit overflow on large launches.
- **Cleanup** — `potential_energy()` now returns the Ewald terms directly and is marked `inline`.
