### PR TITLE
Ported initilize_reciprocal_energy to CUDA

### DIFF
--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -77,15 +77,15 @@ namespace {
 
 __global__
 void cudaInitializeReciprocalEnergy(
-    const std::size_t num_G,
-    const real_t* RESTRICT g_weights,
-    const real_t* RESTRICT sum_real,
-    const real_t* RESTRICT sum_imag,
-    real_t* RESTRICT G_sum
+  const std::size_t num_G,
+  const real_t* RESTRICT g_weights,
+  const real_t* RESTRICT sum_real,
+  const real_t* RESTRICT sum_imag,
+  real_t* RESTRICT G_sum
 ) {
   const auto [g]{vmc::cudaThreadIdx<1>()};
-  if (g >= num_G) return;
-  atomicAdd(G_sum, g_weights[g] * (sum_real[g]*sum_real[g] + sum_imag[g]*sum_imag[g]));
+  if (g >= num_G) { return; }
+  atomicAdd(G_sum, g_weights[g] * (sum_real[g] * sum_real[g] + sum_imag[g] * sum_imag[g]));
 }
 
 } // namespace
@@ -93,7 +93,7 @@ void cudaInitializeReciprocalEnergy(
 
 
 void EnergyTracker::initialize_reciprocal_energy() noexcept {
-  #ifdef VMC_CUDA_BACKEND
+#ifdef VMC_CUDA_BACKEND
 
   const real_t prefactor{1.0_r / (2.0_r * std::numbers::pi_v<real_t> * box_length_ * box_length_ * box_length_)};
   AlignedSoA<real_t> G_sum{1, 1};
@@ -113,7 +113,6 @@ void EnergyTracker::initialize_reciprocal_energy() noexcept {
  CUDA_CHECK(cudaDeviceSynchronize());
  V_recip_ = prefactor * *G_sum[0];
  return;
-
 
   #else
   const real_t L{box_length_};
@@ -136,12 +135,6 @@ void EnergyTracker::initialize_reciprocal_energy() noexcept {
   V_recip_ = prefactor * sum;
   #endif
 }
-
-
-
-
-
-
 
 void EnergyTracker::initialize_real_energy(const Particles& particles) noexcept {
   const std::size_t N{particles.size()};

--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -72,7 +72,50 @@ EnergyTracker::EnergyTracker(real_t box_length, real_t num_particles)
   std::copy_n(tmp_w.data(), num_g_vectors_, g_weights());
 }
 
+#ifdef VMC_CUDA_BACKEND
+namespace {
+
+__global__
+void cudaInitializeReciprocalEnergy(
+    const std::size_t num_G,
+    const real_t* RESTRICT g_weights,
+    const real_t* RESTRICT sum_real,
+    const real_t* RESTRICT sum_imag,
+    real_t* RESTRICT G_sum
+) {
+  const auto [g]{vmc::cudaThreadIdx<1>()};
+  if (g >= num_G) return;
+  atomicAdd(G_sum, g_weights[g] * (sum_real[g]*sum_real[g] + sum_imag[g]*sum_imag[g]));
+}
+
+} // namespace
+#endif
+
+
 void EnergyTracker::initialize_reciprocal_energy() noexcept {
+  #ifdef VMC_CUDA_BACKEND
+
+  const real_t prefactor{1.0_r / (2.0_r * std::numbers::pi_v<real_t> * box_length_ * box_length_ * box_length_)};
+  AlignedSoA<real_t> G_sum{1, 1};
+  const auto num_G{num_g_vectors_};
+
+  dim3 initalizeReciprocalEnergyThreads(256);
+  dim3 initalizeReciprocalEnergyBlocks(vmc::cudaNumBlocks(num_G, initalizeReciprocalEnergyThreads.x));
+
+ cudaInitializeReciprocalEnergy<<<initalizeReciprocalEnergyBlocks, initalizeReciprocalEnergyThreads>>>(
+   num_G,
+    this->g_weights(),
+    this->sum_real(),
+    this->sum_imag(),
+    G_sum[0]
+ );
+ CUDA_CHECK(cudaGetLastError());
+ CUDA_CHECK(cudaDeviceSynchronize());
+ V_recip_ = prefactor * *G_sum[0];
+ return;
+
+
+  #else
   const real_t L{box_length_};
   const real_t prefactor{1.0_r / (2.0_r * std::numbers::pi_v<real_t> * L * L * L)};
 
@@ -91,7 +134,14 @@ void EnergyTracker::initialize_reciprocal_energy() noexcept {
     sum += g_weights[g] * (sum_real[g] * sum_real[g] + sum_imag[g] * sum_imag[g]);
   }
   V_recip_ = prefactor * sum;
+  #endif
 }
+
+
+
+
+
+
 
 void EnergyTracker::initialize_real_energy(const Particles& particles) noexcept {
   const std::size_t N{particles.size()};


### PR DESCRIPTION
Fixes #87 
## Summary

Ports `EnergyTracker::initialize_reciprocal_energy` to CUDA, computing the reciprocal-space Ewald energy `V_recip` on the GPU while preserving the existing CPU path.

## Changes

- **Reciprocal energy CUDA port** — Adds a `cudaInitializeReciprocalEnergy` kernel behind `#ifdef VMC_CUDA_BACKEND` that evaluates the reciprocal-space sum `Σ w_g · (Re[S(g)]² + Im[S(g)]²)` over all G-vectors. One thread per G-vector accumulates its weighted structure-factor magnitude into a single device scalar via `atomicAdd`, using the `vmc::cudaThreadIdx<1>()` structured-binding indexing helper. The host side allocates a 1-element `AlignedSoA<real_t>` sum buffer, launches at 256 threads/block (`vmc::cudaNumBlocks`), and scales the result by the prefactor `1 / (2π · L³)` to set `V_recip_`. The original CPU loop is preserved unchanged under `#else`.
- **Kernel inputs** — The kernel reads `g_weights`, `sum_real`, and `sum_imag` device buffers (all `RESTRICT`-qualified) and writes the reduced energy into `G_sum`.
