### PR TITLE
Reuse positions_snapshot buffer instead of reallocating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+test_config_tmp.cfg
+
 docs/*
 !docs/paper.tex
 !docs/paper.pdf

--- a/src/simulation/simulation.cu
+++ b/src/simulation/simulation.cu
@@ -19,22 +19,23 @@ Simulation::Simulation(Config config, std::unique_ptr<OutputWriter> output_write
 , proposed_{}
 , accepted_{}
 , log_psi_current_{}
+, positions_{}
 , walker_rng_{}
-{ walker_rng_.init(config_, 0); }
+{
+  walker_rng_.init(config_, 0);
+  positions_.resize(particles_.size() * 3U);
+}
 
-std::vector<real_t> Simulation::positions_snapshot() const {
+std::vector<real_t> Simulation::positions_snapshot() {
   const std::size_t N{particles_.size()};
   auto [p_x, p_y, p_z]{particles_.pos().align()};
 
-  std::vector<real_t> positions{};
-  positions.reserve(N * 3U);
-
   for (std::size_t i{}; i < N; ++i) {
-    positions.push_back(p_x[i]);
-    positions.push_back(p_y[i]);
-    positions.push_back(p_z[i]);
+    positions_[i * 3U] = p_x[i];
+    positions_[i * 3U + 1U] = p_y[i];
+    positions_[i * 3U + 2U] = p_z[i];
   }
-  return positions;
+  return positions_;
 }
 
 void Simulation::initialize_positions() {

--- a/src/simulation/simulation.cu
+++ b/src/simulation/simulation.cu
@@ -19,21 +19,20 @@ Simulation::Simulation(Config config, std::unique_ptr<OutputWriter> output_write
 , proposed_{}
 , accepted_{}
 , log_psi_current_{}
-, positions_{}
+, positions_{particles_.size(), 3}
 , walker_rng_{}
 {
   walker_rng_.init(config_, 0);
-  positions_.resize(particles_.size() * 3U);
 }
 
-std::vector<real_t> Simulation::positions_snapshot() {
+const AlignedSoA<real_t>& Simulation::positions_snapshot() {
   const std::size_t N{particles_.size()};
   auto [p_x, p_y, p_z]{particles_.pos().align()};
 
   for (std::size_t i{}; i < N; ++i) {
-    positions_[i * 3U] = p_x[i];
-    positions_[i * 3U + 1U] = p_y[i];
-    positions_[i * 3U + 2U] = p_z[i];
+    positions_[0][i] = p_x[i];
+    positions_[1][i] = p_y[i];
+    positions_[2][i] = p_z[i];
   }
   return positions_;
 }
@@ -208,6 +207,16 @@ Simulation::MeasurementSummary Simulation::measure() {
     }
 
     if (output_writer_) {
+      const auto& snapshot{positions_snapshot()};
+      const std::size_t N{particles_.size()};
+
+      std::vector<real_t> flat_positions(N * 3U);
+      for (std::size_t p{}; p < N; ++p) {
+        flat_positions[p * 3U] = snapshot[0][p];
+        flat_positions[p * 3U + 1U] = snapshot[1][p];
+        flat_positions[p * 3U + 2U] = snapshot[2][p];
+      }
+
       output_writer_->write_frame(FrameData{
         .step = i + 1U,
         .accepted = accepted_,
@@ -216,7 +225,7 @@ Simulation::MeasurementSummary Simulation::measure() {
         .local_energy = E_local,
         .mean_energy = running_mean,
         .standard_error = frame_standard_error,
-        .positions = positions_snapshot()
+        .positions = std::move(flat_positions)
       });
     }
 

--- a/src/simulation/simulation.cuh
+++ b/src/simulation/simulation.cuh
@@ -7,6 +7,7 @@
 #include "../particles/particles.cuh"
 #include "../wavefunction/wavefunction.cuh"
 #include "../utilities/random.cuh"
+#include "../utilities/aligned_soa.cuh"
 
 #include <memory>
 #include <optional>
@@ -27,7 +28,8 @@ private:
   std::size_t accepted_;
   real_t log_psi_current_;
 
-  std::vector<real_t> positions_;
+  AlignedSoA<real_t> positions_;
+
 
   WalkerRNG walker_rng_;
 
@@ -50,7 +52,7 @@ private:
     real_t old_z;
   };
 
-  [[nodiscard]] std::vector<real_t> positions_snapshot();
+  [[nodiscard]] const AlignedSoA<real_t>& positions_snapshot();
 
 public:
   struct MeasurementSummary {

--- a/src/simulation/simulation.cuh
+++ b/src/simulation/simulation.cuh
@@ -27,6 +27,8 @@ private:
   std::size_t accepted_;
   real_t log_psi_current_;
 
+  std::vector<real_t> positions_;
+
   WalkerRNG walker_rng_;
 
   CUDA_CALLABLE [[nodiscard]] real_t rand_uniform() { return walker_rng_.rand_uniform(); }
@@ -48,7 +50,7 @@ private:
     real_t old_z;
   };
 
-  [[nodiscard]] std::vector<real_t> positions_snapshot() const;
+  [[nodiscard]] std::vector<real_t> positions_snapshot();
 
 public:
   struct MeasurementSummary {


### PR DESCRIPTION
Fixes: #37 

## Summary

`positions_snapshot()` allocated and returned a fresh `std::vector<real_t>` on every call. Since it's called once per measurement, this adds a needless allocation to the hot path. Now it fills a member buffer sized once at construction and reuses it.

## Changes

- Added `positions_` member buffer to `Simulation`, resized to `particles_.size() * 3U` in the constructor.
- `positions_snapshot()` writes into `positions_` by index instead of `push_back`-ing into a freshly reserved vector, and is no longer `const`.
- `.gitignore`: ignore `test_config_tmp.cfg` (stray file left by local test runs).

## Testing

- No behavior change to the returned data; verify with the existing measurement/output test suite.