### PR TITLE
Wire in xpu and adopt its launch and math helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.25)
 
 if(
   NOT DEFINED CMAKE_EXPORT_COMPILE_COMMANDS
@@ -25,8 +25,9 @@ if(VMC_ENABLE_CUDA)
   check_language(CUDA)
   if(CMAKE_CUDA_COMPILER)
     enable_language(CUDA)
-    set(CMAKE_CUDA_STANDARD 20)
+    set(CMAKE_CUDA_STANDARD 23)
     set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    set(CMAKE_CUDA_EXTENSIONS OFF)
     if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
       set(CMAKE_CUDA_ARCHITECTURES native)
     endif()
@@ -44,6 +45,20 @@ if(VMC_FAST_MATH AND FP_64)
 endif()
 
 # --- Dependencies ---
+include(FetchContent)
+
+# xpu must use the same backend as VMC: mixing CPU and CUDA allocation in one
+# linked program is undefined. Let VMC own its own -march flags.
+set(XPU_ENABLE_CUDA ${VMC_ENABLE_CUDA} CACHE BOOL "" FORCE)
+set(XPU_ARCH_NATIVE OFF CACHE BOOL "" FORCE)
+
+fetchcontent_declare(
+  xpu
+  GIT_REPOSITORY https://github.com/UWHPC/xpu.git
+  GIT_TAG 22fdac2
+)
+fetchcontent_makeavailable(xpu)
+
 find_package(OpenMP QUIET COMPONENTS CXX)
 
 if(OpenMP_CXX_FOUND)
@@ -132,6 +147,8 @@ add_library(vmc_lib STATIC
 
 target_include_directories(vmc_lib PUBLIC src)
 
+target_link_libraries(vmc_lib PUBLIC xpu::xpu)
+
 if(NOT VMC_CUDA AND VMC_CUDA_EXTENSION_SOURCES)
   set_source_files_properties(
     ${VMC_CUDA_EXTENSION_SOURCES}
@@ -217,7 +234,6 @@ if(BUILD_TESTING)
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
     GIT_TAG v3.8.1
   )
-
   fetchcontent_makeavailable(Catch2)
 
   add_executable(vmc_tests

--- a/src/energy_tracking/energy_tracking.cu
+++ b/src/energy_tracking/energy_tracking.cu
@@ -1,3 +1,4 @@
+#include <xpu/xpu.hpp>
 #include "energy_tracking.cuh"
 
 #include <numbers>
@@ -5,7 +6,7 @@
 EnergyTracker::EnergyTracker(real_t box_length, real_t num_particles)
 : box_length_{box_length}
 , ewald_alpha_{6.0_r / box_length}
-, ewald_correction_{-6.0_r * num_particles / (vmc::sqrt(std::numbers::pi_v<real_t>) * box_length)}
+, ewald_correction_{-6.0_r * num_particles / (xpu::sqrt(std::numbers::pi_v<real_t>) * box_length)}
 , ewald_background_{-std::numbers::pi_v<real_t> * num_particles * num_particles / (72.0_r * box_length)}
 , V_recip_{}
 , V_real_{}
@@ -13,10 +14,10 @@ EnergyTracker::EnergyTracker(real_t box_length, real_t num_particles)
 , data_{} {
   const real_t two_pi_over_L{2.0_r * std::numbers::pi_v<real_t> / box_length};
   const real_t four_alpha_sq{4.0_r * ewald_alpha_ * ewald_alpha_};
-  const real_t cutoff_factor{-vmc::log(EWALD_RECIPROCAL_TOLERANCE)};
+  const real_t cutoff_factor{-xpu::log(EWALD_RECIPROCAL_TOLERANCE)};
 
   const real_t g_max_mag_sq{four_alpha_sq * cutoff_factor};
-  const int m_max{static_cast<int>(vmc::ceil(vmc::sqrt(g_max_mag_sq) / two_pi_over_L)) + 1};
+  const int m_max{static_cast<int>(xpu::ceil(xpu::sqrt(g_max_mag_sq) / two_pi_over_L)) + 1};
 
   std::vector<real_t> tmp_x, tmp_y, tmp_z, tmp_w;
 
@@ -55,7 +56,7 @@ EnergyTracker::EnergyTracker(real_t box_length, real_t num_particles)
         g_z.emplace_back(g_cand_z);
         weights.emplace_back(
           8.0_r * std::numbers::pi_v<real_t> * std::numbers::pi_v<real_t> / g_cand_mag_sq *
-          vmc::exp(-g_cand_mag_sq / four_alpha_sq)
+          xpu::exp(-g_cand_mag_sq / four_alpha_sq)
         );
       }
     }
@@ -83,7 +84,7 @@ void cudaInitializeReciprocalEnergy(
   const real_t* RESTRICT sum_imag,
   real_t* RESTRICT G_sum
 ) {
-  const auto [g]{vmc::cudaThreadIdx<1>()};
+  const auto [g]{xpu::global_index<1>()};
   if (g >= num_G) { return; }
   atomicAdd(G_sum, g_weights[g] * (sum_real[g] * sum_real[g] + sum_imag[g] * sum_imag[g]));
 }
@@ -152,7 +153,7 @@ void cudaInitializeRealEnergy(
   const real_t* RESTRICT pos_z,
   real_t* RESTRICT sum
 ) {
-  const auto [i, j]{vmc::cudaThreadIdx<2>()};
+  const auto [i, j]{xpu::global_index<2>()};
 
   if (i >= N || j >= N) return;
   if (j <= i) return;
@@ -165,10 +166,10 @@ void cudaInitializeRealEnergy(
   dy += L * (dy <= neg_half_L) + neg_L * (dy > half_L);
   dz += L * (dz <= neg_half_L) + neg_L * (dz > half_L);
 
-  const real_t r{vmc::sqrt(dx * dx + dy * dy + dz * dz)};
+  const real_t r{xpu::sqrt(dx * dx + dy * dy + dz * dz)};
   const real_t inv_r{(r < 1e-12_r) ? 1.0_r : 1.0_r / r};
 
-  atomicAdd(sum, vmc::erfc(alpha * r) * inv_r);
+  atomicAdd(sum, xpu::erfc(alpha * r) * inv_r);
 }
 
 } // namespace
@@ -229,14 +230,14 @@ void EnergyTracker::initialize_real_energy(const Particles& particles) noexcept 
       dz += L * (dz <= neg_half_L) + neg_L * (dz > half_L);
 
       const real_t r{
-        vmc::sqrt(
+        xpu::sqrt(
           dx * dx +
           dy * dy +
           dz * dz
         )
       };
       const real_t inv_r{(r < 1e-12_r) ? 1.0_r : 1.0_r / r};
-      local_sum += vmc::erfc(alpha * r) * inv_r;
+      local_sum += xpu::erfc(alpha * r) * inv_r;
     }
     sum += local_sum;
   }
@@ -254,7 +255,7 @@ void cudaInitializeStructureFactors(
   real_t* RESTRICT sum_real, real_t* RESTRICT sum_imag,
   const std::size_t num_G, const std::size_t N
 ) {
-  const auto [i, j]{vmc::cudaThreadIdx<2>()};
+  const auto [i, j]{xpu::global_index<2>()};
   if (i >= num_G || j >= N) return;
   const real_t G_dot_r{
     g_x[i] * pos_x[j] +
@@ -353,7 +354,7 @@ void cudaUpdateStructureFactors(
   const real_t old_x, const real_t old_y, const real_t old_z,
   const real_t new_x, const real_t new_y, const real_t new_z
 ) {
-  const auto [g]{vmc::cudaThreadIdx<1>()};
+  const auto [g]{xpu::global_index<1>()};
   if (g >= num_G) return;
 
   const real_t old_dot{
@@ -483,7 +484,7 @@ void cudaKineticEnergy(
   const real_t* RESTRICT lap,
   real_t* RESTRICT T_sum
 ) {
-  const auto [i]{vmc::cudaThreadIdx<1>()};
+  const auto [i]{xpu::global_index<1>()};
   if (i >= N) return;
 
   // ||Grad(logPsi)||^2 for particle i
@@ -565,7 +566,7 @@ void cudaUpdateRealEnergy(
   const real_t half_L{0.5_r * L};
   const real_t neg_half_L{-1.0_r * half_L};
 
-  const auto [j]{vmc::cudaThreadIdx<1>()};
+  const auto [j]{xpu::global_index<1>()};
   if (j >= N) return;
 
   // Branchless mask to safely skip the moved particle
@@ -581,7 +582,7 @@ void cudaUpdateRealEnergy(
   dz_old += L * (dz_old <= neg_half_L) + neg_L * (dz_old > half_L);
 
   const real_t r_old{
-    vmc::sqrt(
+    xpu::sqrt(
       dx_old * dx_old +
       dy_old * dy_old +
       dz_old * dz_old
@@ -589,7 +590,7 @@ void cudaUpdateRealEnergy(
   };
   // Protect against 1.0 / 0.0 generating NaN
   const real_t inv_r_old{(r_old < 1e-12_r) ? 1.0_r : 1.0_r / r_old};
-  const real_t erfc_old{vmc::erfc(alpha * r_old) * inv_r_old};
+  const real_t erfc_old{xpu::erfc(alpha * r_old) * inv_r_old};
 
   real_t dx_new{new_x - pos_x[j]};
   real_t dy_new{new_y - pos_y[j]};
@@ -600,7 +601,7 @@ void cudaUpdateRealEnergy(
   dz_new += L * (dz_new <= neg_half_L) + neg_L * (dz_new > half_L);
 
   const real_t r_new{
-    vmc::sqrt(
+    xpu::sqrt(
       dx_new * dx_new +
       dy_new * dy_new +
       dz_new * dz_new
@@ -609,7 +610,7 @@ void cudaUpdateRealEnergy(
 
   // Protect against 1.0 / 0.0 generating NaN
   const real_t inv_r_new{(r_new < 1e-12_r) ? 1.0_r : 1.0_r / r_new};
-  const real_t erfc_new{vmc::erfc(alpha * r_new) * inv_r_new};
+  const real_t erfc_new{xpu::erfc(alpha * r_new) * inv_r_new};
 
   atomicAdd(delta, valid_mask * (erfc_new - erfc_old));
 }
@@ -684,7 +685,7 @@ void EnergyTracker::update_real_energy(
     dz_old += L * (dz_old <= neg_half_L) + neg_L * (dz_old > half_L);
 
     const real_t r_old{
-      vmc::sqrt(
+      xpu::sqrt(
         dx_old * dx_old +
         dy_old * dy_old +
         dz_old * dz_old
@@ -692,7 +693,7 @@ void EnergyTracker::update_real_energy(
     };
     // Protect against 1.0 / 0.0 generating NaN
     const real_t inv_r_old{(r_old < 1e-12_r) ? 1.0_r : 1.0_r / r_old};
-    const real_t erfc_old{vmc::erfc(alpha * r_old) * inv_r_old};
+    const real_t erfc_old{xpu::erfc(alpha * r_old) * inv_r_old};
 
     // New pair
     real_t dx_new{new_x - pos.x_[j]};
@@ -704,7 +705,7 @@ void EnergyTracker::update_real_energy(
     dz_new += L * (dz_new <= neg_half_L) + neg_L * (dz_new > half_L);
 
     const real_t r_new{
-      vmc::sqrt(
+      xpu::sqrt(
         dx_new * dx_new +
         dy_new * dy_new +
         dz_new * dz_new
@@ -713,7 +714,7 @@ void EnergyTracker::update_real_energy(
 
     // Protect against 1.0 / 0.0 generating NaN
     const real_t inv_r_new{(r_new < 1e-12_r) ? 1.0_r : 1.0_r / r_new};
-    const real_t erfc_new{vmc::erfc(alpha * r_new) * inv_r_new};
+    const real_t erfc_new{xpu::erfc(alpha * r_new) * inv_r_new};
 
     delta += valid_mask * (erfc_new - erfc_old);
   }

--- a/src/jastrow_pade/add_derivatives.cu
+++ b/src/jastrow_pade/add_derivatives.cu
@@ -1,3 +1,4 @@
+#include <xpu/xpu.hpp>
 #include "jastrow_pade.cuh"
 
 #ifdef VMC_CUDA_BACKEND
@@ -12,7 +13,7 @@ void cudaAddDerivatives(
   real_t* RESTRICT grad_x, real_t* RESTRICT grad_y, real_t* RESTRICT grad_z,
   real_t* RESTRICT laplacian
 ) {
-  const auto [i, j]{vmc::cudaThreadIdx<2>()};
+  const auto [i, j]{xpu::global_index<2>()};
   if (i >= num_particles || j >= num_particles) { return; }
   if (i == j) { return; }
 
@@ -35,7 +36,7 @@ void cudaAddDerivatives(
     displ_z * displ_z
   };
 
-  const auto dist{vmc::sqrt(dist_sq)};
+  const auto dist{xpu::sqrt(dist_sq)};
 
   if (dist < 1e-12_r) { return; }
   const real_t inv_dist{1.0_r / dist};
@@ -123,7 +124,7 @@ void JastrowPade::add_derivatives(
         displ_y * displ_y +
         displ_z * displ_z
       };
-      const real_t dist{vmc::sqrt(dist_sq)};
+      const real_t dist{xpu::sqrt(dist_sq)};
 
       const bool degenerate{dist < 1e-12_r};
       const real_t inv_dist{degenerate ? 1.0_r : 1.0_r / dist};

--- a/src/jastrow_pade/jastrow_pade.cu
+++ b/src/jastrow_pade/jastrow_pade.cu
@@ -1,3 +1,4 @@
+#include <xpu/xpu.hpp>
 #include "jastrow_pade.cuh"
 
 #include <cmath>
@@ -17,7 +18,7 @@ void cudaComputeDerivatives(
   real_t* RESTRICT grad_x, real_t* RESTRICT grad_y, real_t* RESTRICT grad_z,
   real_t* RESTRICT laplacian
 ) {
-  const auto [i]{vmc::cudaThreadIdx<1>()};
+  const auto [i]{xpu::global_index<1>()};
   if (i >= N || i == moved) { return; }
 
   real_t displ_old_x{old_x - p_x[i]};
@@ -29,7 +30,7 @@ void cudaComputeDerivatives(
   displ_old_z += L * (displ_old_z <= -half_L) + -L * (displ_old_z > half_L);
 
   const real_t dist_old{
-    vmc::sqrt(
+    xpu::sqrt(
       displ_old_x * displ_old_x +
       displ_old_y * displ_old_y +
       displ_old_z * displ_old_z
@@ -60,7 +61,7 @@ void cudaComputeDerivatives(
   displ_new_z += L * (displ_new_z <= -half_L) + -L * (displ_new_z > half_L);
 
   const real_t dist_new{
-    vmc::sqrt(
+    xpu::sqrt(
       displ_new_x * displ_new_x +
       displ_new_y * displ_new_y +
       displ_new_z * displ_new_z
@@ -186,7 +187,7 @@ void JastrowPade::update_derivatives_for_move(
     displ_old_z += L * (displ_old_z <= neg_half_L) + neg_L * (displ_old_z > half_L);
 
     const real_t dist_old{
-      vmc::sqrt(
+      xpu::sqrt(
         displ_old_x * displ_old_x +
         displ_old_y * displ_old_y +
         displ_old_z * displ_old_z
@@ -214,7 +215,7 @@ void JastrowPade::update_derivatives_for_move(
     displ_new_z += L * (displ_new_z <= neg_half_L) + neg_L * (displ_new_z > half_L);
 
     const real_t dist_new{
-      vmc::sqrt(
+      xpu::sqrt(
         displ_new_x * displ_new_x +
         displ_new_y * displ_new_y +
         displ_new_z * displ_new_z

--- a/src/jastrow_pade/value_delta_value.cu
+++ b/src/jastrow_pade/value_delta_value.cu
@@ -1,3 +1,4 @@
+#include <xpu/xpu.hpp>
 #include "jastrow_pade.cuh"
 
 #ifdef VMC_CUDA_BACKEND
@@ -36,7 +37,7 @@ void cudaValue(
     displ_y * displ_y +
     displ_z * displ_z
   };
-  const real_t dist{vmc::sqrt(dist_sq)};
+  const real_t dist{xpu::sqrt(dist_sq)};
 
   const real_t denom{1.0_r + b * dist};
   const real_t inv_denom{1.0_r / denom};
@@ -71,7 +72,7 @@ void cudaDeltaValue(
   displ_old_z += L * (displ_old_z <= neg_half_L) + neg_L * (displ_old_z > half_L);
 
   const real_t dist_old{
-    vmc::sqrt(
+    xpu::sqrt(
       displ_old_x * displ_old_x +
       displ_old_y * displ_old_y +
       displ_old_z * displ_old_z
@@ -88,7 +89,7 @@ void cudaDeltaValue(
   displ_new_z += L * (displ_new_z <= neg_half_L) + neg_L * (displ_new_z > half_L);
 
   const real_t dist_new{
-    vmc::sqrt(
+    xpu::sqrt(
       displ_new_x * displ_new_x +
       displ_new_y * displ_new_y +
       displ_new_z * displ_new_z
@@ -164,7 +165,7 @@ real_t JastrowPade::value(const Particles& particles) const noexcept {
         displ_y * displ_y +
         displ_z * displ_z
       };
-      const real_t dist{vmc::sqrt(dist_sq)};
+      const real_t dist{xpu::sqrt(dist_sq)};
 
       const real_t denom{1.0_r + b_local * dist};
       const real_t inv_denom{1.0_r / denom};
@@ -238,7 +239,7 @@ real_t JastrowPade::delta_value(
     displ_old_z += L * (displ_old_z <= neg_half_L) + neg_L * (displ_old_z > half_L);
 
     const real_t dist_old{
-      vmc::sqrt(
+      xpu::sqrt(
         displ_old_x * displ_old_x +
         displ_old_y * displ_old_y +
         displ_old_z * displ_old_z
@@ -255,7 +256,7 @@ real_t JastrowPade::delta_value(
     displ_new_z += L * (displ_new_z <= neg_half_L) + neg_L * (displ_new_z > half_L);
 
     const real_t dist_new{
-      vmc::sqrt(
+      xpu::sqrt(
         displ_new_x * displ_new_x +
         displ_new_y * displ_new_y +
         displ_new_z * displ_new_z

--- a/src/optimizer/jastrow_optimizer.cu
+++ b/src/optimizer/jastrow_optimizer.cu
@@ -1,3 +1,4 @@
+#include <xpu/xpu.hpp>
 #include "jastrow_optimizer.hpp"
 #include "../simulation/simulation.cuh"
 
@@ -14,7 +15,7 @@ real_t JastrowOptimizer::compute_rs(const Config& cfg) {
   const real_t N{static_cast<real_t>(cfg.num_particles)};
   const real_t volume{cfg.box_length * cfg.box_length * cfg.box_length};
   const real_t density{N / volume};
-  return vmc::cbrt(3.0_r / (4.0_r * std::numbers::pi_v<real_t> * density));
+  return xpu::cbrt(3.0_r / (4.0_r * std::numbers::pi_v<real_t> * density));
 }
 
 JastrowOptimizer::Result JastrowOptimizer::optimize(const Config& base_config, bool verbose) {
@@ -99,13 +100,13 @@ JastrowOptimizer::Result JastrowOptimizer::optimize(const Config& base_config, b
   }
 
   // Check if the winner is the boundary point and an outlier
-  const bool at_boundary{vmc::abs(best_b - b_min) < 1e-10_r};
+  const bool at_boundary{xpu::abs(best_b - b_min) < 1e-10_r};
   if (at_boundary && results.size() > 2) {
     // Compute the energy spread of all non-boundary points
     real_t interior_min{std::numeric_limits<real_t>::max()};
     real_t interior_max{std::numeric_limits<real_t>::lowest()};
     for (const auto& r : results) {
-      if (vmc::abs(r.b - b_min) < 1e-10_r)
+      if (xpu::abs(r.b - b_min) < 1e-10_r)
         continue;
       interior_min = std::min(interior_min, r.energy);
       interior_max = std::max(interior_max, r.energy);
@@ -123,7 +124,7 @@ JastrowOptimizer::Result JastrowOptimizer::optimize(const Config& base_config, b
       best_b = 1.0_r;
       best_energy = std::numeric_limits<real_t>::max();
       for (const auto& r : results) {
-        if (vmc::abs(r.b - b_min) < 1e-10_r)
+        if (xpu::abs(r.b - b_min) < 1e-10_r)
           continue;
         if (r.energy < best_energy) {
           best_energy = r.energy;

--- a/src/simulation/simulation.cu
+++ b/src/simulation/simulation.cu
@@ -1,3 +1,4 @@
+#include <xpu/xpu.hpp>
 #include "simulation.cuh"
 
 #include <cmath>
@@ -82,9 +83,9 @@ Simulation::StepResult Simulation::metropolis_step() {
   p_z[rand] += rand_proposal();
 
   // Branchless wrapping for [0, L)
-  p_x[rand] -= L * vmc::floor(p_x[rand] * inv_L);
-  p_y[rand] -= L * vmc::floor(p_y[rand] * inv_L);
-  p_z[rand] -= L * vmc::floor(p_z[rand] * inv_L);
+  p_x[rand] -= L * xpu::floor(p_x[rand] * inv_L);
+  p_y[rand] -= L * xpu::floor(p_y[rand] * inv_L);
+  p_z[rand] -= L * xpu::floor(p_z[rand] * inv_L);
 
   auto& slater{wave_function_.slater_plane_wave()};
 
@@ -99,16 +100,16 @@ Simulation::StepResult Simulation::metropolis_step() {
       rand, old_x, old_y, old_z
     )
   };
-  const real_t log_ratio_sq{2.0_r * vmc::log(vmc::abs(slater_ratio)) + 2.0_r * delta_jastrow};
+  const real_t log_ratio_sq{2.0_r * xpu::log(xpu::abs(slater_ratio)) + 2.0_r * delta_jastrow};
 
-  const real_t u{vmc::max(rand_uniform(), std::numeric_limits<real_t>::min())};
-  const real_t log_u{vmc::log(u)};
-  const real_t min_term{vmc::min(0.0_r, log_ratio_sq)};
+  const real_t u{xpu::max(rand_uniform(), std::numeric_limits<real_t>::min())};
+  const real_t log_u{xpu::log(u)};
+  const real_t min_term{xpu::min(0.0_r, log_ratio_sq)};
 
   const bool accepted{log_u < min_term};
 
   if (accepted) {
-    log_psi_current_ += vmc::log(vmc::abs(slater_ratio)) + delta_jastrow;
+    log_psi_current_ += xpu::log(xpu::abs(slater_ratio)) + delta_jastrow;
     slater.accept_move(rand, new_row, slater_ratio);
 
     energy_tracker_.update_structure_factors(
@@ -150,7 +151,7 @@ void Simulation::warmup() {
     if (window_proposed % warmup_batch_size == 0) {
       acceptance_rate_window =
           static_cast<real_t>(window_accepted) / static_cast<real_t>(window_proposed);
-      step_size *= vmc::exp(gain * (acceptance_rate_window - acceptance_target));
+      step_size *= xpu::exp(gain * (acceptance_rate_window - acceptance_target));
 
       const real_t MAX_STEP{config_.box_length * 0.5_r};
       if (step_size > MAX_STEP) {

--- a/src/slater_plane_wave/add_derivatives.cu
+++ b/src/slater_plane_wave/add_derivatives.cu
@@ -1,3 +1,4 @@
+#include <xpu/xpu.hpp>
 #include "slater_plane_wave.cuh"
 
 #ifdef VMC_CUDA_BACKEND
@@ -13,7 +14,7 @@ void cudaAccumulateDerivatives(
   real_t* RESTRICT g_mag,
   real_t* RESTRICT lap
 ) {
-  const auto [i]{vmc::cudaThreadIdx<1>()};
+  const auto [i]{xpu::global_index<1>()};
   if (i >= size_orb) { return; }
 
   g_mag[i] = (
@@ -33,7 +34,7 @@ void cudaAddDerivatives(
   const real_t* RESTRICT inv_det, const real_t* RESTRICT s_cache, const real_t* RESTRICT c_cache,
   real_t* RESTRICT grad_x, real_t* RESTRICT grad_y, real_t* RESTRICT grad_z, real_t* RESTRICT lap
 ) {
-  const auto [i, j]{vmc::cudaThreadIdx<2>()};
+  const auto [i, j]{xpu::global_index<2>()};
   if (i >= size_orb || j >= size_orb) { return; }
 
   const std::size_t trig_offset{i * trig_S};

--- a/src/slater_plane_wave/build_row_determinant_ratio.cu
+++ b/src/slater_plane_wave/build_row_determinant_ratio.cu
@@ -1,3 +1,4 @@
+#include <xpu/xpu.hpp>
 #include "slater_plane_wave.cuh"
 
 #ifdef VMC_CUDA_BACKEND
@@ -10,7 +11,7 @@ __global__ void cudaBuildRow(
   const std::size_t* RESTRICT k_idx, const std::uint8_t* RESTRICT orb_t,
   real_t* RESTRICT row
 ) {
-  const auto [i]{vmc::cudaThreadIdx<1>()};
+  const auto [i]{xpu::global_index<1>()};
   if (i >= N) { return; }
 
   const real_t type{static_cast<real_t>(orb_t[i])};
@@ -26,7 +27,7 @@ __global__ void cudaDeterminantRatio(
   const real_t* RESTRICT new_row, const real_t* RESTRICT inv_det,
   real_t* RESTRICT ratio
 ) {
-  const auto [i]{vmc::cudaThreadIdx<1>()};
+  const auto [i]{xpu::global_index<1>()};
   if (i >= N) { return; }
 
   real_t product{new_row[i] * inv_det[particle * S + i]};

--- a/src/slater_plane_wave/initialize.cu
+++ b/src/slater_plane_wave/initialize.cu
@@ -1,3 +1,4 @@
+#include <xpu/xpu.hpp>
 #include "slater_plane_wave.cuh"
 #include "../utilities/matrix.hpp"
 
@@ -20,7 +21,7 @@ void cudaFindNVecCandidates(
   int* RESTRICT nv_mag_sq,
   unsigned long long* RESTRICT counter
 ) {
-  const auto [raw_i, raw_j, raw_k]{vmc::cudaThreadIdx<3>()};
+  const auto [raw_i, raw_j, raw_k]{xpu::global_index<3>()};
   const auto side{static_cast<std::size_t>(2 * n_max + 1)};
   if (raw_i >= side || raw_j >= side || raw_k >= side) { return; }
 
@@ -50,7 +51,7 @@ void cudaAssignOrbitals(
   real_t* RESTRICT k_x, real_t* RESTRICT k_y, real_t* RESTRICT k_z,
   std::size_t* RESTRICT orb_k_idx, std::uint8_t* RESTRICT orb_type
 ) {
-  const auto [i]{vmc::cudaThreadIdx<1>()};
+  const auto [i]{xpu::global_index<1>()};
   if (i >= num_unique_k) { return; }
 
   const std::size_t src{order[i]};
@@ -102,7 +103,7 @@ void SlaterPlaneWave::initialize(const Particles& particles) {
     N_VEC_ARR
   };
 
-  const int n_max{static_cast<int>(vmc::ceil(vmc::cbrt(static_cast<real_t>(N)))) + 2};
+  const int n_max{static_cast<int>(xpu::ceil(xpu::cbrt(static_cast<real_t>(N)))) + 2};
   const std::size_t side{static_cast<std::size_t>(2 * n_max + 1)};
   const std::size_t max_candidates{side * side * side};
 
@@ -181,7 +182,7 @@ void SlaterPlaneWave::initialize(const Particles& particles) {
     int n_mag_sq;
   };
 
-  const int N_MAX{static_cast<int>(vmc::ceil(vmc::cbrt(static_cast<real_t>(N)))) + 2};
+  const int N_MAX{static_cast<int>(xpu::ceil(xpu::cbrt(static_cast<real_t>(N)))) + 2};
   const std::size_t side{static_cast<std::size_t>((2 * N_MAX + 1))};
 
   std::vector<nVectorCandidate> n_candidates{};

--- a/src/slater_plane_wave/log_abs_det.cu
+++ b/src/slater_plane_wave/log_abs_det.cu
@@ -1,3 +1,4 @@
+#include <xpu/xpu.hpp>
 #include "slater_plane_wave.cuh"
 
 #ifdef VMC_CUDA_BACKEND
@@ -92,7 +93,7 @@ void cudaBuildTrigCache(
   const real_t* RESTRICT k_x, const real_t* RESTRICT k_y, const real_t* RESTRICT k_z,
   real_t* RESTRICT s_cache, real_t* RESTRICT c_cache
 ) {
-  const auto [i, j]{vmc::cudaThreadIdx<2>()};
+  const auto [i, j]{xpu::global_index<2>()};
   if (i >= num_unique_k || j >= N) {return; }
 
   const real_t dot{
@@ -114,7 +115,7 @@ void cudaBuildDetFromCache(
   const std::size_t* RESTRICT k_idx, const std::uint8_t* RESTRICT orb_t,
   real_t* RESTRICT det_mat
 ) {
-  const auto [i, j]{vmc::cudaThreadIdx<2>()};
+  const auto [i, j]{xpu::global_index<2>()};
   if (i >= N || j >= N) { return; }
 
   const std::size_t offset{j * trig_S};
@@ -134,12 +135,12 @@ void cudaComputeLogAbsDet(
   const real_t* lower_upper,
   real_t* log_abs_det
 ) {
-  const auto [i]{vmc::cudaThreadIdx<1>()};
+  const auto [i]{xpu::global_index<1>()};
   if (i >= N) { return; }
 
   const real_t U_diag{lower_upper[i * mat_S + i]};
 
-  atomicAdd(log_abs_det, vmc::log(vmc::abs(U_diag)));
+  atomicAdd(log_abs_det, xpu::log(xpu::abs(U_diag)));
 }
 
 __global__
@@ -148,7 +149,7 @@ void cudaBuildIdentity(
   std::size_t mat_S,
   real_t* matrix
 ) {
-  const auto [i]{vmc::cudaThreadIdx<1>()};
+  const auto [i]{xpu::global_index<1>()};
   if (i >= N * mat_S) { return; }
 
   const std::size_t row{i / mat_S};
@@ -375,9 +376,9 @@ real_t SlaterPlaneWave::log_abs_det(const Particles& particles) {
   #pragma omp simd reduction(+ : log_abs_det)
   for (std::size_t diag = 0; diag < N; ++diag) {
     const real_t U_ii{lower_upper_matrix[diag * S + diag]};
-    const real_t abs_U_ii{vmc::abs(U_ii)};
+    const real_t abs_U_ii{xpu::abs(U_ii)};
 
-    log_abs_det += vmc::log(abs_U_ii);
+    log_abs_det += xpu::log(abs_U_ii);
   }
 
   if (!std::isfinite(log_abs_det)) {

--- a/src/slater_plane_wave/slater_plane_wave.cu
+++ b/src/slater_plane_wave/slater_plane_wave.cu
@@ -1,3 +1,4 @@
+#include <xpu/xpu.hpp>
 #include "slater_plane_wave.cuh"
 #include "../utilities/matrix.hpp"
 #include "particles/particles.cuh"

--- a/src/slater_plane_wave/update_restore_trig.cu
+++ b/src/slater_plane_wave/update_restore_trig.cu
@@ -1,3 +1,4 @@
+#include <xpu/xpu.hpp>
 #include "slater_plane_wave.cuh"
 
 #ifdef VMC_CUDA_BACKEND
@@ -10,7 +11,7 @@ __global__ void cudaUpdateTrigRow(
   const real_t* RESTRICT k_x, const real_t* RESTRICT k_y, const real_t* RESTRICT k_z,
   real_t* RESTRICT s_cache, real_t* RESTRICT c_cache
 ) {
-  const auto [i]{vmc::cudaThreadIdx<1>()};
+  const auto [i]{xpu::global_index<1>()};
   if (i >= num_k) { return; }
 
   const real_t dot{

--- a/src/utilities/macros.cuh
+++ b/src/utilities/macros.cuh
@@ -66,12 +66,16 @@ using complex_t = std::complex<real_t>;
 #endif
 
 // Restrict pointers:
-#if defined(__GNUC__) || defined(__clang__)
-  #define RESTRICT __restrict__
-#elif defined(_MSC_VER)
-  #define RESTRICT __restrict
-#else
-  #define RESTRICT
+// Guarded because xpu/config.hpp defines RESTRICT too. The expansions are
+// equivalent on every compiler we target, so whichever header lands first wins.
+#ifndef RESTRICT
+  #if defined(__GNUC__) || defined(__clang__)
+    #define RESTRICT __restrict__
+  #elif defined(_MSC_VER)
+    #define RESTRICT __restrict
+  #else
+    #define RESTRICT
+  #endif
 #endif
 
 // SIMD Bytes

--- a/src/wavefunction/wavefunction.cu
+++ b/src/wavefunction/wavefunction.cu
@@ -1,3 +1,4 @@
+#include <xpu/xpu.hpp>
 #include "wavefunction.cuh"
 
 #include <algorithm>
@@ -16,7 +17,7 @@ void cudaDerivativeSums(
   real_t* log_gx, real_t* log_gy, real_t* log_gz, real_t* log_lap,
   real_t* jp_gx, real_t* jp_gy, real_t* jp_gz, real_t* jp_lap
 ) {
-  const auto [i]{vmc::cudaThreadIdx<1>()};
+  const auto [i]{xpu::global_index<1>()};
   if (i >= p_N) { return; }
 
   log_gx[i] += jp_gx[i];


### PR DESCRIPTION
## Summary

Fixes: #103 

Adds [xpu](https://github.com/UWHPC/xpu) as a dependency and moves the CUDA `.cu` sources onto its thread-indexing and math helpers. This is deliberately a foothold rather than a migration: `AlignedSoA`, `macros.cuh`, and `math.cuh` all stay, and the goal is to land the build-system and toolchain changes on their own so the later `xpu::soa` work is purely about the memory model.

## Changes

- **`CMakeLists.txt`:** fetches xpu via `FetchContent` in the Dependencies section and links it into `vmc_lib` as `PUBLIC`. `XPU_ENABLE_CUDA` is forced to follow `VMC_ENABLE_CUDA` — the two backends must agree, since xpu's README notes CPU and CUDA allocation cannot be mixed in one linked program. `XPU_ARCH_NATIVE` is forced off so VMC keeps owning its own `-march` flags and, by extension, its SIMD width.
- **`CMAKE_CUDA_STANDARD` 20 → 23**, with `CMAKE_CUDA_EXTENSIONS OFF`. xpu requires C++23 and appends `-std=c++23` to CUDA compiles; leaving VMC at 20 would put conflicting flags on every `.cu` file.
- **`cmake_minimum_required` 3.24 → 3.25**, which is what xpu declares.
- **13 `.cu` files:** `vmc::cudaThreadIdx<N>()` → `xpu::global_index<N>()`, and `vmc::sqrt/abs/log/erfc/floor/ceil/cbrt/exp/min/max` → their `xpu::` equivalents. `#include <xpu/xpu.hpp>` is first in each file.
- **`macros.cuh`:** `RESTRICT` is now `#ifndef`-guarded. xpu defines it too (as `__restrict` rather than `__restrict__`), and its definition is unguarded, so without this every translation unit including both emitted `-Wmacro-redefined`.

## Notes

The xpu include is placed first in each `.cu` file rather than after the project headers. That ordering is load-bearing: xpu's `RESTRICT` is unguarded, so it has to define the macro before `macros.cuh`'s guard sees it. The two expansions are equivalent on every compiler we target.

The include lives in the `.cu` files rather than in `macros.cuh` or `math.cuh`. Those headers are reachable from `blocking_analysis.cpp`, `output_writer.cpp`, and `main.cpp`, and `xpu/config.hpp` `#error`s if `XPU_CUDA` is set without nvcc. Routing xpu through them would force all three into `.cu`. Splitting `real_t`/`complex_t`/`arithmetic` into a dependency-free header is the better fix and is left for a follow-up.

Four call-site groups are deliberately **not** migrated:

- `vmc::sincos` (10 sites) — xpu's host path calls `sin()` and `cos()` separately, losing the combined intrinsic on both Apple and glibc, and it has no `VMC_FAST_MATH` equivalent. Migrating would roughly double the trig cost in `trig_cell`, which runs once per k-vector per particle per Metropolis step.
- `vmc::cudaNumBlocks` (33 sites) — `xpu::block_per_dim` casts `std::size_t` through `int`. Harmless at current problem sizes but a real defect.
- `CUDA_CHECK` (59 sites) — a macro-to-function change rather than a namespace rename, and `CUSOLVER_CHECK` has no xpu counterpart, so `macros.cuh` keeps that block either way.
- `ASSUME_ALIGNED` (53 sites) — xpu has no equivalent.

The first two are being fixed upstream in xpu; the renames follow once the pin moves.

## Testing

CPU FP64: `ctest --test-dir build-cpu` — 94/94 passing, no warnings. Configure and build verified with both `BUILD_TESTING=ON` and `OFF`.

**CUDA is unverified.** Every `xpu::global_index` substitution sits inside `#ifdef VMC_CUDA_BACKEND` and has never been compiled — `global_index` is `__device__`-only and guarded by `#if defined(XPU_CUDA)`. The `CMAKE_CUDA_STANDARD 23` bump is likewise untested; the `.cu` sources have only ever been compiled as C++20. Please verify:

​```bash
cmake -S . -B build-cuda -G Ninja -DVMC_ENABLE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=89 \
  -DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_CUDA_HOST_COMPILER=g++-14 \
  -DFP_64=ON -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build-cuda --target vmc vmc_tests -j
ctest --test-dir build-cuda --output-on-failure -j 1
​```

Note this requires **GCC 14+**: xpu `FATAL_ERROR`s below it, because nvcc silently downgrades to C++14 rather than rejecting an unsupported host compiler.