### PR TITLE
port inilitize structure factors and initilize real energy

### DIFF
--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -203,9 +203,6 @@ void EnergyTracker::initialize_real_energy(const Particles& particles) noexcept 
 
   V_real_ = *Sum[0];
   return;
-
-
-
   #else
   const std::size_t N{particles.size()};
   const real_t L{box_length_};
@@ -257,19 +254,19 @@ void cudaInitializeStructureFactors(
   real_t* RESTRICT sum_real, real_t* RESTRICT sum_imag,
   const std::size_t num_G, const std::size_t N
 ) {
-  const auto [g, j]{vmc::cudaThreadIdx<2>()};
-  if (g >= num_G || j >= N) return;
+  const auto [i, j]{vmc::cudaThreadIdx<2>()};
+  if (i >= num_G || j >= N) return;
   const real_t G_dot_r{
-    g_x[g] * pos_x[j] +
-    g_y[g] * pos_y[j] +
-    g_z[g] * pos_z[j]
+    g_x[i] * pos_x[j] +
+    g_y[i] * pos_y[j] +
+    g_z[i] * pos_z[j]
   };
   real_t cos_temp{};
   real_t sin_temp{};
   vmc::sincos(G_dot_r, &sin_temp, &cos_temp);
 
-  atomicAdd(&sum_real[g], cos_temp);
-  atomicAdd(&sum_imag[g], sin_temp);
+  atomicAdd(&sum_real[i], cos_temp);
+  atomicAdd(&sum_imag[i], sin_temp);
 
 
  }
@@ -284,11 +281,10 @@ void EnergyTracker::initialize_structure_factors(const Particles& particles) noe
   const auto pos{particles.pos()};
   const auto gv{g_vector()};
 
-  real_t* RESTRICT sr{sum_real()};
-  real_t* RESTRICT si{sum_imag()};
-
-  CUDA_CHECK(cudaMemset(sr, 0, num_G * sizeof(real_t)));
-  CUDA_CHECK(cudaMemset(si, 0, num_G * sizeof(real_t)));
+ 
+  auto const total_bytes{num_G * sizeof(real_t)};
+  CUDA_CHECK(cudaMemset(this->sum_real(), 0, total_bytes));
+  CUDA_CHECK(cudaMemset(this->sum_imagl(), 0, total_bytes));
 
   dim3 initializeStructureFactorsThreads(16, 16);
   dim3 initializeStructureFactorsBlocks(
@@ -304,7 +300,6 @@ void EnergyTracker::initialize_structure_factors(const Particles& particles) noe
   );
   CUDA_CHECK(cudaGetLastError());
   CUDA_CHECK(cudaDeviceSynchronize());
-  return;
 
   #else
   const std::size_t N{particles.size()};

--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -136,7 +136,77 @@ void EnergyTracker::initialize_reciprocal_energy() noexcept {
   #endif
 }
 
+#ifdef VMC_CUDA_BACKEND
+namespace {
+
+__global__
+void cudaInitializeRealEnergy(
+  const std::size_t N,
+  const real_t L,
+  const real_t neg_L,
+  const real_t half_L,
+  const real_t neg_half_L,
+  const real_t alpha,
+  const real_t* RESTRICT pos_x,
+  const real_t* RESTRICT pos_y,
+  const real_t* RESTRICT pos_z,
+  real_t* RESTRICT sum
+) {
+  const auto [i, j]{vmc::cudaThreadIdx<2>()};
+
+  if (i >= N || j >= N) return;
+  if (j <= i) return;
+
+  real_t dx{pos_x[i] - pos_x[j]};
+  real_t dy{pos_y[i] - pos_y[j]};
+  real_t dz{pos_z[i] - pos_z[j]};
+
+  dx += L * (dx <= neg_half_L) + neg_L * (dx > half_L);
+  dy += L * (dy <= neg_half_L) + neg_L * (dy > half_L);
+  dz += L * (dz <= neg_half_L) + neg_L * (dz > half_L);
+
+  const real_t r{vmc::sqrt(dx * dx + dy * dy + dz * dz)};
+  const real_t inv_r{(r < 1e-12_r) ? 1.0_r : 1.0_r / r};
+
+  atomicAdd(sum, vmc::erfc(alpha * r) * inv_r);
+}
+
+} // namespace
+#endif
+
 void EnergyTracker::initialize_real_energy(const Particles& particles) noexcept {
+#ifdef VMC_CUDA_BACKEND
+
+  const std::size_t N{particles.size()};
+  const real_t L{box_length_};
+  const real_t neg_L{-1.0_r * L};
+  const real_t half_L{0.5_r * L};
+  const real_t neg_half_L{-1.0_r * half_L};
+  const real_t alpha{ewald_alpha_};
+
+  const auto pos{particles.pos()};
+  AlignedSoA<real_t> Sum{1, 1};
+
+  dim3 initializeRealEnergyThreads(16, 16);
+  dim3 initializeRealEnergyBlocks(
+    vmc::cudaNumBlocks(N, initializeRealEnergyThreads.x),
+    vmc::cudaNumBlocks(N, initializeRealEnergyThreads.y)
+  );
+
+  cudaInitializeRealEnergy<<<initializeRealEnergyBlocks, initializeRealEnergyThreads>>>(
+    N, L, neg_L, half_L, neg_half_L, alpha,
+    pos.x_, pos.y_, pos.z_,
+    Sum[0]
+  );
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+
+  V_real_ = *Sum[0];
+  return;
+
+
+
+  #else
   const std::size_t N{particles.size()};
   const real_t L{box_length_};
   const real_t neg_L{-1.0_r * L};
@@ -174,9 +244,69 @@ void EnergyTracker::initialize_real_energy(const Particles& particles) noexcept 
     sum += local_sum;
   }
   V_real_ = sum;
+  #endif
 }
 
+#ifdef VMC_CUDA_BACKEND
+namespace {
+
+__global__
+void cudaInitializeStructureFactors(
+  const real_t* RESTRICT g_x, const real_t* RESTRICT g_y, const real_t* RESTRICT g_z,
+  const real_t* RESTRICT pos_x, const real_t* RESTRICT pos_y, const real_t* RESTRICT pos_z,
+  real_t* RESTRICT sum_real, real_t* RESTRICT sum_imag,
+  const std::size_t num_G, const std::size_t N
+) {
+  const auto [g, j]{vmc::cudaThreadIdx<2>()};
+  if (g >= num_G || j >= N) return;
+  const real_t G_dot_r{
+    g_x[g] * pos_x[j] +
+    g_y[g] * pos_y[j] +
+    g_z[g] * pos_z[j]
+  };
+  real_t cos_temp{};
+  real_t sin_temp{};
+  vmc::sincos(G_dot_r, &sin_temp, &cos_temp);
+
+  atomicAdd(&sum_real[g], cos_temp);
+  atomicAdd(&sum_imag[g], sin_temp);
+
+
+ }
+} // namespace
+#endif
+
 void EnergyTracker::initialize_structure_factors(const Particles& particles) noexcept {
+  #ifdef VMC_CUDA_BACKEND
+  const std::size_t N{particles.size()};
+  const std::size_t num_G{num_g_vectors_};
+
+  const auto pos{particles.pos()};
+  const auto gv{g_vector()};
+
+  real_t* RESTRICT sr{sum_real()};
+  real_t* RESTRICT si{sum_imag()};
+
+  CUDA_CHECK(cudaMemset(sr, 0, num_G * sizeof(real_t)));
+  CUDA_CHECK(cudaMemset(si, 0, num_G * sizeof(real_t)));
+
+  dim3 initializeStructureFactorsThreads(16, 16);
+  dim3 initializeStructureFactorsBlocks(
+    vmc::cudaNumBlocks(num_G, initializeStructureFactorsThreads.x),
+    vmc::cudaNumBlocks(N,     initializeStructureFactorsThreads.y)
+  );
+
+  cudaInitializeStructureFactors<<<initializeStructureFactorsBlocks, initializeStructureFactorsThreads>>>(
+    gv.x_, gv.y_, gv.z_,
+    pos.x_, pos.y_, pos.z_,
+    sr, si,
+    num_G, N
+  );
+  CUDA_CHECK(cudaGetLastError());
+  CUDA_CHECK(cudaDeviceSynchronize());
+  return;
+
+  #else
   const std::size_t N{particles.size()};
   const std::size_t num_G{num_g_vectors_};
 
@@ -213,6 +343,7 @@ void EnergyTracker::initialize_structure_factors(const Particles& particles) noe
     sum_real[g] = cos_sum;
     sum_imag[g] = sin_sum;
   }
+  #endif
 }
 
 


### PR DESCRIPTION
Fixes #94 
### What
Adds CUDA backends for `EnergyTracker::initialize_real_energy` and
`EnergyTracker::initialize_structure_factors`, behind `VMC_CUDA_BACKEND`.
The CPU `#else` branches are untouched and remain the reference implementation.

### How

**`initialize_real_energy`** — `cudaInitializeRealEnergy`
- 2D grid, one thread per particle pair `(i, j)`. Guards `i >= N`, `j >= N`, and
  `j <= i` reproduce the CPU's `j = i+1` triangular loop (each unordered pair once,
  no diagonal).
- Each thread computes one pair's `erfc(α·r)/r` and `atomicAdd`s into a single
  scalar accumulator (`AlignedSoA<real_t> Sum{1,1}`), which is freshly constructed
  and therefore zero-initialized.

**`initialize_structure_factors`** — `cudaInitializeStructureFactors`
- 2D grid, one thread per `(g, particle)` pair. `atomicAdd`s each thread's
  `cos`/`sin` contribution into the aligned-SoA `sum_real[g]` / `sum_imag[g]`.
- Because `sum_real` / `sum_imag` are persistent (reused across calls and consumed
  by `initialize_reciprocal_energy` / `update_structure_factors`), they are zeroed
  with `cudaMemset` before the accumulation kernel — the atomic-add-from-zero
  precondition is not free here, unlike the real-energy scalar.

### Correctness / races
- The only cross-thread writes go through `atomicAdd`; all position/G-vector reads
  are read-only. No data races.
- FP accumulation order is nondeterministic (atomics), so results agree with the CPU
  path to rounding tolerance, not bit-for-bit — consistent with the existing
  `INCREMENTAL_REBUILD_TOLERANCE`.
