### PR TITLE
Port wavefunction derivative accumulation to CUDA

### DIFF
--- a/src/wavefunction/wavefunction.cu
+++ b/src/wavefunction/wavefunction.cu
@@ -3,13 +3,103 @@
 #include <algorithm>
 
 real_t WaveFunction::evaluate_log_psi(const Particles& particles) {
-  const real_t log_det{slater_plane_wave().log_abs_det(particles)};
-  const real_t jastrow{jastrow_pade().value(particles)};
-
-  return log_det + jastrow;
+  return this->slater_plane_wave().log_abs_det(particles) + this->jastrow_pade().value(particles);
 }
 
+#if defined(VMC_CUDA_BACKEND)
+
+namespace {
+
+__global__
+void cudaDerivativeSums(
+  std::size_t p_N,
+  real_t* log_gx, real_t* log_gy, real_t* log_gz, real_t* log_lap,
+  real_t* jp_gx, real_t* jp_gy, real_t* jp_gz, real_t* jp_lap
+) {
+  const auto [i]{vmc::cudaThreadIdx<1>()};
+  if (i >= p_N) { return; }
+
+  log_gx[i] += jp_gx[i];
+  log_gy[i] += jp_gy[i];
+  log_gz[i] += jp_gz[i];
+  log_lap[i] += jp_lap[i];
+}
+
+void cudaFillDerivatives(
+  std::size_t total_bytes,
+  real_t* gx, real_t* gy, real_t* gz,
+  real_t* lap
+) {
+  CUDA_CHECK(cudaMemset(gx, 0, total_bytes));
+  CUDA_CHECK(cudaMemset(gy, 0, total_bytes));
+  CUDA_CHECK(cudaMemset(gz, 0, total_bytes));
+  CUDA_CHECK(cudaMemset(lap, 0, total_bytes));
+}
+
+}
+
+#endif
+
 void WaveFunction::evaluate_derivatives(Particles& particles) noexcept {
+#if defined(VMC_CUDA_BACKEND)
+  const auto total_bytes{
+    static_cast<std::size_t>(particles.p_stride() * sizeof(real_t))
+  };
+
+  cudaFillDerivatives(
+    total_bytes,
+    particles.grad_log_psi().x_,
+    particles.grad_log_psi().y_,
+    particles.grad_log_psi().z_,
+    particles.lap_log_psi()
+  );
+
+  cudaFillDerivatives(
+    total_bytes,
+    this->j_grad().x_,
+    this->j_grad().y_,
+    this->j_grad().z_,
+    this->j_lap()
+  );
+
+  slater_plane_wave_.add_derivatives(
+    particles.grad_log_psi().x_,
+    particles.grad_log_psi().y_,
+    particles.grad_log_psi().z_,
+    particles.lap_log_psi()
+  );
+
+  jastrow_pade_.add_derivatives(
+    particles,
+    this->j_grad().x_,
+    this->j_grad().y_,
+    this->j_grad().z_,
+    this->j_lap()
+  );
+
+  dim3 derivativeSumsThreads(256);
+  dim3 derivativeSumsBlocks(
+    vmc::cudaNumBlocks(particles.p_stride(), derivativeSumsThreads.x)
+  );
+  
+  cudaDerivativeSums<<<derivativeSumsBlocks, derivativeSumsThreads>>>(
+    particles.p_stride(),
+    particles.grad_log_psi().x_,
+    particles.grad_log_psi().y_,
+    particles.grad_log_psi().z_,
+    particles.lap_log_psi(),
+    this->j_grad().x_,
+    this->j_grad().y_,
+    this->j_grad().z_,
+    this->j_lap()
+  );
+
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  set_jastrow_cache_valid(true);
+  set_steps_since_refresh(0);
+#else
   const std::size_t padded_stride{particles.p_stride()};
 
   const auto log_grad{particles.grad_log_psi().align()};
@@ -43,6 +133,7 @@ void WaveFunction::evaluate_derivatives(Particles& particles) noexcept {
   }
   set_jastrow_cache_valid(true);
   set_steps_since_refresh(0);
+#endif
 }
 
 void WaveFunction::evaluate_derivatives(
@@ -55,15 +146,65 @@ void WaveFunction::evaluate_derivatives(
     evaluate_derivatives(particles);
     return;
   }
-  std::size_t steps{steps_since_refresh()};
-  if (steps >= 500) {
+  if (steps_since_refresh() >= 500) {
     evaluate_derivatives(particles);
     return;
   }
-  set_steps_since_refresh(steps + 1);
+  set_steps_since_refresh(steps_since_refresh() + 1);
   if (!move_accepted) {
     return;
   }
+
+#if defined(VMC_CUDA_BACKEND)
+  const auto total_bytes{
+    static_cast<std::size_t>(particles.p_stride() * sizeof(real_t))
+  };
+
+  jastrow_pade_.update_derivatives_for_move(
+    particles,
+    moved,
+    old_x, old_y, old_z,
+    this->j_grad().x_,
+    this->j_grad().y_,
+    this->j_grad().z_,
+    this->j_lap()
+  );
+
+  cudaFillDerivatives(
+    total_bytes,
+    particles.grad_log_psi().x_,
+    particles.grad_log_psi().y_,
+    particles.grad_log_psi().z_,
+    particles.lap_log_psi()
+  );
+
+  slater_plane_wave_.add_derivatives(
+    particles.grad_log_psi().x_,
+    particles.grad_log_psi().y_,
+    particles.grad_log_psi().z_,
+    particles.lap_log_psi()
+  );
+
+  dim3 derivativeSumsThreads(256);
+  dim3 derivativeSumsBlocks(
+    vmc::cudaNumBlocks(particles.p_stride(), derivativeSumsThreads.x)
+  );
+  
+  cudaDerivativeSums<<<derivativeSumsBlocks, derivativeSumsThreads>>>(
+    particles.p_stride(),
+    particles.grad_log_psi().x_,
+    particles.grad_log_psi().y_,
+    particles.grad_log_psi().z_,
+    particles.lap_log_psi(),
+    this->j_grad().x_,
+    this->j_grad().y_,
+    this->j_grad().z_,
+    this->j_lap()
+  );
+
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+#else
   const std::size_t padded_stride{particles.p_stride()};
 
   const auto log_grad{particles.grad_log_psi().align()};
@@ -100,4 +241,5 @@ void WaveFunction::evaluate_derivatives(
     log_grad.z_[i] += jg.z_[i];
     log_lap[i] += jastrow_lap[i];
   }
+#endif
 }


### PR DESCRIPTION
## Summary

Fixes: #90

Ports both `WaveFunction::evaluate_derivatives` overloads to CUDA: the full recompute path and the incremental single particle move path. Follows the same zero, accumulate, sum pattern already used by `slater_plane_wave_.add_derivatives` and `jastrow_pade_.add_derivatives`.

## Changes

- `cudaFillDerivatives` helper zeroes the gradient and Laplacian buffers with `cudaMemset` instead of `std::fill_n`.
- New `cudaDerivativeSums` kernel, one thread per particle, adds the Jastrow buffer into the Slater buffer on the device.
- Both `evaluate_derivatives` overloads get a `VMC_CUDA_BACKEND` branch that mirrors the existing CPU logic: zero the Slater buffer, recompute it fully, and add in the Jastrow buffer, which stays unzeroed since it is updated incrementally on accepted moves.
- All new CUDA calls wrapped in `CUDA_CHECK`.
- CPU `#else` paths are unchanged.

## Notes

- `JastrowPade::update_derivatives_for_move` is still CPU only. It works here only because `AlignedSoA` uses `cudaMallocManaged`, so it will need its own CUDA port before #57 (switching to `cudaMalloc`) lands.

## Testing

Verified numerically with an isolated standalone driver (nvcc, no CMake) built directly against `WaveFunction`/`SlaterPlaneWave`/`JastrowPade`/`Particles` — no `simulation`/`energy_tracking`/`optimizer` sources involved. N=19 closed-shell free electron gas, L=7.0, seeded positions (`mt19937_64`, seed 42).

Exercised both code paths this PR touches:
- **FULL**: `evaluate_derivatives(particles)` — full recompute (`cudaFillDerivatives` + both `add_derivatives` + new `cudaDerivativeSums`)
- **INCR**: `evaluate_derivatives(particles, true, moved, old_x, old_y, old_z)` — one accepted Metropolis move replayed by hand (mirroring `Simulation::metropolis_step`), exercising the incremental branch of the same kernels

Compared every `grad_x/grad_y/grad_z/laplacian` component (19 particles × 2 paths × 4 components = 152 values) plus `log_psi`, CPU `#else` branch vs `VMC_CUDA_BACKEND` branch, across three build configs:

| Config | max abs diff | max rel diff | worst component |
|---|---|---|---|
| FP64 | 2.13e-12 | 2.11e-13 | `INCR[16].gx` |
| FP32 | 3.28e-04 | 2.21e-04 | `INCR[16].gx` |
| FP32 + fast-math | 3.66e-04 | 8.38e-05 | `INCR[16].gx` |

FP64 matches CPU to machine precision. FP32 gaps are consistent with ordinary summation-order noise (CPU's sequential per-particle reduction vs GPU's unordered `atomicAdd`) rather than a defect in the port — isolating the fast-math intrinsics alone (GPU-fp32 vs GPU-fp32-fastmath) gives 6.10e-05 abs / 1.37e-04 rel, smaller than the CPU-vs-GPU fp32 gap itself.

